### PR TITLE
feat(k8s): add GAR registry auth for Image Updater

### DIFF
--- a/k8s/namespaces/argocd/base/image-updater-values.yaml
+++ b/k8s/namespaces/argocd/base/image-updater-values.yaml
@@ -4,7 +4,23 @@ serviceAccount:
 
 config:
   logLevel: info
-  registries: []
+  registries:
+  - name: GAR
+    prefix: asia-northeast2-docker.pkg.dev
+    api_url: https://asia-northeast2-docker.pkg.dev
+    ping: false
+    credentials: ext:/scripts/auth.sh
+    credsexpire: 55m
+
+authScripts:
+  enabled: true
+  scripts:
+    auth.sh: |
+      #!/bin/sh
+      TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+        | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+      echo "oauth2accesstoken:${TOKEN}"
 
 extraArgs:
 - --interval


### PR DESCRIPTION
## 🔗 Related Issue
Closes #104

## 📝 Summary of Changes
- Add explicit GAR registry authentication for ArgoCD Image Updater
- Configure `authScripts` with a shell script that fetches OAuth2 tokens from GKE metadata server via Workload Identity
- Set `config.registries` with GAR endpoint, `ext:/scripts/auth.sh` credentials, and 55m token expiry

Image Updater does not automatically use GKE Workload Identity for container registry access. This adds the required explicit authentication configuration per the [official docs](https://argocd-image-updater.readthedocs.io/en/stable/basics/authentication/).

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
No Pulumi changes — this is a Kubernetes manifest change only.

## 📦 State Changes
No state changes required.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.