### PR TITLE
fix: correct CORS environment variable name

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,7 +1,7 @@
 # Environment
 ENVIRONMENT=development
 # CORS
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://liverty-music.app
+SERVER_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
 # GCP_VERTEX_AI_SEARCH_DATA_STORE=projects/liverty-music-dev/locations/global/collections/default_collection/dataStores/concert-search-engine


### PR DESCRIPTION
## Summary

Fixes CORS configuration by using the correct environment variable name expected by the backend application.

## Issue

PR #51 added `CORS_ALLOWED_ORIGINS` to the ConfigMap, but the backend config expects `SERVER_ALLOWED_ORIGINS` due to its nested structure:

```go
type Config struct {
    Server ServerConfig `envconfig:"SERVER"`
}

type ServerConfig struct {
    AllowedOrigins []string `envconfig:"ALLOWED_ORIGINS"`
    // Full env var name: SERVER_ALLOWED_ORIGINS
}
```

## Changes

- Rename `CORS_ALLOWED_ORIGINS` → `SERVER_ALLOWED_ORIGINS` in configmap.env

## Testing

After merge and ArgoCD sync, verify with:

```bash
curl -i -X OPTIONS "https://api.dev.liverty-music.app/liverty_music.rpc.artist.v1.ArtistService/SearchArtists" \
  -H "Origin: http://localhost:5173" \
  -H "Access-Control-Request-Method: POST"
```

Expected headers:
- `Access-Control-Allow-Origin: http://localhost:5173`
- `Access-Control-Allow-Methods: POST, GET, OPTIONS`
- `Access-Control-Allow-Headers: ...`

## Related

- Fixes: #expose-api-via-gateway (Task 6.3)
- Follow-up to PR #51