### PR TITLE
feat(monitoring): add log-based alerts for backend ERROR logs

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -1,0 +1,151 @@
+import * as gcp from '@pulumi/gcp'
+import * as pulumi from '@pulumi/pulumi'
+
+/** Backend workload definition for alert policy creation. */
+interface Workload {
+	/** Display name used in the alert policy title. */
+	displayName: string
+	/** Value of the k8s-pod/app label used in the log filter. */
+	appLabel: string
+}
+
+export interface MonitoringComponentArgs {
+	project: gcp.organizations.Project
+	environment: string
+	/** GKE cluster location (e.g., "asia-northeast2"). */
+	clusterLocation: string
+	/** GKE cluster name (e.g., "cluster-osaka"). */
+	clusterName: string
+	/** Google Chat Space ID for alert notifications (e.g., "spaces/XXXXXXXXX"). */
+	chatSpaceId: string
+	/** Email address for alert notifications. */
+	notificationEmail: string
+}
+
+/**
+ * MonitoringComponent provisions Cloud Monitoring notification channels
+ * and log-based alert policies for backend workload ERROR log detection.
+ */
+export class MonitoringComponent extends pulumi.ComponentResource {
+	public readonly chatChannel: gcp.monitoring.NotificationChannel
+	public readonly emailChannel: gcp.monitoring.NotificationChannel
+	public readonly alertPolicies: gcp.monitoring.AlertPolicy[]
+
+	constructor(
+		name: string,
+		args: MonitoringComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('gcp:liverty-music:MonitoringComponent', name, args, opts)
+
+		const {
+			project,
+			clusterLocation,
+			clusterName,
+			chatSpaceId,
+			notificationEmail,
+		} = args
+
+		// 1. Notification Channels
+		this.chatChannel = new gcp.monitoring.NotificationChannel(
+			'notification-google-chat',
+			{
+				displayName: `Google Chat`,
+				type: 'google_chat',
+				project: project.projectId,
+				labels: {
+					space_id: chatSpaceId,
+				},
+			},
+			{ parent: this },
+		)
+
+		this.emailChannel = new gcp.monitoring.NotificationChannel(
+			'notification-email',
+			{
+				displayName: `Email`,
+				type: 'email',
+				project: project.projectId,
+				labels: {
+					email_address: notificationEmail,
+				},
+			},
+			{ parent: this },
+		)
+
+		const notificationChannels = [
+			this.chatChannel.name,
+			this.emailChannel.name,
+		]
+
+		// 2. Log-Based Alert Policies (one per workload)
+		const projectId = project.projectId
+		const workloads: Workload[] = [
+			{ displayName: 'Server', appLabel: 'server' },
+			{ displayName: 'Consumer', appLabel: 'consumer' },
+			{
+				displayName: 'Concert Discovery',
+				appLabel: 'concert-discovery',
+			},
+		]
+
+		this.alertPolicies = workloads.map(
+			(workload) =>
+				new gcp.monitoring.AlertPolicy(
+					`alert-error-log-${workload.appLabel}`,
+					{
+						displayName: `${workload.displayName} ERROR Log`,
+						project: projectId,
+						combiner: 'OR',
+						conditions: [
+							{
+								displayName: `${workload.displayName} error log detected`,
+								conditionMatchedLog: {
+									filter: pulumi.interpolate`resource.type="k8s_container"
+resource.labels.project_id="${projectId}"
+resource.labels.location="${clusterLocation}"
+resource.labels.cluster_name="${clusterName}"
+resource.labels.namespace_name="backend"
+labels.k8s-pod/app="${workload.appLabel}"
+severity="ERROR"`,
+									labelExtractors: {
+										error_code:
+											'EXTRACT(jsonPayload.error.code)',
+										rpc_method:
+											'EXTRACT(jsonPayload.rpc_method)',
+									},
+								},
+							},
+						],
+						alertStrategy: {
+							notificationRateLimit: {
+								period: '43200s', // 12 hours
+							},
+							autoClose: '3600s', // 1 hour
+						},
+						notificationChannels,
+						documentation: {
+							content: [
+								`## ${workload.displayName} ERROR Log Alert`,
+								'',
+								'An ERROR-level log entry was detected in the backend application.',
+								'',
+								'### Triage Steps',
+								'1. Check the linked Cloud Logging entry for the full error details',
+								'2. Look at `error_code` and `rpc_method` labels in this alert for quick context',
+								'3. Search for related logs using the `trace_id` from the log entry',
+							].join('\n'),
+							mimeType: 'text/markdown',
+						},
+					},
+					{ parent: this },
+				),
+		)
+
+		this.registerOutputs({
+			chatChannelName: this.chatChannel.name,
+			emailChannelName: this.emailChannel.name,
+			alertPolicyCount: this.alertPolicies.length,
+		})
+	}
+}

