### PR TITLE
fix: preserve Workload Identity by moving ServiceAccount out of namePrefix scope

### DIFF
--- a/k8s/namespaces/backend/base/kustomization.yaml
+++ b/k8s/namespaces/backend/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- serviceaccount.yaml
 - server
 
 namespace: backend

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -8,7 +8,7 @@ spec:
     metadata:
       # Labels handled by commonLabels
     spec:
-      serviceAccountName: app
+      serviceAccountName: backend-app
       containers:
       - name: server
         image: server

--- a/k8s/namespaces/backend/base/server/kustomization.yaml
+++ b/k8s/namespaces/backend/base/server/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 resources:
 - deployment.yaml
 - service.yaml
-- serviceaccount.yaml
 - health-check-policy.yaml
 - backend-policy.yaml
 - httproute.yaml

--- a/k8s/namespaces/backend/base/serviceaccount.yaml
+++ b/k8s/namespaces/backend/base/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: app
+  name: backend-app
   annotations:
     # Requires the GSA created by Pulumi: backend-app@<project-id>.iam.gserviceaccount.com
     # Using placeholder for now, Kustomize overlay should update this or use a configMapGenerator

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -7,11 +7,11 @@ resources:
 namespace: backend
 
 patches:
-# Target server-app after prefixing
+# Target backend-app (no longer affected by namePrefix)
 - path: serviceaccount_patch.yaml
   target:
     kind: ServiceAccount
-    name: server-app
+    name: backend-app
 
 # Global Spot VM patch for all Deployments in dev
 - path: spot-vm_patch.yaml


### PR DESCRIPTION
## Summary
Fixes Workload Identity binding by moving ServiceAccount out of the server/ directory so it's not affected by `namePrefix`.

## Issue
The Kustomize `namePrefix: server-` was renaming ServiceAccount from `backend-app` to `server-app`, breaking the Workload Identity binding which expected `ns/backend/sa/backend-app`.

## Changes
- Moved `serviceaccount.yaml` from `backend/base/server/` to `backend/base/`
- Updated ServiceAccount name to `backend-app` 
- Updated deployment to reference `backend-app`
- Updated overlay patch target to `backend-app`

## Result
ServiceAccount now keeps its original name `backend-app`, matching the GCP IAM Workload Identity binding.

## Related
- Fixes Cloud SQL connection error: `Permission 'iam.serviceAccounts.getAccessToken' denied`
- Part of #expose-api-via-gateway implementation

## Testing
After merge, backend pods should successfully authenticate to Cloud SQL via Workload Identity.