### PR TITLE
fix: add required spec.namespace to ImageUpdater CR

### DIFF
--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -3,6 +3,7 @@ kind: ImageUpdater
 metadata:
   name: dev-apps
 spec:
+  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:


### PR DESCRIPTION
## Summary
- Add `spec.namespace: argocd` to ImageUpdater CR (required field by CRD)
- Without this, the CR fails validation: `spec.namespace: Required value`

## Test plan
- [x] kubectl kustomize renders correctly with spec.namespace
- [ ] ArgoCD sync succeeds with valid ImageUpdater CR