### PR TITLE
fix(k8s): update VAPID_CONTACT to personal email

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/concert-discovery/configmap.env
@@ -20,4 +20,4 @@ DATABASE_SSL_MODE=disable
 
 # Push Notifications (VAPID)
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY
-VAPID_CONTACT=mailto:admin@liverty-music.app
+VAPID_CONTACT=mailto:pepperoni9@gmail.com

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -28,4 +28,4 @@ TICKET_SBT_ADDRESS=TO_REPLACE_BY_OVERLAY
 
 # Push Notifications (VAPID)
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY
-VAPID_CONTACT=mailto:admin@liverty-music.app
+VAPID_CONTACT=mailto:pepperoni9@gmail.com


### PR DESCRIPTION
## Summary

- Update `VAPID_CONTACT` from `mailto:admin@liverty-music.app` to `mailto:pepperoni9@gmail.com` in both server and cronjob configmaps

## Changes

- `k8s/namespaces/backend/base/server/configmap.env`
- `k8s/namespaces/backend/base/cronjob/concert-discovery/configmap.env`

## Test plan

- [x] `kubectl kustomize` dev overlay builds without errors