### PR TITLE
fix(gcp): read cloudSqlUsers from GcpConfig instead of wrong namespace

### DIFF
--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -7,6 +7,7 @@ export interface GcpConfig {
 	billingAccount: string
 	geminiApiKey?: string
 	lastFmApiKey?: string
+	cloudSqlUsers?: string[]
 	/** Private key for the TicketSBT contract deployer EOA on Base Sepolia. */
 	ticketSbtDeployerKey?: string
 	/** Base Sepolia JSON-RPC endpoint URL. */

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -55,9 +55,7 @@ export class Gcp {
 			cloudflareConfig,
 		} = args
 
-		const gcpPulumiConfig = new pulumi.Config('gcp')
-		const cloudSqlUsers =
-			gcpPulumiConfig.getObject<string[]>('cloudSqlUsers') ?? []
+		const cloudSqlUsers = gcpConfig.cloudSqlUsers ?? []
 
 		// 1. Project and Folders
 		const projectBasis = new ProjectComponent({


### PR DESCRIPTION
## 🔗 Related Issue
Closes #86

## 📝 Summary of Changes
`new pulumi.Config('gcp')` was reading from the bare `gcp:` Pulumi config namespace, which is not populated by Pulumi ESC. The `cloudSqlUsers` value is stored under `pulumiConfig.gcp.cloudSqlUsers` in ESC, which maps to `liverty-music:gcp.cloudSqlUsers` (the `liverty-music` project namespace). Fixed by:

- Adding `cloudSqlUsers?: string[]` to `GcpConfig` interface
- Reading the value via `gcpConfig.cloudSqlUsers` (already resolved from ESC by the caller)

Without this fix, `cloudSqlUsers` always resolved to `[]` and no Cloud SQL IAM users were created.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
Verified locally: `+2 to create` — `gcp:sql/user:User` (CLOUD_IAM_USER) and `gcp:projects/iAMMember:IAMMember` (roles/cloudsql.instanceUser) for `pannpers@pannpers.dev`.

## 📦 State Changes
No state migration needed. New resources will be created on `pulumi up`.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.