### PR TITLE
fix(iam): grant serviceUsageConsumer to backend-app SA

### DIFF
--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -141,6 +141,7 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 				Roles.CloudTrace.Agent,
 				Roles.CloudSql.InstanceUser,
 				Roles.AiPlatform.User,
+				Roles.ServiceUsage.ServiceUsageConsumer,
 			],
 			backendApp,
 			backendAppSa.email,

--- a/src/gcp/services/iam.ts
+++ b/src/gcp/services/iam.ts
@@ -32,6 +32,9 @@ export const Roles = {
 	AiPlatform: {
 		User: 'roles/aiplatform.user',
 	},
+	ServiceUsage: {
+		ServiceUsageConsumer: 'roles/serviceusage.serviceUsageConsumer',
+	},
 	ArtifactRegistry: {
 		Reader: 'roles/artifactregistry.reader',
 		Writer: 'roles/artifactregistry.writer',


### PR DESCRIPTION
## Summary

- Add `roles/serviceusage.serviceUsageConsumer` to backend-app SA project-level IAM bindings
- Add `ServiceUsage.ServiceUsageConsumer` constant to `Roles` in `iam.ts`

## Why

OAuth-authenticated calls to Places API (New) with `X-Goog-User-Project` require `serviceusage.services.use` permission. The backend-app SA lacked this, causing all venue enrichment calls to return `403 permission_denied`.

This was not needed with API key auth (previous implementation) because the key carries project context directly.

## Test plan

- [x] `make check` passes (biome + tsc)
- [x] `pulumi preview` shows exactly 1 new IAM binding
- [ ] After `pulumi up`: verify consumer logs show successful Places API responses

close: #146