### PR TITLE
fix(gcp): enable Cloud DNS API for NetworkComponent

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -67,6 +67,7 @@ export class Gcp {
     const network = new NetworkComponent('network', {
       region: Regions.Osaka,
       regionName: RegionNames.Osaka,
+      projectId: this.project.projectId,
     })
 
     // 4. Concert Data Store (Vertex AI Search)

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -22,6 +22,7 @@ export type GoogleApis =
   | 'sqladmin.googleapis.com'
   | 'servicenetworking.googleapis.com'
   | 'container.googleapis.com'
+  | 'dns.googleapis.com'
 
 export class ApiService {
   constructor(private projectId: pulumi.Input<string>) {}


### PR DESCRIPTION
## 🔗 Related Issue

close: #23

## 📝 Summary of Changes

- Added  to the list of supported Google Cloud APIs.
- Updated  to accept  and enable the Cloud DNS API using .
- Added an explicit  for the  resource to ensure the API is enabled first.
- Updated the  class to pass the missing  to .

## 🌍 Affected Stacks

- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

- Verified locally that  service is created and the  correctly depends on it.
- Infrastructure provisioning now proceeds past the DNS zone creation.

## ✅ Checklist

- [x] `npm run lint` passes.
- [x] `pulumi preview` passes locally.
