### PR TITLE
fix(argocd): enable image-updater digest tracking for consumer and concert-discovery

### DIFF
--- a/k8s/argocd-apps/dev/backend.yaml
+++ b/k8s/argocd-apps/dev/backend.yaml
@@ -4,11 +4,16 @@ metadata:
   name: backend
   namespace: argocd
   annotations:
-    argocd-image-updater.argoproj.io/image-list: server=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server, consumer=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
+    argocd-image-updater.argoproj.io/image-list: server=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server, consumer=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer, concert-discovery=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
     argocd-image-updater.argoproj.io/server.update-strategy: digest
     argocd-image-updater.argoproj.io/server.allow-tags: regexp:^main$
+    argocd-image-updater.argoproj.io/server.kustomize.image-name: server
     argocd-image-updater.argoproj.io/consumer.update-strategy: digest
     argocd-image-updater.argoproj.io/consumer.allow-tags: regexp:^main$
+    argocd-image-updater.argoproj.io/consumer.kustomize.image-name: consumer
+    argocd-image-updater.argoproj.io/concert-discovery.update-strategy: digest
+    argocd-image-updater.argoproj.io/concert-discovery.allow-tags: regexp:^main$
+    argocd-image-updater.argoproj.io/concert-discovery.kustomize.image-name: concert-discovery
     argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
## Summary
- Add `kustomize.image-name` annotations for server, consumer, and concert-discovery to map image-updater aliases to Kustomize short names
- Add `concert-discovery` to `image-list` with digest strategy and `main` tag filter
- Fixes the mismatch where image-updater used full registry paths as kustomize override keys while Kustomize bases use short alias names (`server`, `consumer`, `concert-discovery`)

## Test plan
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/dev` renders without errors
- [x] ArgoCD Application YAML has valid annotation syntax
- [ ] After merge, verify `kubectl get application backend -n argocd -o jsonpath='{.spec.source.kustomize.images}'` shows entries for all three images
- [ ] Verify image-updater logs show `images_updated>=1` when a new consumer image is pushed

close: #136