### PR TITLE
fix(argocd): enable Helm via argocd-cm instead of Application spec

### DIFF
--- a/k8s/argocd-apps/dev/external-secrets.yaml
+++ b/k8s/argocd-apps/dev/external-secrets.yaml
@@ -14,8 +14,6 @@ spec:
     repoURL: https://github.com/liverty-music/cloud-provisioning.git
     targetRevision: main
     path: k8s/namespaces/external-secrets/overlays/dev
-    kustomize:
-      enableHelm: true
   destination:
     server: https://kubernetes.default.svc
     namespace: external-secrets

--- a/k8s/argocd-apps/dev/reloader.yaml
+++ b/k8s/argocd-apps/dev/reloader.yaml
@@ -14,8 +14,6 @@ spec:
     repoURL: https://github.com/liverty-music/cloud-provisioning.git
     targetRevision: main
     path: k8s/namespaces/reloader/overlays/dev
-    kustomize:
-      enableHelm: true
   destination:
     server: https://kubernetes.default.svc
     namespace: reloader

--- a/k8s/namespaces/argocd/base/values.yaml
+++ b/k8s/namespaces/argocd/base/values.yaml
@@ -2,6 +2,12 @@ global:
   nodeSelector:
     cloud.google.com/compute-class: "autopilot-spot"
 
+configs:
+  cm:
+    # Enable Helm template rendering inside kustomize overlays that use helmCharts:.
+    # Required for external-secrets and reloader overlays.
+    kustomize.buildOptions: "--enable-helm"
+
 server:
   service:
     type: ClusterIP


### PR DESCRIPTION
## Summary

- Set `kustomize.buildOptions: "--enable-helm"` globally in `argocd-cm` via Helm `values.yaml`
- Remove `kustomize.enableHelm: true` from `external-secrets` and `reloader` Application specs

## Root Cause

PR #75 used `spec.source.kustomize.enableHelm: true` in the ArgoCD Application spec, but this field is not declared in the ArgoCD v3.3.0 Application CRD schema. When `root-app` applies the Application resources via ServerSideApply, the API server rejected the field with:

```
.spec.source.kustomize.enableHelm: field not declared in schema
```

## Fix

The correct approach is `argocd-cm` (`configs.cm` in Helm values):

```yaml
configs:
  cm:
    kustomize.buildOptions: "--enable-helm"
```

This globally enables Helm rendering for all kustomize overlays that use `helmCharts:`, without per-Application configuration.

## Test Plan

- [ ] `argocd-cm` ConfigMap contains `kustomize.buildOptions: --enable-helm`
- [ ] `external-secrets` Application syncs (Status: Synced / Health: Healthy)
- [ ] `reloader` Application syncs (Status: Synced / Health: Healthy)
- [ ] ESO pods Running in `external-secrets` namespace
- [ ] `ClusterSecretStore google-secret-manager` reports Ready
- [ ] `ExternalSecret` in `backend` namespace syncs → `backend-secrets` Secret created

Closes: #70