### PR TITLE
fix: align blockchain secret naming across all layers

### DIFF
--- a/docs/TICKET_SYSTEM_SETUP.md
+++ b/docs/TICKET_SYSTEM_SETUP.md
@@ -22,7 +22,7 @@ The ticket system requires three categories of configuration:
 |---------------------------|------------------------------------------------------------------------------|
 | `blockchain-deployer-private-key` | Private key of the EOA that deploys and mints TicketSBT NFTs on Base Sepolia |
 | `blockchain-rpc-url`    | JSON-RPC endpoint for the Base Sepolia testnet                               |
-| `bundler-api-key`         | ERC-4337 bundler API key (Pimlico or Alchemy Account Kit)                   |
+| `blockchain-bundler-api-key` | ERC-4337 bundler API key (Pimlico or Alchemy Account Kit)                |
 
 ### B. ZKP Circuit Artifacts (Entry Verification)
 
@@ -113,7 +113,7 @@ A balance of `0.05 ETH` or more is sufficient for development.
 
 You need two values from Alchemy:
 1. A **Base Sepolia RPC URL** (`blockchain-rpc-url`)
-2. A **Bundler API key** for ERC-4337 (`bundler-api-key`)
+2. A **Bundler API key** for ERC-4337 (`blockchain-bundler-api-key`)
 
 ### 3-a. Create an Alchemy account
 
@@ -145,28 +145,25 @@ Sign up at <https://dashboard.alchemy.com/> (free tier available).
    ```
    https://api.pimlico.io/v2/base-sepolia/rpc?apikey=<YOUR_API_KEY>
    ```
-   Use `<YOUR_API_KEY>` as the `bundler-api-key` secret value.
+   Use `<YOUR_API_KEY>` as the `blockchain-bundler-api-key` secret value.
 
 ---
 
 ## Step 4 — Register Secrets in Pulumi ESC
 
-Run from the `cloud-provisioning` directory with the correct stack selected:
+Use `esc env set` to store secrets in the correct ESC environment (not `pulumi config set`):
 
 ```bash
-# Select your target stack (e.g., dev)
-pulumi stack select dev
-
-# Set secrets (values are encrypted at rest by Pulumi)
-pulumi config set --path gcp.ticketSbtDeployerKey --secret <PRIVATE_KEY_HEX>
-pulumi config set --path gcp.baseSepoliaRpcUrl    --secret <RPC_URL>
-pulumi config set --path gcp.bundlerApiKey        --secret <API_KEY>
+# Set secrets (values are encrypted at rest by Pulumi ESC)
+esc env set liverty-music/dev pulumiConfig.blockchain.deployerPrivateKey "<PRIVATE_KEY_HEX>" --secret
+esc env set liverty-music/dev pulumiConfig.blockchain.rpcUrl             "<RPC_URL>"         --secret
+esc env set liverty-music/dev pulumiConfig.blockchain.bundlerApiKey      "<API_KEY>"         --secret
 ```
 
-Verify (values will appear as `[secret]`):
+Verify (secret values will appear as `[secret]`):
 
 ```bash
-pulumi config
+esc env get liverty-music/dev --value pulumiConfig.blockchain
 ```
 
 ---

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -14,15 +14,15 @@ spec:
   - secretKey: LASTFM_API_KEY
     remoteRef:
       key: lastfm-api-key
-  - secretKey: TICKET_SBT_DEPLOYER_KEY
+  - secretKey: BLOCKCHAIN_DEPLOYER_PRIVATE_KEY
     remoteRef:
-      key: ticket-sbt-deployer-key
-  - secretKey: BASE_SEPOLIA_RPC_URL
+      key: blockchain-deployer-private-key
+  - secretKey: BLOCKCHAIN_RPC_URL
     remoteRef:
-      key: base-sepolia-rpc-url
-  - secretKey: BUNDLER_API_KEY
+      key: blockchain-rpc-url
+  - secretKey: BLOCKCHAIN_BUNDLER_API_KEY
     remoteRef:
-      key: bundler-api-key
+      key: blockchain-bundler-api-key
   - secretKey: VAPID_PRIVATE_KEY
     remoteRef:
       key: vapid-private-key

--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -2,18 +2,22 @@ import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import { ApiService } from '../services/api.js'
 
