### PR TITLE
fix(k8s): use wget instead of curl in Image Updater auth script

### DIFF
--- a/k8s/namespaces/argocd/base/image-updater-values.yaml
+++ b/k8s/namespaces/argocd/base/image-updater-values.yaml
@@ -17,7 +17,7 @@ authScripts:
   scripts:
     auth.sh: |
       #!/bin/sh
-      TOKEN=$(curl -sf -H "Metadata-Flavor: Google" \
+      TOKEN=$(wget -qO- --header="Metadata-Flavor: Google" \
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
         | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
       echo "oauth2accesstoken:${TOKEN}"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #104

## 📝 Summary of Changes
- Replace `curl` with `wget` in the Image Updater GAR auth script
- The `argocd-image-updater` container (Alpine-based) does not include `curl`, causing the auth script to silently fail and return an empty token

**Root cause**: `curl: not found` in the container, confirmed by `kubectl exec` into the pod.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
No Pulumi changes — Kubernetes manifest only.

## 📦 State Changes
No state changes required.

## ✅ Checklist
- [x] `kubectl kustomize --enable-helm k8s/namespaces/argocd/overlays/dev` renders without errors
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.