### PR TITLE
Infra: Use Organization Secret for GEMINI_API_KEY

### DIFF
--- a/src/components/github/index.ts
+++ b/src/components/github/index.ts
@@ -30,7 +30,7 @@ export class GitHubComponent extends pulumi.ComponentResource {
   public readonly provider: github.Provider
   public readonly organizationSettings: github.OrganizationSettings
   public readonly repositories: Record<RepositoryName, github.Repository>
-  public readonly secrets: github.ActionsSecret[]
+  public readonly secrets: (github.ActionsSecret | github.ActionsOrganizationSecret)[]
 
   constructor(args: GitHubComponentArgs, opts?: pulumi.ComponentResourceOptions) {
     super('GitHub', 'github', {}, opts)
@@ -139,11 +139,11 @@ export class GitHubComponent extends pulumi.ComponentResource {
     this.secrets = [bufTokenSecret]
 
     if (githubConfig.geminiApiKey) {
-      const geminiApiKeySecret = new github.ActionsSecret(
+      const geminiApiKeySecret = new github.ActionsOrganizationSecret(
         'gemini-api-key',
         {
-          repository: RepositoryName.BACKEND,
           secretName: 'GEMINI_API_KEY',
+          visibility: 'all',
           plaintextValue: githubConfig.geminiApiKey,
         },
         { provider: this.provider }


### PR DESCRIPTION
## 🔗 Related Issue
Closes #11

## 📝 Summary of Changes
Switched `GEMINI_API_KEY` provisioning from a Repository Secret to an **Organization Secret** with `visibility: 'all'`.
This enables the API key to be used by all repositories in the organization (including `backend` and potentially `frontend`) without per-repo configuration.

## 🌍 Affected Stacks
- [ ] Dev
- [x] Prod

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] Secrets are managed in Pulumi Config.
- [x] Visibility set to 'all' for broad access.