### PR TITLE
fix(k8s): correct CORS_ALLOWED_ORIGINS for dev environment

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,7 +1,7 @@
 # Environment
 ENVIRONMENT=development
 # CORS
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://liverty-music.app
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
 # GCP_VERTEX_AI_SEARCH_DATA_STORE=projects/liverty-music-dev/locations/global/collections/default_collection/dataStores/concert-search-engine


### PR DESCRIPTION
## 🔗 Related Issue
Closes #65

## 📝 Summary of Changes
- Replace production domain (`https://liverty-music.app`) with dev domain (`https://dev.liverty-music.app`) in the dev backend ConfigMap `CORS_ALLOWED_ORIGINS`

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
N/A - This is a Kubernetes ConfigMap change, not a Pulumi resource change.

## 📦 State Changes
None.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.