+/** Blockchain (EVM) configuration for smart contract interactions. */
+export interface BlockchainConfig {
+	/** Hex-encoded private key of the deployer EOA (holds MINTER_ROLE on TicketSBT). */
+	deployerPrivateKey?: string
+	/** JSON-RPC endpoint URL for the target EVM chain. */
+	rpcUrl?: string
+	/** ERC-4337 Bundler (Pimlico/Alchemy) API key. */
+	bundlerApiKey?: string
+}
+
 export interface GcpConfig {
 	organizationId: string
 	billingAccount: string
 	geminiApiKey?: string
 	lastFmApiKey?: string
 	cloudSqlUsers?: string[]
-	/** Private key for the TicketSBT contract deployer EOA on Base Sepolia. */
-	ticketSbtDeployerKey?: string
-	/** Base Sepolia JSON-RPC endpoint URL. */
-	baseSepoliaRpcUrl?: string
-	/** ERC-4337 Bundler (Pimlico/Alchemy) API key. */
-	bundlerApiKey?: string
 	/** Password for the Cloud SQL built-in postgres admin user. */
 	postgresAdminPassword?: string
 	/** VAPID private key for Web Push notification signing (ECDSA P-256). */

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -6,7 +6,11 @@ import { MonitoringComponent } from './components/monitoring.js'
 // import { ConcertDataStore } from './components/concert-data-store.js'
 import { NetworkComponent } from './components/network.js'
 import { PostgresComponent } from './components/postgres.js'
-import { type GcpConfig, ProjectComponent } from './components/project.js'
+import {
+	type BlockchainConfig,
+	type GcpConfig,
+	ProjectComponent,
+} from './components/project.js'
 import { WorkloadIdentityComponent } from './components/workload-identity.js'
 import { RegionNames, Regions } from './region.js'
 
@@ -15,6 +19,7 @@ export interface GcpArgs {
 	displayName: string
 	environment: 'dev' | 'staging' | 'prod'
 	gcpConfig: GcpConfig
+	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
 }
 
@@ -53,6 +58,7 @@ export class Gcp {
 			displayName,
 			environment,
 			gcpConfig,
+			blockchainConfig,
 			cloudflareConfig,
 		} = args
 
@@ -136,31 +142,31 @@ export class Gcp {
 							},
 						]
 					: []),
-				...(gcpConfig.ticketSbtDeployerKey
+				...(blockchainConfig?.deployerPrivateKey
 					? [
 							{
 								name: 'blockchain-deployer-private-key',
 								value: pulumi.secret(
-									gcpConfig.ticketSbtDeployerKey,
+									blockchainConfig.deployerPrivateKey,
 								),
 							},
 						]
 					: []),
-				...(gcpConfig.baseSepoliaRpcUrl
+				...(blockchainConfig?.rpcUrl
 					? [
 							{
 								name: 'blockchain-rpc-url',
-								value: pulumi.secret(
-									gcpConfig.baseSepoliaRpcUrl,
-								),
+								value: pulumi.secret(blockchainConfig.rpcUrl),
 							},
 						]
 					: []),
-				...(gcpConfig.bundlerApiKey
+				...(blockchainConfig?.bundlerApiKey
 					? [
 							{
-								name: 'bundler-api-key',
-								value: pulumi.secret(gcpConfig.bundlerApiKey),
+								name: 'blockchain-bundler-api-key',
+								value: pulumi.secret(
+									blockchainConfig.bundlerApiKey,
+								),
 							},
 						]
 					: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from './cloudflare/config.js'
 import type { Environment } from './config.js'
-import type { GcpConfig } from './gcp/components/project.js'
+import type { BlockchainConfig, GcpConfig } from './gcp/components/project.js'
 import { Gcp } from './gcp/index.js'
 import {
 	type BufConfig,
@@ -18,6 +18,9 @@ const displayName = 'Liverty Music'
 const config = new pulumi.Config('liverty-music')
 const githubConfig = config.requireObject('github') as GitHubConfig
 const gcpConfig = config.requireObject('gcp') as GcpConfig
+const blockchainConfig = config.getObject('blockchain') as
+	| BlockchainConfig
+	| undefined
 const bufConfig = config.requireObject('buf') as BufConfig
 const zitadelConfig = config.requireObject('zitadel') as ZitadelConfig
 const cloudflareConfig = config.getObject('cloudflare') as CloudflareConfig
@@ -52,6 +55,7 @@ const gcp = new Gcp({
 	displayName,
 	environment: env,
 	gcpConfig,
+	blockchainConfig,
 	cloudflareConfig,
 })
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #140

## 📝 Summary of Changes

Unify all blockchain-related secret naming under `BLOCKCHAIN_*` / `blockchain-*` convention to resolve the ExternalSecret `SecretSyncedError` causing ArgoCD `backend` Application Degraded status since 2026-02-21.

### Pulumi TypeScript
- Extract `BlockchainConfig` interface from `GcpConfig` in `project.ts`
- Read config from new `blockchain` ESC namespace in `index.ts`
- Rename Secret Manager resources: `blockchain-deployer-private-key`, `blockchain-rpc-url`, `blockchain-bundler-api-key`

### Kubernetes ExternalSecret
- Update `secretKey` and `remoteRef.key` to `BLOCKCHAIN_*` / `blockchain-*` naming

### Documentation
- Update `TICKET_SYSTEM_SETUP.md` to use `esc env set` with `blockchain.*` namespace

### ESC + Secret Manager (already deployed)
- Migrated ESC secrets from `smartContract.*` to `blockchain.*` namespace
- `pulumi up` completed: 3 new Secret Manager secrets + IAM bindings created

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
`pulumi up` already applied: +12 create, ~1 update, 0 delete.

## 📦 State Changes
No state operations needed. Old Secret Manager resources (if any) can be cleaned up later.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.