### PR TITLE
fix: specify GAR image path and tag for backend deployment

### DIFF
--- a/k8s/namespaces/backend/base/server/kustomization.yaml
+++ b/k8s/namespaces/backend/base/server/kustomization.yaml
@@ -21,6 +21,8 @@ labels:
 
 images:
 - name: server
+  newName: asia-northeast1-docker.pkg.dev/liverty-music-dev/backend/server
+  newTag: latest
 
 configMapGenerator:
 - name: config


### PR DESCRIPTION
## Summary
Fixes backend deployment ImagePullBackOff error by specifying the correct GAR image path in Kustomize configuration.

## Changes
- Updated `k8s/namespaces/backend/base/server/kustomization.yaml`
- Added `newName` and `newTag` to images transformer
- Now correctly references `asia-northeast1-docker.pkg.dev/liverty-music-dev/backend/server:latest`

## Related
- Part of #expose-api-via-gateway implementation
- Fixes backend pod failing with ImagePullBackOff

## Testing
After merge, ArgoCD will sync and backend pods should start successfully.