### PR TITLE
fix(k8s): add consumer and concert-discovery to ImageUpdater CRD

### DIFF
--- a/k8s/argocd-apps/dev/backend.yaml
+++ b/k8s/argocd-apps/dev/backend.yaml
@@ -3,18 +3,6 @@ kind: Application
 metadata:
   name: backend
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: server=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server, consumer=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer, concert-discovery=asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
-    argocd-image-updater.argoproj.io/server.update-strategy: digest
-    argocd-image-updater.argoproj.io/server.allow-tags: regexp:^main$
-    argocd-image-updater.argoproj.io/server.kustomize.image-name: server
-    argocd-image-updater.argoproj.io/consumer.update-strategy: digest
-    argocd-image-updater.argoproj.io/consumer.allow-tags: regexp:^main$
-    argocd-image-updater.argoproj.io/consumer.kustomize.image-name: consumer
-    argocd-image-updater.argoproj.io/concert-discovery.update-strategy: digest
-    argocd-image-updater.argoproj.io/concert-discovery.allow-tags: regexp:^main$
-    argocd-image-updater.argoproj.io/concert-discovery.kustomize.image-name: concert-discovery
-    argocd-image-updater.argoproj.io/write-back-method: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -14,6 +14,18 @@ spec:
       commonUpdateSettings:
         updateStrategy: digest
         pullSecret: ext:/scripts/auth.sh
+    - alias: consumer
+      imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer:main
+      commonUpdateSettings:
+        updateStrategy: digest
+        forceUpdate: true
+        pullSecret: ext:/scripts/auth.sh
+    - alias: concert-discovery
+      imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery:main
+      commonUpdateSettings:
+        updateStrategy: digest
+        forceUpdate: true
+        pullSecret: ext:/scripts/auth.sh
   - namePattern: frontend
     images:
     - alias: web-app


### PR DESCRIPTION
## Summary

Add `consumer` and `concert-discovery` images to the `ImageUpdater` CRD (`dev-apps`) with `forceUpdate: true`, and remove redundant annotation-based config from `backend.yaml`.

## Why

The CRD only defined `server` and `web-app`. Since the CRD takes precedence over annotations (`useAnnotations: false`), consumer and concert-discovery images were never updated by Image Updater. Combined with `replicas=0` (consumer scales up only on demand), this caused the consumer to run stale images after backend merges.

## Changes

- **image-updater.yaml**: Add `consumer` and `concert-discovery` with `forceUpdate: true` and `digest` strategy
- **backend.yaml**: Remove redundant annotation-based image-updater config (CRD is source of truth)

close: #144
