### PR TITLE
fix(github): use correct status check context name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,11 +69,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.BACKEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: [
-		'Atlas CI / CI Success',
-		'Lint / CI Success',
-		'Test / CI Success',
-	],
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Frontend Repository
@@ -93,7 +89,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.SPECIFICATION,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['Buf PR Checks / CI Success'],
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Cloud Provisioning Repository


### PR DESCRIPTION
## Summary

- Fix required status check context names from `Lint / CI Success` / `Atlas CI / CI Success` / `Test / CI Success` / `Buf PR Checks / CI Success` to `CI Success`
- GitHub branch protection matches on the Check Run `name` field only, not `Workflow / Job` format
- All workflows share the same `name: CI Success` job name, so a single context is sufficient to require all of them

## Root Cause

The previous configuration assumed that required status checks use the `WorkflowName / JobName` format (as displayed in GitHub UI). In reality, GitHub matches on the Check Run `name` field, which is just `CI Success` for all three backend workflows and the specification workflow.

## Test Plan

- [ ] Verify PR #62 (backend) becomes mergeable after Pulumi applies the updated branch protection
- [ ] Confirm `CI Success` check is required on main branch of backend and specification repos

close: #63