### PR TITLE
feat: add ArgoCD Image Updater for automated dev deployments

### DIFF
--- a/k8s/argocd-apps/dev/backend.yaml
+++ b/k8s/argocd-apps/dev/backend.yaml
@@ -3,6 +3,9 @@ kind: Application
 metadata:
   name: backend
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: server=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
+    argocd-image-updater.argoproj.io/server.update-strategy: latest
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/argocd-apps/dev/frontend.yaml
+++ b/k8s/argocd-apps/dev/frontend.yaml
@@ -3,6 +3,9 @@ kind: Application
 metadata:
   name: frontend
   namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: web-app=asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
+    argocd-image-updater.argoproj.io/web-app.update-strategy: latest
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/namespaces/argocd/base/image-updater-values.yaml
+++ b/k8s/namespaces/argocd/base/image-updater-values.yaml
@@ -1,0 +1,15 @@
+config:
+  logLevel: info
+  registries: []
+
+extraArgs:
+- --interval
+- 30s
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/k8s/namespaces/argocd/base/kustomization.yaml
+++ b/k8s/namespaces/argocd/base/kustomization.yaml
@@ -11,11 +11,18 @@ helmCharts:
   namespace: argocd
   includeCRDs: true
   valuesFile: values.yaml
+- name: argocd-image-updater
+  repo: oci://ghcr.io/argoproj/argo-helm
+  version: 1.1.1
+  releaseName: argocd-image-updater
+  namespace: argocd
+  valuesFile: image-updater-values.yaml
 
 patches:
 - target:
     kind: (Deployment|StatefulSet|Job)
     namespace: argocd
+    name: argocd-*
   patch: |-
     - op: remove
       path: /spec/template/spec/nodeSelector/kubernetes.io~1os

--- a/k8s/namespaces/backend/base/cronjob/concert-discovery/cronjob.yaml
+++ b/k8s/namespaces/backend/base/cronjob/concert-discovery/cronjob.yaml
@@ -16,6 +16,7 @@ spec:
           containers:
           - name: concert-discovery
             image: concert-discovery
+            imagePullPolicy: Always
             envFrom:
             - configMapRef:
                 name: job-config

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: server
         image: server
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
           name: http

--- a/k8s/namespaces/frontend/base/web/deployment.yaml
+++ b/k8s/namespaces/frontend/base/web/deployment.yaml
@@ -11,6 +11,7 @@ spec:
       containers:
       - name: caddy
         image: web-app
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
           name: http


### PR DESCRIPTION
## Summary
- Install ArgoCD Image Updater (Helm chart v1.1.1) with 30s polling interval
- Use `argocd` write-back method — updates Application parameter overrides directly, zero commit spam
- Add Image Updater annotations to dev backend/frontend ArgoCD Applications
- Set `imagePullPolicy: Always` on all base deployments and cronjobs

## Design
ArgoCD Image Updater polls GAR every 30 seconds for new image digests behind the `latest` tag. When a new digest is detected, it updates the ArgoCD Application's kustomize image override via the ArgoCD API (no git commits). ArgoCD then syncs the new image to the cluster.

## Test plan
- [ ] Verify Image Updater pod is running in argocd namespace
- [ ] Check Image Updater logs for successful registry scan
- [ ] Merge a PR to main in backend repo to trigger image build
- [ ] Verify Image Updater detects new digest within ~30s
- [ ] Verify new pod is running with updated image
- [ ] Verify no commits were created in cloud-provisioning repo