### PR TITLE
chore: add CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Adds a symbolic link from `CLAUDE.md` to `AGENTS.md` to ensure project-specific instructions and skill routing documentation are loaded by default in Claude Code.

## Background

AGENTS.md contains project-specific instructions including:
- Skill routing for specialized workflows (e.g., database migrations, deployments)
- Repository-specific conventions and standards
- Tool and command references

However, Claude Code loads `CLAUDE.md` by default, not `AGENTS.md`. This PR creates a symlink so that the content of `AGENTS.md` is automatically accessible.

## Changes

- Created symbolic link: `CLAUDE.md -> AGENTS.md`

## Benefits

- ✅ AGENTS.md content is loaded automatically in Claude Code sessions
- ✅ Consistent approach across all repositories (backend, specification, cloud-provisioning)
- ✅ No duplication of documentation
- ✅ Single source of truth for project-specific instructions

## Testing

Verified that the symlink is created correctly:
```bash
$ ls -la CLAUDE.md
lrwxrwxrwx - pannpers CLAUDE.md -> AGENTS.md
```