### PR TITLE
ci: provision ANTHROPIC_API_KEY as GitHub org secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,52 @@ esc env get liverty-music/dev pulumiConfig.gcp.postgresAdminPassword
 
 To rotate the password, re-run the steps above with a new value and run `pulumi up`. The Cloud SQL user password and Secret Manager version will be updated automatically. The ESO sync interval will propagate the new secret to K8s.
 
+## Claude Code Review (GitHub Actions)
+
+Claude Code Review provides AI-powered PR review across all repositories, using the Anthropic API subscription (no per-token charges).
+
+### Prerequisites
+
+- Anthropic API key (from [console.anthropic.com](https://console.anthropic.com))
+- GitHub Organization admin access
+
+### 1. Install the Claude GitHub App (Manual, One-Time)
+
+1. Visit https://github.com/apps/claude
+2. Click **Install** and select the `liverty-music` organization
+3. Grant access to **All repositories** (or select specific ones)
+4. Required permissions: Contents (R/W), Issues (R/W), Pull requests (R/W)
+
+### 2. Store the API Key in Pulumi ESC
+
+```bash
+# Store ANTHROPIC_API_KEY as a secret in the common ESC environment
+esc env set liverty-music/common pulumiConfig.github.anthropicApiKey $API_KEY --secret
+
+# Verify
+esc env get liverty-music/common pulumiConfig.github.anthropicApiKey
+```
+
+This value is consumed by `OrganizationComponent` to create a `ANTHROPIC_API_KEY` GitHub Organization Secret (visibility: all repositories).
+
+### 3. Deploy with Pulumi
+
+```bash
+pulumi stack select prod
+pulumi up
+```
+
+### 4. Add Workflow to Each Repository
+
+Add `.github/workflows/claude.yml` to each repository. See the `backend` repository for the reference workflow configuration.
+
+### Workflow Capabilities
+
+- **Auto Review**: Runs on `pull_request` events (`opened`, `synchronize`)
+- **Interactive**: Respond to `@claude` mentions in PR/issue comments
+- **CLAUDE.md Aware**: Automatically reads repository `CLAUDE.md` for project-specific review rules
+- **Cost Control**: Use `--max-turns` in `claude_args` to limit API usage
+
 ## Kubernetes & ArgoCD Bootstrap
 
 When setting up a fresh cluster (e.g., `cluster-osaka`), follow these steps to bootstrap the environment.

--- a/src/github/components/organization.ts
+++ b/src/github/components/organization.ts
@@ -143,6 +143,19 @@ export class GitHubOrganizationComponent extends pulumi.ComponentResource {
 			this.secrets.push(geminiApiKeySecret)
 		}
 
+		if (githubConfig.anthropicApiKey) {
+			const anthropicApiKeySecret = new github.ActionsOrganizationSecret(
+				'anthropic-api-key',
+				{
+					secretName: 'ANTHROPIC_API_KEY',
+					visibility: 'all',
+					plaintextValue: githubConfig.anthropicApiKey,
+				},
+				{ provider: this.provider, parent: this },
+			)
+			this.secrets.push(anthropicApiKeySecret)
+		}
+
 		// Register outputs
 		this.registerOutputs({
 			provider: this.provider,

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -3,6 +3,7 @@ export interface GitHubConfig {
 	token: string
 	billingEmail: string
 	geminiApiKey?: string
+	anthropicApiKey?: string
 }
 
 export interface BufConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ if (env === 'prod') {
 		githubConfig: {
 			...githubConfig,
 			geminiApiKey: gcpConfig.geminiApiKey,
+			anthropicApiKey: githubConfig.anthropicApiKey,
 		},
 		bufConfig,
 	})


### PR DESCRIPTION
## Summary
- Add `anthropicApiKey` to `GitHubConfig` interface
- Provision `ANTHROPIC_API_KEY` as an org-level Actions secret (visibility: all repos)
- Wire the key from Pulumi ESC (`githubConfig.anthropicApiKey`) through to `GitHubOrganizationComponent`
- Add Claude Code Review setup documentation to README

## Prerequisites
API key must be stored in Pulumi ESC before running `pulumi up`:
```bash
esc env set liverty-music/common pulumiConfig.github.anthropicApiKey $API_KEY --secret
```

## Test plan
- [ ] `pulumi preview` shows new `ActionsOrganizationSecret` resource
- [ ] `pulumi up` creates `ANTHROPIC_API_KEY` org secret
- [ ] Verify secret is visible in GitHub org settings