### PR TITLE
fix(monitoring): simplify Atlas migration alert filter

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -137,7 +137,7 @@ resource.labels.location="${clusterLocation}"
 resource.labels.cluster_name="${clusterName}"
 resource.labels.namespace_name="atlas-operator"
 resource.labels.container_name="manager"
-textPayload=~"\"reason\": \"(TransientErr|BackoffLimitExceeded)\""`,
+textPayload=~"TransientErr|BackoffLimitExceeded"`,
 						},
 					},
 				],


### PR DESCRIPTION
## Related Issue
Closes #128

## Summary of Changes
Simplify the Atlas migration alert filter regex from `textPayload=~"\"reason\": \"(TransientErr|BackoffLimitExceeded)\""` to `textPayload=~"TransientErr|BackoffLimitExceeded"`.

The previous filter contained escaped quotes that resolved to literal `"` characters at runtime, which Cloud Monitoring's filter parser cannot handle inside regex values. This caused Pulumi Deployment #155 to fail with `Error 400: Unparseable filter`.

The simplified pattern matches the same log entries — the keywords `TransientErr` and `BackoffLimitExceeded` are sufficiently unique within the `atlas-operator` namespace + `manager` container scope to avoid false positives.

## Affected Stacks
- [x] Dev
- [x] Prod

## Pulumi Preview
The fix has already been deployed to dev via `pulumi up` locally. The alert policy was created successfully.

## State Changes
None — this is a filter string change only.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
