### PR TITLE
fix(argocd): add enableHelm to external-secrets and reloader apps

### DIFF
--- a/k8s/argocd-apps/dev/external-secrets.yaml
+++ b/k8s/argocd-apps/dev/external-secrets.yaml
@@ -14,6 +14,8 @@ spec:
     repoURL: https://github.com/liverty-music/cloud-provisioning.git
     targetRevision: main
     path: k8s/namespaces/external-secrets/overlays/dev
+    kustomize:
+      enableHelm: true
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets

--- a/k8s/argocd-apps/dev/reloader.yaml
+++ b/k8s/argocd-apps/dev/reloader.yaml
@@ -14,6 +14,8 @@ spec:
     repoURL: https://github.com/liverty-music/cloud-provisioning.git
     targetRevision: main
     path: k8s/namespaces/reloader/overlays/dev
+    kustomize:
+      enableHelm: true
   destination:
     server: https://kubernetes.default.svc
     namespace: reloader


### PR DESCRIPTION
## Summary

- Add `kustomize.enableHelm: true` to `external-secrets` ArgoCD Application
- Add `kustomize.enableHelm: true` to `reloader` ArgoCD Application

Both operators use `helmCharts:` in their base `kustomization.yaml`, but ArgoCD's built-in kustomize does not enable Helm by default, causing the following error:

```
must specify --enable-helm
```

This prevented both Wave 0 operators from syncing, which cascaded to prevent `core` (Wave 1) from deploying `ClusterSecretStore` since the CRD was never installed.

## Root Cause

ArgoCD Application specs must explicitly opt-in to Helm rendering via:
```yaml
source:
  kustomize:
    enableHelm: true
```

## Test Plan

- [ ] `external-secrets` Application syncs successfully (Status: Synced / Health: Healthy)
- [ ] ESO pods Running in `external-secrets` namespace
- [ ] `ClusterSecretStore` CRD installed → `core` app syncs
- [ ] `ClusterSecretStore google-secret-manager` reports Ready
- [ ] `ExternalSecret` in `backend` namespace syncs → `backend-secrets` Secret created
- [ ] `reloader` Application syncs (Status: Synced / Health: Healthy)

Closes: #70