### PR TITLE
fix: migrate Image Updater to CRD-based config (v1.1.0)

### DIFF
--- a/k8s/argocd-apps/dev/backend.yaml
+++ b/k8s/argocd-apps/dev/backend.yaml
@@ -3,9 +3,6 @@ kind: Application
 metadata:
   name: backend
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: server=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
-    argocd-image-updater.argoproj.io/server.update-strategy: latest
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/argocd-apps/dev/frontend.yaml
+++ b/k8s/argocd-apps/dev/frontend.yaml
@@ -3,9 +3,6 @@ kind: Application
 metadata:
   name: frontend
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: web-app=asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
-    argocd-image-updater.argoproj.io/web-app.update-strategy: latest
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -1,0 +1,20 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: dev-apps
+spec:
+  writeBackConfig:
+    method: argocd
+  applicationRefs:
+  - namePattern: backend
+    images:
+    - alias: server
+      imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
+      commonUpdateSettings:
+        updateStrategy: latest
+  - namePattern: frontend
+    images:
+    - alias: web-app
+      imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
+      commonUpdateSettings:
+        updateStrategy: latest

--- a/k8s/namespaces/argocd/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../../base
+- image-updater.yaml
 
 patches:
 # Global Spot VM patches for dev


### PR DESCRIPTION
## Summary
- Replace legacy Application annotations with ImageUpdater CR
- v1.1.0 uses CRD-based configuration; annotation scanning no longer works
- ImageUpdater CR in dev overlay targets backend and frontend Applications

## Changes
- Remove `argocd-image-updater.argoproj.io/*` annotations from dev backend/frontend Applications
- Add `ImageUpdater` CR (`dev-apps`) to argocd dev overlay with `argocd` write-back method

## Test plan
- [ ] Verify ImageUpdater controller picks up the CR
- [ ] Check logs for successful registry scanning
- [ ] Verify automatic image update on new push