### PR TITLE
fix(gcp): resolve GKE tag and Cloud SQL insights configuration errors

### DIFF
--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -102,11 +102,6 @@ export class KubernetesComponent extends pulumi.ComponentResource {
         costManagementConfig: {
           enabled: true,
         },
-        nodePoolAutoConfig: {
-          resourceManagerTags: {
-            environment,
-          },
-        },
       },
       { parent: this, dependsOn: enabledApis }
     )

--- a/src/gcp/components/postgres.ts
+++ b/src/gcp/components/postgres.ts
@@ -117,7 +117,7 @@ export class PostgresComponent extends pulumi.ComponentResource {
           insightsConfig: {
             queryInsightsEnabled: true,
             recordApplicationTags: true,
-            recordClientAddress: true,
+            recordClientAddress: false,
           },
           databaseFlags: [
             { name: 'cloudsql.iam_authentication', value: 'on' },


### PR DESCRIPTION
## 🔗 Related Issue

close: #25

## 📝 Summary of Changes

- Removed `resourceManagerTags` from `KubernetesComponent` because the provide key "environment" was not a valid CRM resource name.
- Set `recordClientAddress: false` in `PostgresComponent`'s `insightsConfig` because it is incompatible with Private Service Connect (PSC).

## 🌍 Affected Stacks

- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

- Verified that GKE cluster and Cloud SQL instance configurations are now valid.
- Infrastructure provisioning should now complete without 400 Bad Request errors.

## ✅ Checklist

- [x] `npm run lint` passes.
- [x] `pulumi preview` passes locally.
