### PR TITLE
ci: unify lint via Makefile and pre-commit hook

### DIFF
--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# PreToolUse hook: runs `make check` before git commit.
+# Exit 2 = block the tool call (stderr shown to Claude as reason).
+
+COMMAND=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Only act on git commit calls
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
+
+make check
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Blocked: 'make check' failed (exit $EXIT_CODE). Fix errors before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-check.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
               - 'package-lock.json'
               - 'tsconfig.json'
               - 'biome.json'
+              - 'Makefile'
               - '.github/workflows/**'
 
   lint:
@@ -49,8 +50,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run linter and check formatting
-        run: npx biome check src
+      - name: Run make lint-ts
+        run: make lint-ts
 
   lint-skip:
     needs: changes
@@ -60,41 +61,13 @@ jobs:
     steps:
       - run: echo "No relevant changes, skipping lint"
 
-  typecheck:
-    needs: changes
-    if: needs.changes.outputs.src == 'true'
-    name: Typecheck
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run type check
-        run: npm run typecheck
-
-  typecheck-skip:
-    needs: changes
-    if: needs.changes.outputs.src == 'false'
-    name: Typecheck
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No relevant changes, skipping typecheck"
-
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, lint, lint-skip, typecheck, typecheck-skip]
+    needs: [changes, lint, lint-skip]
     if: always()
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: lint, lint-skip, typecheck, typecheck-skip
+          allowed-skips: lint, lint-skip
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,14 @@ on:
       - "k8s/**"
       - ".kube-linter.yaml"
       - "scripts/check-spot-nodeselector.sh"
+      - "Makefile"
       - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "k8s/**"
       - ".kube-linter.yaml"
       - "scripts/check-spot-nodeselector.sh"
+      - "Makefile"
       - ".github/workflows/lint.yml"
 
 permissions:
@@ -37,25 +39,11 @@ jobs:
       - name: Install Kustomize
         uses: imranismail/setup-kustomize@v2
 
-      - name: Render all dev overlays
+      - name: Install KubeLinter
         run: |
-          mkdir -p /tmp/rendered
-          for overlay in k8s/namespaces/*/overlays/dev; do
-            namespace=$(echo "$overlay" | cut -d'/' -f3)
-            echo "::group::Rendering $namespace"
-            kustomize build --enable-helm "$overlay" \
-              > "/tmp/rendered/${namespace}.yaml" || {
-              echo "::error::Failed to render $namespace"
-              exit 1
-            }
-            echo "::endgroup::"
-          done
+          curl -sLO "https://github.com/stackrox/kube-linter/releases/latest/download/kube-linter-linux.tar.gz"
+          tar -xzf kube-linter-linux.tar.gz
+          sudo install kube-linter /usr/local/bin/
 
-      - name: Run KubeLinter
-        uses: stackrox/kube-linter-action@v1
-        with:
-          directory: /tmp/rendered
-          config: .kube-linter.yaml
-
-      - name: Check Spot VM nodeSelector
-        run: ./scripts/check-spot-nodeselector.sh /tmp/rendered
+      - name: Run make lint-k8s
+        run: make lint-k8s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,13 @@
   <responsibilities>GCP infrastructure via Pulumi (TypeScript). Kubernetes manifests
   managed by ArgoCD with Kustomize base/overlays. Multi-environment (dev/staging/prod).</responsibilities>
   <essential-commands>
-    pulumi preview                   # Preview infra changes
-    pulumi up                        # Deploy (requires user approval)
-    kubectl kustomize k8s/...        # Dry-run K8s manifests
+    make lint              # All linters: biome + tsc + kustomize render + kube-linter + spot check
+    make lint-ts           # TypeScript only: biome check + tsc (matches CI)
+    make lint-k8s          # K8s manifests: render + kube-linter + spot nodeSelector check
+    make fix               # Auto-fix formatting (biome check --write)
+    make check             # Pre-commit check (lint-ts; lint-k8s requires kustomize/kube-linter)
+    pulumi preview         # Preview infra changes
+    pulumi up              # Deploy (requires user approval)
   </essential-commands>
 </poly-repo-context>
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: lint lint-ts lint-k8s fix check
+
+## lint: all linters — TypeScript (biome + tsc) and K8s manifests (kustomize + kube-linter + spot check)
+lint: lint-ts lint-k8s
+
+## lint-ts: biome check + typecheck for Pulumi code
+lint-ts:
+	npx biome check src
+	npx tsc --noEmit
+
+## lint-k8s: render + kube-linter + spot nodeSelector check for K8s manifests
+lint-k8s:
+	mkdir -p /tmp/rendered
+	@for overlay in k8s/namespaces/*/overlays/dev; do \
+		namespace=$$(echo "$$overlay" | cut -d'/' -f3); \
+		echo "==> Rendering $$namespace"; \
+		kustomize build --enable-helm "$$overlay" > "/tmp/rendered/$${namespace}.yaml" || exit 1; \
+	done
+	kube-linter lint /tmp/rendered --config .kube-linter.yaml
+	./scripts/check-spot-nodeselector.sh /tmp/rendered
+
+## fix: auto-fix formatting (biome)
+fix:
+	npx biome check --write src
+
+## check: full pre-commit check (lint-ts only; lint-k8s requires kustomize/kube-linter)
+check: lint-ts


### PR DESCRIPTION
## Summary

Unify lint operations in the cloud-provisioning repo via Makefile targets, and enforce pre-commit checks structurally through a Claude Code PreToolUse hook.

### Changes

- **Makefile**: New file with unified targets
  - `make lint`: all linters (lint-ts + lint-k8s)
  - `make lint-ts`: biome check + tsc typecheck (matches CI)
  - `make lint-k8s`: kustomize render + kube-linter + spot nodeSelector check
  - `make fix`: auto-fix with `biome check --write`
  - `make check`: pre-commit (lint-ts only; lint-k8s requires kustomize/kube-linter)
- **CI workflows**:
  - `ci.yml`: use `make lint-ts`, removed separate typecheck job
  - `lint.yml`: install kube-linter CLI, then use `make lint-k8s`
- **PreToolUse hook**: Blocks `git commit` unless `make check` passes
- **AGENTS.md**: Updated essential-commands to reference Makefile targets

close: #133, close: #134, close: #135, close: #136
