### PR TITLE
fix(monitoring): fix Google Chat NotificationChannel label config

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -79,7 +79,7 @@ export class MonitoringComponent extends pulumi.ComponentResource {
 						type: 'google_chat',
 						displayName: 'Google Chat Alert Backend',
 						labels: {
-							space: spaceId,
+							space: `spaces/${spaceId}`,
 						},
 					},
 					{ parent: this },


### PR DESCRIPTION
## 🔗 Related Issue
Closes #157

## 📝 Summary of Changes

Fix Google Chat `NotificationChannel` label configuration:

- Change label key from `space_id` to `space` (v216/v217 fix)
- Prefix space ID with `spaces/` to match GCP regex `spaces/[^/]+` (v218 fix)

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

Previous deployments failed with:
- v216/v217: `labels['space_id'] is not allowed` → fixed by renaming to `space`
- v218: `Value does not match "spaces/[^/]+"` → fixed by prefixing `spaces/`

## 📦 State Changes
None. The resource failed to create, so no state cleanup needed.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
