### PR TITLE
fix(zitadel): correct post-logout redirect URI to match frontend

### DIFF
--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -32,10 +32,10 @@ export class FrontendComponent extends pulumi.ComponentResource {
 		const domain = domainMap[env]
 
 		const redirectUris = [`https://${domain}/auth/callback`]
-		const postLogoutRedirectUris = [`https://${domain}/signedout`]
+		const postLogoutRedirectUris = [`https://${domain}/`]
 		if (env === 'dev') {
 			redirectUris.push('http://localhost:9000/auth/callback')
-			postLogoutRedirectUris.push('http://localhost:9000/signedout')
+			postLogoutRedirectUris.push('http://localhost:9000/')
 		}
 
 		// 1. Define zitadel.ApplicationOidc resource


### PR DESCRIPTION
## 🔗 Related Issue
Closes #102

## 📝 Summary of Changes
Update the OIDC `postLogoutRedirectUris` registered in Zitadel from `/signedout` to `/` for all environments (production, dev localhost).

The frontend's `oidc-client-ts` library sends `window.location.origin` (e.g., `https://dev.liverty-music.app`) as the `post_logout_redirect_uri`, which didn't match the registered `/signedout` path, causing a **400 invalid_request** error on sign-out.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
```
~ postLogoutRedirectUris:
    [0]: "https://dev.liverty-music.app/signedout" => "https://dev.liverty-music.app/"
    [1]: "http://localhost:9000/signedout" => "http://localhost:9000/"
```

## 📦 State Changes
No state operations required. Simple in-place update of the Zitadel ApplicationOidc resource.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.