### PR TITLE
fix(k8s): use per-image pullSecret for Image Updater GAR auth

### DIFF
--- a/k8s/namespaces/argocd/base/image-updater-values.yaml
+++ b/k8s/namespaces/argocd/base/image-updater-values.yaml
@@ -9,8 +9,6 @@ config:
     prefix: asia-northeast2-docker.pkg.dev
     api_url: https://asia-northeast2-docker.pkg.dev
     ping: false
-    credentials: ext:/scripts/auth.sh
-    credsexpire: 55m
 
 authScripts:
   enabled: true

--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -13,9 +13,11 @@ spec:
       imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server:main
       commonUpdateSettings:
         updateStrategy: digest
+        pullSecret: ext:/scripts/auth.sh
   - namePattern: frontend
     images:
     - alias: web-app
       imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app:main
       commonUpdateSettings:
         updateStrategy: digest
+        pullSecret: ext:/scripts/auth.sh


### PR DESCRIPTION
## 🔗 Related Issue
Refs #106

## 📝 Summary of Changes
Move GAR authentication from registry-level `credentials`/`credsexpire` to per-image `pullSecret` in the ImageUpdater CR.

**Root cause**: Registry-level credentials are cached in Image Updater's internal transport cache with a hardcoded 30-minute TTL (`go-cache`). The `credsexpire` setting does NOT invalidate this transport cache, so after the GCE metadata token expires (~60 min), authentication fails and only recovers with a pod restart.

**Fix**: Per-image `pullSecret` re-executes the auth script on every polling cycle (30s), bypassing the transport cache entirely. This is the [officially documented workaround](https://argocd-image-updater.readthedocs.io/en/stable/configuration/registries/): "credentials will be read from their source every time an image update cycle is performed."

### Changes
- `image-updater.yaml`: Add `pullSecret: ext:/scripts/auth.sh` to each image's `commonUpdateSettings`
- `image-updater-values.yaml`: Remove `credentials` and `credsexpire` from registry config (auth script and authScripts remain for the `ext:` mechanism)

### Verification
- Kustomize dry-run: `kubectl kustomize --enable-helm k8s/namespaces/argocd/overlays/dev` ✅
- Applied to dev cluster and confirmed auth script executes every 30s cycle with unique execIDs
- Confirmed no authentication errors after applying

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
No Pulumi changes — K8s manifests only.

## 📦 State Changes
None.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.