### PR TITLE
fix(keda): correct consumer name and cap dev replicas

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -15,6 +15,6 @@ spec:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
       account: "$G"
       stream: "CONCERT"
-      consumer: "consumer"
+      consumer: "CONCERT_discovered"
       lagThreshold: "10"
       activationLagThreshold: "1"

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -93,6 +93,18 @@ patches:
                 cpu: 200m
                 memory: 128Mi
 
+# Reduce maxReplicaCount for consumer ScaledObject in dev
+- target:
+    kind: ScaledObject
+    name: consumer-app
+  patch: |-
+    apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    metadata:
+      name: consumer-app
+    spec:
+      maxReplicaCount: 2
+
 configMapGenerator:
 - name: config
   behavior: merge


### PR DESCRIPTION
## Summary
- Fix KEDA ScaledObject consumer name from `"consumer"` to `"CONCERT_discovered"` to match actual durable consumer
- Add dev overlay patch to cap `maxReplicaCount` at 2 to reduce Spot node churn

## Root cause
After the stream naming refactor (PR #154), Watermill's `DurableCalculator` creates consumers named `CONCERT_discovered` (replacing `.` with `_`). The KEDA ScaledObject still referenced `consumer: "consumer"`, which doesn't exist. KEDA interpreted the entire stream message count (9,082) as lag and permanently requested max replicas, causing unnecessary Spot node scale-out and compounding the NATS timeout issue.

## Companion PRs
- **backend**: liverty-music/backend — NATS retry + health server refactor (liverty-music/backend#169)
- **specification**: liverty-music/specification — OpenSpec artifacts

## Test plan
- [x] `kubectl kustomize` renders correctly for base
- [x] `kubectl kustomize` renders correctly for dev overlay with maxReplicaCount: 2
- [x] Consumer name matches Watermill DurableCalculator output
