### PR TITLE
feat: add CORS configuration for backend API

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,5 +1,7 @@
 # Environment
 ENVIRONMENT=development
+# CORS
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
 # GCP_VERTEX_AI_SEARCH_DATA_STORE=projects/liverty-music-dev/locations/global/collections/default_collection/dataStores/concert-search-engine


### PR DESCRIPTION
## Summary
Adds CORS configuration to enable frontend applications to access the backend API.

## Changes
- Added `CORS_ALLOWED_ORIGINS` to `k8s/namespaces/backend/overlays/dev/server/configmap.env`
- Allowed origins: 
  - `http://localhost:5173` (Vite dev server)
  - `http://localhost:9000` (local testing)
  - `https://liverty-music.app` (production frontend)

## Related
- Part of #expose-api-via-gateway implementation (Task 2.4)
- Completes Phase 6 testing requirements

## Testing
After merge and ArgoCD sync:
```bash
curl -X OPTIONS https://api.dev.liverty-music.app/liverty_music.rpc.artist.v1.ArtistService/SearchArtists \
  -H "Origin: http://localhost:5173" \
  -H "Access-Control-Request-Method: POST" \
  -v
```

Expected: Response includes `Access-Control-Allow-Origin` header