### PR TITLE
feat: add Workload Identity for Image Updater GAR access

### DIFF
--- a/k8s/namespaces/argocd/base/image-updater-values.yaml
+++ b/k8s/namespaces/argocd/base/image-updater-values.yaml
@@ -1,3 +1,7 @@
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: argocd-image-updater@liverty-music-dev.iam.gserviceaccount.com
+
 config:
   logLevel: info
   registries: []

--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -12,10 +12,10 @@ spec:
     - alias: server
       imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
       commonUpdateSettings:
-        updateStrategy: latest
+        updateStrategy: newest-build
   - namePattern: frontend
     images:
     - alias: web-app
       imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
       commonUpdateSettings:
-        updateStrategy: latest
+        updateStrategy: newest-build


### PR DESCRIPTION
## Summary
- Create GCP SA `argocd-image-updater` with Artifact Registry Reader permissions on backend/frontend repos
- Bind k8s SA `argocd-image-updater` to GCP SA via Workload Identity Federation for GKE
- Add `iam.gke.io/gcp-service-account` annotation to Image Updater Helm values
- Rename update strategy `latest` -> `newest-build` per v1.1.0 deprecation

## Context
Image Updater was getting `Unauthenticated request` errors when trying to list tags from GAR. GKE Autopilot requires Workload Identity binding for pod-level GCP access.

## Test plan
- [ ] `pulumi preview` shows new GCP SA + IAM bindings
- [ ] After deploy, Image Updater logs show successful registry scan
- [ ] No more `Unauthenticated request` errors