### PR TITLE
fix(k8s): add connection pool limits to dev overlay

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/consumer/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/consumer/configmap.env
@@ -4,6 +4,9 @@ ENVIRONMENT=development
 DATABASE_USER=backend-app@liverty-music-dev.iam
 DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog.
 DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry

--- a/k8s/namespaces/backend/overlays/dev/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/concert-discovery/configmap.env
@@ -7,6 +7,9 @@ DATABASE_USER=backend-app@liverty-music-dev.iam
 # Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
 DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
 DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
 
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222

--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -10,6 +10,9 @@ DATABASE_USER=backend-app@liverty-music-dev.iam
 # Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
 DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog.
 DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
 # OIDC
 OIDC_ISSUER_URL=https://dev-svijfm.us1.zitadel.cloud
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/backend#173

## 📝 Summary of Changes

Add DATABASE_MAX_OPEN_CONNS=5 and DATABASE_MAX_IDLE_CONNS=1 to all three dev overlay ConfigMaps (server, consumer, concert-discovery). This budgets 5 connections per workload within the db-f1-micro max_connections=25 limit, leaving headroom for Atlas Operator and operational access.

Companion PR: liverty-music/backend#175

## 📋 Commit Log

- 7edb7bd fix(k8s): add connection pool limits to dev overlay ConfigMaps

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] kubectl kustomize renders correctly with new env vars.
- [x] My code follows the architecture and style guidelines of the project.