### PR TITLE
fix(network): make postmark DNS config required

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -19,7 +19,7 @@ export interface NetworkComponentArgs {
 		apiToken: pulumi.Input<string>
 		zoneId: pulumi.Input<string>
 	}
-	postmarkConfig?: PostmarkDnsConfig
+	postmarkConfig: PostmarkDnsConfig
 }
 
 export class NetworkComponent extends pulumi.ComponentResource {
@@ -80,7 +80,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 		)
 
 		// 3. Postmark Email DNS Records (prod: Cloudflare DNS)
-		if (environment === 'prod' && postmarkConfig) {
+		if (environment === 'prod') {
 			const cfProvider = new cloudflare.Provider(
 				'postmark-cloudflare-provider',
 				{ apiToken: cloudflareConfig.apiToken },
@@ -368,35 +368,33 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			)
 
 			// Postmark Email DNS Records (dev/staging: GCP Cloud DNS)
-			if (postmarkConfig) {
-				const mailSubdomain = `mail.${environment}`
+			const mailSubdomain = `mail.${environment}`
 
-				// Postmark DKIM settings (https://account.postmarkapp.com/signature_domains/4169912)
-				new gcp.dns.RecordSet(
-					'postmark-dkim',
-					{
-						name: `${postmarkConfig.dkimSelector}._domainkey.${mailSubdomain}.${tld}.`,
-						managedZone: publicZone.name,
-						type: 'TXT',
-						ttl: 300,
-						rrdatas: [`"k=rsa;p=${postmarkConfig.dkimPublicKey}"`],
-					},
-					{ parent: this, dependsOn: enabledApis },
-				)
+			// Postmark DKIM settings (https://account.postmarkapp.com/signature_domains/4169912)
+			new gcp.dns.RecordSet(
+				'postmark-dkim',
+				{
+					name: `${postmarkConfig.dkimSelector}._domainkey.${mailSubdomain}.${tld}.`,
+					managedZone: publicZone.name,
+					type: 'TXT',
+					ttl: 300,
+					rrdatas: [`"k=rsa;p=${postmarkConfig.dkimPublicKey}"`],
+				},
+				{ parent: this, dependsOn: enabledApis },
+			)
 
-				// Postmark Return-Path settings (https://account.postmarkapp.com/signature_domains/4169912)
-				new gcp.dns.RecordSet(
-					'postmark-return-path',
-					{
-						name: `pm-bounces.${mailSubdomain}.${tld}.`,
-						managedZone: publicZone.name,
-						type: 'CNAME',
-						ttl: 300,
-						rrdatas: ['pm.mtasv.net.'],
-					},
-					{ parent: this, dependsOn: enabledApis },
-				)
-			}
+			// Postmark Return-Path settings (https://account.postmarkapp.com/signature_domains/4169912)
+			new gcp.dns.RecordSet(
+				'postmark-return-path',
+				{
+					name: `pm-bounces.${mailSubdomain}.${tld}.`,
+					managedZone: publicZone.name,
+					type: 'CNAME',
+					ttl: 300,
+					rrdatas: ['pm.mtasv.net.'],
+				},
+				{ parent: this, dependsOn: enabledApis },
+			)
 
 			this.registerOutputs({
 				publicZoneNameservers: publicZone.nameServers,

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -26,7 +26,7 @@ export interface GcpArgs {
 	fanartTvApiKey?: pulumi.Output<string>
 	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
-	postmarkConfig?: PostmarkDnsConfig
+	postmarkConfig: PostmarkDnsConfig
 }
 
 export const NetworkConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,9 @@ const blockchainConfig = config.getObject('blockchain') as
 const bufConfig = config.requireObject('buf') as BufConfig
 const zitadelConfig = config.requireObject('zitadel') as ZitadelConfig
 const cloudflareConfig = config.getObject('cloudflare') as CloudflareConfig
-const postmarkConfig = config.getObject('postmark') as
-	| import('./gcp/components/network.js').PostmarkDnsConfig
-	| undefined
+const postmarkConfig = config.requireObject(
+	'postmark',
+) as import('./gcp/components/network.js').PostmarkDnsConfig
 
 const env = pulumi.getStack() as Environment
 


### PR DESCRIPTION
## Related Issue
N/A

## Summary of Changes
Make Postmark DNS configuration (`dkimSelector`, `dkimPublicKey`) required instead of optional.

- `postmarkConfig` changed from optional to required in `NetworkComponentArgs` and `GcpArgs` interfaces
- `config.getObject('postmark')` changed to `config.requireObject('postmark')` — Pulumi will now fail fast if config is missing
- Removed conditional guards (`if (postmarkConfig)`) around DNS record creation for both prod (Cloudflare) and dev/staging (GCP Cloud DNS)

## Affected Stacks
- [x] Dev
- [x] Prod

## Pulumi Preview
Please check the CI/GitHub Actions output for the Preview result.

## State Changes
No state changes required. DNS records already exist in state.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
