### PR TITLE
refactor: rename schema repository to specification

### DIFF
--- a/src/components/github/index.ts
+++ b/src/components/github/index.ts
@@ -20,7 +20,7 @@ export interface GitHubComponentArgs {
 
 export enum RepositoryName {
   CLOUD_PROVISIONING = 'cloud-provisioning',
-  SCHEMA = 'schema',
+  SPECIFICATION = 'specification',
   BACKEND = 'backend',
   FRONTEND = 'frontend',
 }
@@ -79,12 +79,12 @@ export class GitHubComponent extends pulumi.ComponentResource {
       { provider: this.provider }
     )
 
-    const schemaRepo = new github.Repository(
-      RepositoryName.SCHEMA,
+    const specificationRepo = new github.Repository(
+      RepositoryName.SPECIFICATION,
       {
         ...defaultRepositoryArgs,
-        name: RepositoryName.SCHEMA,
-        description: 'Schema',
+        name: RepositoryName.SPECIFICATION,
+        description: 'Specification',
         template: {
           owner: githubConfig.owner,
           repository: 'protobuf-scaffold',
@@ -119,7 +119,7 @@ export class GitHubComponent extends pulumi.ComponentResource {
 
     this.repositories = {
       [RepositoryName.CLOUD_PROVISIONING]: cloudProvisioningRepo,
-      [RepositoryName.SCHEMA]: schemaRepo,
+      [RepositoryName.SPECIFICATION]: specificationRepo,
       [RepositoryName.BACKEND]: backendRepo,
       [RepositoryName.FRONTEND]: frontendRepo,
     }
@@ -128,7 +128,7 @@ export class GitHubComponent extends pulumi.ComponentResource {
     const bufTokenSecret = new github.ActionsSecret(
       'buf-token',
       {
-        repository: RepositoryName.SCHEMA,
+        repository: RepositoryName.SPECIFICATION,
         secretName: 'BUF_TOKEN',
         plaintextValue: bufConfig.token,
       },


### PR DESCRIPTION
## Description
Renames the `schema` GitHub repository to `specification` in the cloud-provisioning infrastructure code.

## Related Issue
close: #7

## Changes
- Updated `RepositoryName` enum in `src/components/github/index.ts`
- Renamed repository resource and variables
- Updated `buf-token` secret scope

## Verification
- Ran `npm run lint` (Passed)
- Ran `npm run typecheck` (Passed)