### PR TITLE
feat(infra): add fanart.tv API key and artist-image-sync CronJob

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/artist-image-sync/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/artist-image-sync/configmap.env
@@ -1,0 +1,18 @@
+# Environment
+ENVIRONMENT=TO_REPLACE_BY_OVERLAY
+# Logging
+LOGGING_LEVEL=debug
+LOGGING_FORMAT=json
+# Telemetry
+TELEMETRY_SERVICE_NAME=liverty-music-artist-image-sync
+# Database (Defaults)
+DATABASE_NAME=liverty-music
+DATABASE_HOST=postgres.osaka.psc.internal
+DATABASE_PORT=5432
+DATABASE_USER=TO_REPLACE_BY_OVERLAY
+# Must be 'disable' because the Cloud SQL Connector handles internal encryption.
+DATABASE_SSL_MODE=disable
+DATABASE_SCHEMA=app
+
+# Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
+SHUTDOWN_TIMEOUT=90s

--- a/k8s/namespaces/backend/base/cronjob/artist-image-sync/cronjob.yaml
+++ b/k8s/namespaces/backend/base/cronjob/artist-image-sync/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: app
+spec:
+  schedule: "0 10 * * *" # 19:00 JST daily (1h after concert-discovery)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          terminationGracePeriodSeconds: 120
+          serviceAccountName: backend-app
+          restartPolicy: Never
+          containers:
+          - name: artist-image-sync
+            image: artist-image-sync
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: job-config
+            - secretRef:
+                name: backend-secrets
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 250m
+                memory: 256Mi

--- a/k8s/namespaces/backend/base/cronjob/artist-image-sync/kustomization.yaml
+++ b/k8s/namespaces/backend/base/cronjob/artist-image-sync/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cronjob.yaml
+
+namePrefix: artist-image-sync-
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: artist-image-sync
+
+images:
+- name: artist-image-sync
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
+  newTag: latest
+
+configMapGenerator:
+- name: job-config
+  envs:
+  - configmap.env

--- a/k8s/namespaces/backend/base/kustomization.yaml
+++ b/k8s/namespaces/backend/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - serviceaccount.yaml
 - server
 - cronjob/concert-discovery
+- cronjob/artist-image-sync
 - consumer
 
 namespace: backend

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -26,3 +26,6 @@ spec:
   - secretKey: VAPID_PRIVATE_KEY
     remoteRef:
       key: vapid-private-key
+  - secretKey: FANARTTV_API_KEY
+    remoteRef:
+      key: fanarttv-api-key

--- a/k8s/namespaces/backend/overlays/dev/cronjob/artist-image-sync/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/artist-image-sync/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=development
+# GCP
+GCP_PROJECT_ID=liverty-music-dev
+# Database
+DATABASE_USER=backend-app@liverty-music-dev.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -110,10 +110,14 @@ configMapGenerator:
   behavior: merge
   envs:
   - server/configmap.env
-- name: job-config
+- name: concert-discovery-job-config
   behavior: merge
   envs:
   - cronjob/concert-discovery/configmap.env
+- name: artist-image-sync-job-config
+  behavior: merge
+  envs:
+  - cronjob/artist-image-sync/configmap.env
 - name: consumer-config
   behavior: merge
   envs:

--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -16,7 +16,6 @@ export interface GcpConfig {
 	organizationId: string
 	billingAccount: string
 	geminiApiKey?: string
-	lastFmApiKey?: string
 	cloudSqlUsers?: string[]
 	/** Password for the Cloud SQL built-in postgres admin user. */
 	postgresAdminPassword?: string

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -22,6 +22,8 @@ export interface GcpArgs {
 	displayName: string
 	environment: 'dev' | 'staging' | 'prod'
 	gcpConfig: GcpConfig
+	lastFmApiKey?: pulumi.Output<string>
+	fanartTvApiKey?: pulumi.Output<string>
 	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
 	postmarkConfig?: PostmarkDnsConfig
@@ -63,6 +65,8 @@ export class Gcp {
 			displayName,
 			environment,
 			gcpConfig,
+			lastFmApiKey,
+			fanartTvApiKey,
 			blockchainConfig,
 			cloudflareConfig,
 			postmarkConfig,
@@ -142,11 +146,11 @@ export class Gcp {
 				frontendArtifactRegistry,
 			],
 			secrets: [
-				...(gcpConfig.lastFmApiKey
+				...(lastFmApiKey
 					? [
 							{
 								name: 'lastfm-api-key',
-								value: pulumi.secret(gcpConfig.lastFmApiKey),
+								value: lastFmApiKey,
 							},
 						]
 					: []),
@@ -193,6 +197,14 @@ export class Gcp {
 							{
 								name: 'vapid-private-key',
 								value: pulumi.secret(gcpConfig.vapidPrivateKey),
+							},
+						]
+					: []),
+				...(fanartTvApiKey
+					? [
+							{
+								name: 'fanarttv-api-key',
+								value: fanartTvApiKey,
 							},
 						]
 					: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ const displayName = 'Liverty Music'
 const config = new pulumi.Config('liverty-music')
 const githubConfig = config.requireObject('github') as GitHubConfig
 const gcpConfig = config.requireObject('gcp') as GcpConfig
+const lastFmApiKey = config.getSecret('lastFmApiKey')
+const fanartTvApiKey = config.getSecret('fanartTvApiKey')
 const blockchainConfig = config.getObject('blockchain') as
 	| BlockchainConfig
 	| undefined
@@ -58,6 +60,8 @@ const gcp = new Gcp({
 	displayName,
 	environment: env,
 	gcpConfig,
+	lastFmApiKey,
+	fanartTvApiKey,
 	blockchainConfig,
 	cloudflareConfig,
 	postmarkConfig,


### PR DESCRIPTION
## Related Issue
Refs: liverty-music/specification#255

## Summary of Changes
- Move `lastFmApiKey` and `fanartTvApiKey` to top-level Pulumi config keys using `config.getSecret()` (out of nested `GcpConfig`), so they are handled as `pulumi.Output<string>` natively
- Remove `lastFmApiKey` field from `GcpConfig` interface
- Add `FANARTTV_API_KEY` entry to backend ExternalSecret for Secret Manager integration
- Add `artist-image-sync` CronJob K8s manifests (base + dev overlay) with spot VM nodeSelector and resource limits

## Affected Stacks
- [x] Dev
- [ ] Prod

## Pulumi Preview
Please check the CI/GitHub Actions output for the Preview result.

## State Changes
No state migrations needed. This is additive only.

## Test plan
- [ ] `make check` passes (lint-ts verified locally)
- [ ] `pulumi preview` in CI shows new Secret Manager secret for `fanarttv-api-key`
- [ ] `kubectl kustomize` renders the new CronJob and ExternalSecret entry correctly
- [ ] Verify dev overlay applies spot nodeSelector and resource limits to artist-image-sync CronJob

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
