### PR TITLE
fix(k8s): remove trailing dot from DATABASE_HOST FQDN

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/concert-discovery/configmap.env
@@ -5,5 +5,5 @@ GCP_PROJECT_ID=liverty-music-dev
 # Database
 DATABASE_USER=backend-app@liverty-music-dev.iam
 # Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
-DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog.
+DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
 DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka


### PR DESCRIPTION
## 🔗 Related Issue
Closes #67

## 📝 Summary of Changes
Remove the trailing `.` from `DATABASE_HOST` in the dev overlay ConfigMap for the `concert-discovery` CronJob.

The trailing dot is a DNS absolute domain notation. While technically valid at the DNS layer, the Go pgx driver and Cloud SQL Connector use this value directly in TLS SNI verification — the trailing dot causes a mismatch that can result in connection failures.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
N/A — this is a Kubernetes manifest change only (no Pulumi resources affected).

## 📦 State Changes
None.

## ✅ Checklist
- [ ] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.