### PR TITLE
fix: grant Artifact Registry Reader to Default Compute SA for GKE Autopilot

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -143,6 +143,15 @@ export class Gcp {
       artifactRegistry
     )
 
+    // Grant default compute service account permission to pull images (required for GKE nodes)
+    iamSvc.bindArtifactRegistryReader(
+      'default-compute-sa',
+      pulumi.interpolate`${this.project.number}-compute@developer.gserviceaccount.com`,
+      artifactRegistry,
+      Regions.Osaka,
+      artifactRegistry
+    )
+
     // 9. Workload Identity Federation
     const wif = new WorkloadIdentityComponent({
       environment,


### PR DESCRIPTION
## 🔗 Related Issue
Follow-up to #32, fixes `403 Forbidden` on image pull.

## 📝 Summary of Changes
Grants `roles/artifactregistry.reader` to the **Default Compute Engine Service Account** via Pulumi.

### Why?
GKE Autopilot nodes use the Default Compute Engine SA to pull images from Artifact Registry (unless `imagePullSecrets` are configured, which Workload Identity does not replace for the Kubelet itself). This permission was missing, causing `ErrImagePull`.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.