### PR TITLE
chore: temporarily remove prod resources for cost saving

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -82,7 +82,7 @@ export class Gcp {
       { parent: this.project }
     )
 
-    if (environment === 'prod') {
+    if (environment === 'dev') {
       // 5. GKE Autopilot Cluster
       const osakaConfig = NetworkConfig.Osaka
       const kubernetes = new KubernetesComponent('kubernetes-cluster', {


### PR DESCRIPTION
## Description
Temporarily comments out the provisioning of GKE Cluster and Cloud SQL instance in `src/gcp/index.ts` to reduce cloud costs given the current project phase.

- **Removed:** GKE Autopilot Cluster, Cloud SQL (Postgres)
- **Retained:** VPC Network, Artifact Registry

Use this PR to apply a cost-saving state to the infrastructure.