### PR TITLE
fix(k8s): resolve KEDA and ArgoCD replicas conflict on consumer-app

### DIFF
--- a/k8s/argocd-apps/dev/backend.yaml
+++ b/k8s/argocd-apps/dev/backend.yaml
@@ -7,6 +7,12 @@ metadata:
   - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    name: consumer-app
+    jsonPointers:
+    - /spec/replicas
   source:
     repoURL: https://github.com/liverty-music/cloud-provisioning.git
     targetRevision: main

--- a/k8s/namespaces/backend/base/consumer/deployment.yaml
+++ b/k8s/namespaces/backend/base/consumer/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
   template:
     spec:
       terminationGracePeriodSeconds: 90


### PR DESCRIPTION
## Summary
- Remove hardcoded `replicas: 1` from consumer-app Deployment, letting KEDA manage replica count
- Add `ignoreDifferences` for `spec.replicas` on the backend ArgoCD Application as defense-in-depth

## Problem
KEDA ScaledObject (`minReplicaCount: 0`) and ArgoCD (`selfHeal: true`) fight over consumer-app replicas, causing an infinite OutOfSync loop (generation 8871+, 38+ selfHeal attempts).

## Test plan
- [ ] Kustomize renders backend overlay without errors
- [ ] ArgoCD syncs to Synced/Healthy after merge
- [ ] OutOfSync loop stops (generation count stabilizes)

Closes #148