--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -18,6 +18,13 @@ export interface GcpConfig {
 	postgresAdminPassword?: string
 	/** VAPID private key for Web Push notification signing (ECDSA P-256). */
 	vapidPrivateKey?: string
+	/** Monitoring alert notification settings. */
+	monitoring?: {
+		/** Google Chat Space ID for alert notifications (e.g., "spaces/XXXXXXXXX"). */
+		chatSpaceId: string
+		/** Email address for alert notifications. */
+		notificationEmail: string
+	}
 	domains?: {
 		publicDomain: string // e.g., "liverty-music.app"
 	}
@@ -81,6 +88,7 @@ export class ProjectComponent extends pulumi.ComponentResource {
 			'cloudasset.googleapis.com', // Recommended for Gemini Cloud Assist.
 			'recommender.googleapis.com', // Recommended for Gemini Cloud Assist.
 			'artifactregistry.googleapis.com', // Required for container images.
+			'clouderrorreporting.googleapis.com', // Required for error grouping and first-seen detection.
 		])
 
 		// Register outputs.

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -2,6 +2,7 @@ import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from '../cloudflare/config.js'
 import { KubernetesComponent } from './components/kubernetes.js'
+import { MonitoringComponent } from './components/monitoring.js'
 // import { ConcertDataStore } from './components/concert-data-store.js'
 import { NetworkComponent } from './components/network.js'
 import { PostgresComponent } from './components/postgres.js'
@@ -209,5 +210,17 @@ export class Gcp {
 		})
 		this.githubWorkloadIdentityProvider = wif.githubProvider.name
 		this.githubActionsSAEmail = wif.githubActionsSA.email
+
+		// 8. Monitoring (Log-Based Alerts + Notification Channels)
+		if (gcpConfig.monitoring) {
+			new MonitoringComponent('monitoring', {
+				project: this.project,
+				environment,
+				clusterLocation: Regions.Osaka,
+				clusterName: `cluster-${RegionNames.Osaka}`,
+				chatSpaceId: gcpConfig.monitoring.chatSpaceId,
+				notificationEmail: gcpConfig.monitoring.notificationEmail,
+			})
+		}
 	}
 }

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -25,6 +25,7 @@ export type GoogleApis =
 	| 'dns.googleapis.com'
 	| 'artifactregistry.googleapis.com'
 	| 'secretmanager.googleapis.com'
+	| 'clouderrorreporting.googleapis.com'
 
 export class ApiService {
 	constructor(private project: gcp.organizations.Project) {}


### PR DESCRIPTION
## 🔗 Related Issue
Closes #123

## 📝 Summary of Changes
- Add `MonitoringComponent` (`src/gcp/components/monitoring.ts`) with:
  - Google Chat and Email notification channels
  - Log-based alert policies for server, consumer, and concert-discovery workloads
  - ERROR severity log filter with `labels.k8s-pod/app` targeting
  - `labelExtractors` for `error_code` and `rpc_method` in alert notifications
  - 12-hour notification rate limiting and 1-hour auto-close
- Enable `clouderrorreporting.googleapis.com` API for Error Reporting
- Add `GcpConfig.monitoring` config for Chat Space ID and notification email (via Pulumi ESC)
- Integrate `MonitoringComponent` into `Gcp` orchestrator with conditional instantiation

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
Please check the CI/GitHub Actions output for the Preview result.

## 📦 State Changes
No state migrations required. All resources are new additions.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.