### PR TITLE
fix(monitoring): use correct label key for Google Chat notification channel

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -79,7 +79,7 @@ export class MonitoringComponent extends pulumi.ComponentResource {
 						type: 'google_chat',
 						displayName: 'Google Chat Alert Backend',
 						labels: {
-							space_id: spaceId,
+							space: spaceId,
 						},
 					},
 					{ parent: this },


### PR DESCRIPTION
## 🔗 Related Issue
Closes #157

## 📝 Summary of Changes

Fix incorrect label key in Google Chat `NotificationChannel` resource.

- Change `space_id` to `space` in the `google_chat` type NotificationChannel labels
- GCP API requires `space` as the label key — `space_id` caused `pulumi up` to fail with error 400

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

Previous deployments (v216, v217) failed with:
```
Error creating NotificationChannel: googleapi: Error 400:
Field "notification_channel.labels['space_id']" is not allowed;
permissible label keys for "google_chat" are: {"space"}.
```

This fix should resolve both stacks.

## 📦 State Changes
None. The resource failed to create, so no state cleanup needed.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
