### PR TITLE
fix(monitoring): update Atlas alert filter to use jsonPayload.reason

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -137,7 +137,7 @@ resource.labels.location="${clusterLocation}"
 resource.labels.cluster_name="${clusterName}"
 resource.labels.namespace_name="atlas-operator"
 resource.labels.container_name="manager"
-textPayload=~"TransientErr|BackoffLimitExceeded"`,
+jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 						},
 					},
 				],
@@ -160,7 +160,7 @@ textPayload=~"TransientErr|BackoffLimitExceeded"`,
 						'- **BackoffLimitExceeded**: The operator exhausted all retry attempts after repeated TransientErr failures',
 						'',
 						'### Triage Steps',
-						'1. Check the linked Cloud Logging entry for the full error message in `textPayload`',
+						'1. Check the linked Cloud Logging entry for the full error message in `jsonPayload`',
 						'2. Look at the `AtlasMigration` resource status: `kubectl -n atlas-operator describe atlasmigration backend-migration`',
 						'3. Check the migration pod logs: `kubectl -n atlas-operator logs -l app.kubernetes.io/name=atlas-operator`',
 						'4. If the error is "non-linear" (out-of-order files), see: https://atlasgo.io/versioned/apply#non-linear-error',


### PR DESCRIPTION
## Related Issue
Refs #128

## Summary of Changes
Update the Atlas migration alert filter from `textPayload` to `jsonPayload.reason` to match the new JSON structured logging format enabled in PR #130.

**Verified via `gcloud logging read`**: After enabling `--zap-encoder=json`, Atlas Operator logs now arrive as `jsonPayload` with a `reason` field containing `TransientErr` or `BackoffLimitExceeded` as distinct values.

**Before**: `textPayload=~"TransientErr|BackoffLimitExceeded"`
**After**: `jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`

This provides precise field-level matching instead of full-text search, reducing false positive risk.

## Affected Stacks
- [x] Dev
- [x] Prod

## Pulumi Preview
Please check CI for the Pulumi preview result.

## State Changes
None — in-place update of the alert policy filter string.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
