### PR TITLE
fix(k8s): resolve argocd CRD overflow and nats sync loop

### DIFF
--- a/k8s/argocd-apps/dev/argocd.yaml
+++ b/k8s/argocd-apps/dev/argocd.yaml
@@ -20,3 +20,4 @@ spec:
       selfHeal: true
     syncOptions:
     - CreateNamespace=true
+    - ServerSideApply=true

--- a/k8s/argocd-apps/dev/nats.yaml
+++ b/k8s/argocd-apps/dev/nats.yaml
@@ -18,11 +18,13 @@ spec:
     server: https://kubernetes.default.svc
     namespace: nats
   ignoreDifferences:
-  # GKE Autopilot injects ephemeral-storage requests/limits into all containers
+  # GKE Autopilot injects ephemeral-storage, securityContext, and other defaults
   - group: apps
     kind: StatefulSet
     jqPathExpressions:
     - .spec.template.spec.containers[].resources
+    - .spec.template.spec.containers[].securityContext
+    - .spec.template.spec.securityContext
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Related Issue
Closes #163

## Summary of Changes

Fix remaining ArgoCD sync issues for `argocd` and `nats` applications in dev:

- **argocd**: Add `ServerSideApply=true` syncOption to fix CRD patch failure caused by `last-applied-configuration` annotation exceeding the 262144 byte limit on `applicationsets.argoproj.io`
- **nats**: Extend `ignoreDifferences` jqPathExpressions to cover GKE Autopilot `securityContext` mutations (container-level `capabilities.drop` and pod-level `seccompProfile`) that caused a persistent OutOfSync → auto-sync loop

## Affected Stacks
- [x] Dev
- [ ] Prod

## Pulumi Preview
No Pulumi changes — K8s manifests only.

## State Changes
None.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
