### PR TITLE
feat(k8s): enable JSON structured logging for Atlas Operator

### DIFF
--- a/k8s/namespaces/atlas-operator/base/kustomization.yaml
+++ b/k8s/namespaces/atlas-operator/base/kustomization.yaml
@@ -14,3 +14,20 @@ helmCharts:
   namespace: atlas-operator
   includeCRDs: true
   valuesFile: values.yaml
+
+patches:
+- target:
+    kind: Deployment
+    name: atlas-operator
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: atlas-operator
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            args:
+            - --zap-encoder=json


### PR DESCRIPTION
## Related Issue
Refs #128

## Summary of Changes
Enable JSON structured logging for the Atlas Operator by adding `--zap-encoder=json` to the manager container args via Kustomize strategic merge patch.

**Before**: Atlas Operator logs in plain text (console encoder) → stored as `textPayload` in Cloud Logging
**After**: Atlas Operator logs in JSON → stored as `jsonPayload` in Cloud Logging

This enables field-level filtering (e.g., `jsonPayload.msg`, `jsonPayload.reason`) for improved troubleshooting and more precise alert filters.

### Next Steps
After this change is deployed via ArgoCD, verify the `jsonPayload` field structure in Cloud Logging, then update the Atlas migration alert filter in monitoring.ts to use `jsonPayload` fields instead of `textPayload`.

## Affected Stacks
- [x] Dev
- [ ] Prod

## Pulumi Preview
No Pulumi changes — this is a K8s manifest change deployed via ArgoCD.

## State Changes
None.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
