### PR TITLE
fix(github): disable strict status checks to unblock PR-only workflows

### DIFF
--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -128,7 +128,7 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 						? {
 								requiredStatusChecks: [
 									{
-										strict: true, // Require branches to be up to date before merging
+										strict: false,
 										contexts: requiredStatusCheckContexts,
 									},
 								],


### PR DESCRIPTION
## Summary

- Set `strict: false` in `BranchProtection` for all repositories

## Why

`strict: true` requires Required Checks to be reported on the base branch (main) HEAD. Since `Atlas CI` runs only on `pull_request`, it is never reported on main after a merge, causing all subsequent PRs to be permanently blocked.

`strict: false` keeps the Required Check gate intact without this constraint.