### PR TITLE
fix: correct GAR region from tokyo to osaka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ charts/
 
 # Agent
 .pr_data/
+
+tmp/

--- a/k8s/namespaces/backend/base/server/kustomization.yaml
+++ b/k8s/namespaces/backend/base/server/kustomization.yaml
@@ -21,7 +21,7 @@ labels:
 
 images:
 - name: server
-  newName: asia-northeast1-docker.pkg.dev/liverty-music-dev/backend/server
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newTag: latest
 
 configMapGenerator:


### PR DESCRIPTION
## Summary
Corrects the Artifact Registry region in the backend image path.

## Issue
The Kustomize configuration was referencing  (Tokyo), but the actual Artifact Registry repository is located in  (Osaka), causing  errors when pulling images.

## Changes
- Updated image path from  to 

## Related
- Follows up on #48
- Part of #expose-api-via-gateway implementation

## Testing
After merge, ArgoCD will sync and backend pods should successfully pull images from the correct GAR location.