### PR TITLE
feat(gcp): provision Secret Manager secrets in KubernetesComponent

### DIFF
--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -6,6 +6,7 @@ export interface GcpConfig {
 	organizationId: string
 	billingAccount: string
 	geminiApiKey?: string
+	lastFmApiKey?: string
 	domains?: {
 		publicDomain: string // e.g., "liverty-music.app"
 	}

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -1,5 +1,5 @@
 import * as gcp from '@pulumi/gcp'
-import type * as pulumi from '@pulumi/pulumi'
+import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from '../cloudflare/config.js'
 import { KubernetesComponent } from './components/kubernetes.js'
 // import { ConcertDataStore } from './components/concert-data-store.js'
@@ -124,6 +124,14 @@ export class Gcp {
 				backendArtifactRegistry,
 				frontendArtifactRegistry,
 			],
+			secrets: gcpConfig.lastFmApiKey
+				? [
+						{
+							name: 'lastfm-api-key',
+							value: pulumi.secret(gcpConfig.lastFmApiKey),
+						},
+					]
+				: [],
 		})
 
 		// 6. Cloud SQL Instance (Postgres)

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -24,6 +24,7 @@ export type GoogleApis =
 	| 'container.googleapis.com'
 	| 'dns.googleapis.com'
 	| 'artifactregistry.googleapis.com'
+	| 'secretmanager.googleapis.com'
 
 export class ApiService {
 	constructor(private project: gcp.organizations.Project) {}

--- a/src/gcp/services/iam.ts
+++ b/src/gcp/services/iam.ts
@@ -36,6 +36,9 @@ export const Roles = {
 		Reader: 'roles/artifactregistry.reader',
 		Writer: 'roles/artifactregistry.writer',
 	},
+	SecretManager: {
+		SecretAccessor: 'roles/secretmanager.secretAccessor',
+	},
 } as const
 
 type DeepValueOf<T> = T extends object


### PR DESCRIPTION
## Summary

- Add `SecretConfig` interface and `secrets` parameter to `KubernetesComponent` for inline GCP Secret Manager provisioning
- Each entry in `secrets` creates a Secret resource, SecretVersion (encrypted value via `pulumi.secret()`), and IAM accessor binding for `backend-app` SA
- Add `secretmanager.googleapis.com` to `GoogleApis` type union in `api.ts`
- Add `roles/secretmanager.secretAccessor` to `Roles.SecretManager` in `iam.ts`
- Add `lastFmApiKey?: string` to `GcpConfig` interface
- Wire up `lastfm-api-key` secret in `Gcp` class using `gcpConfig.lastFmApiKey` from ESC

## Design Decisions

- Secrets provisioned inline in `KubernetesComponent` (not a separate component) for cohesion with IAM bindings
- Secret value passed as `pulumi.Input<string>` to the component — caller wraps with `pulumi.secret()` for encryption
- Secret name uses flat kebab-case (`lastfm-api-key`); GCP project boundary provides environment isolation
- `secretmanager.googleapis.com` API enabled only when `secrets.length > 0`

## Test plan

- [ ] `pulumi preview` shows no unexpected changes on `dev` stack (already applied via `pulumi up`)
- [ ] GCP Secret Manager: `lastfm-api-key` secret exists in `liverty-music-dev` project
- [ ] IAM: `backend-app` SA has `roles/secretmanager.secretAccessor` on `lastfm-api-key`

Closes #70