### PR TITLE
fix(zitadel): enable userLogin as workaround for empty register form

### DIFF
--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -77,8 +77,10 @@ export class FrontendComponent extends pulumi.ComponentResource {
 			'default',
 			{
 				orgId: orgId,
-				// Disable username/password login (userLogin=false disables password auth)
-				userLogin: false,
+				// TODO: Revert to false once upstream fix is released.
+				// Login V2 Register page does not render form fields when userLogin=false,
+				// even with passwordlessType=ALLOWED. See: https://github.com/zitadel/zitadel/issues/11682
+				userLogin: true,
 				allowRegister: true,
 				// Disable external IDPs (Google etc.) to enforce passkey-only authentication
 				allowExternalIdp: false,


### PR DESCRIPTION
## Summary

- Temporarily set `userLogin: true` in the Org-level Login Policy to restore the Register form
- Zitadel Login V2 has an upstream bug where `allowLocalAuthentication=false` + `passwordlessType=ALLOWED` renders an empty Register page with no form fields

## Root Cause

In Zitadel's [`apps/login/src/app/(login)/register/page.tsx`](https://github.com/zitadel/zitadel/blob/main/apps/login/src/app/(login)/register/page.tsx), the `RegisterForm` is gated behind `loginSettings.allowLocalAuthentication`. When this is `false` and no external IdPs are configured, no registration UI renders at all — even with passkeys enabled.

## Upstream Issue

https://github.com/zitadel/zitadel/issues/11682

## Test plan

- [ ] Run `pulumi up` for dev environment
- [ ] Verify Register page at `dev.liverty-music.app` → Sign Up shows form fields
- [ ] Verify passkey registration still works
- [ ] Revert `userLogin` to `false` once upstream fix is released