### PR TITLE
feat(zitadel): enforce passkey-only auth policy

### DIFF
--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -80,8 +80,8 @@ export class FrontendComponent extends pulumi.ComponentResource {
 				// Disable username/password login (userLogin=false disables password auth)
 				userLogin: false,
 				allowRegister: true,
-				// Enable External IDPs (Google) for verification
-				allowExternalIdp: true,
+				// Disable external IDPs (Google etc.) to enforce passkey-only authentication
+				allowExternalIdp: false,
 				forceMfa: false,
 				forceMfaLocalOnly: false,
 				// Allow Passwordless (Passkeys) for better UX and security


### PR DESCRIPTION
## Summary
- Disable external IDPs (`allowExternalIdp: false`) in Org-level login policy to enforce passkey-only authentication
- Update comment to reflect permanent intent (was previously marked as temporary)

## Test plan
- [ ] Run `pulumi up --stack dev` and verify Org Settings show External Login disabled
- [ ] Companion PR: liverty-music/frontend#37 (adds org scope to OIDC)