### PR TITLE
fix(k8s): add GKE Autopilot defaults to nats manifests

### DIFF
--- a/k8s/argocd-apps/dev/nats.yaml
+++ b/k8s/argocd-apps/dev/nats.yaml
@@ -17,18 +17,9 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: nats
-  ignoreDifferences:
-  # GKE Autopilot injects ephemeral-storage, securityContext, and other defaults
-  - group: apps
-    kind: StatefulSet
-    jqPathExpressions:
-    - .spec.template.spec.containers[].resources
-    - .spec.template.spec.containers[].securityContext
-    - .spec.template.spec.securityContext
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
     - ServerSideApply=true
-    - RespectIgnoreDifferences=true

--- a/k8s/namespaces/nats/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/nats/overlays/dev/kustomization.yaml
@@ -25,3 +25,7 @@ patches:
         spec:
           nodeSelector:
             cloud.google.com/compute-class: autopilot-spot
+          # GKE Autopilot injects seccompProfile on all pods
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault

--- a/k8s/namespaces/nats/overlays/dev/values.yaml
+++ b/k8s/namespaces/nats/overlays/dev/values.yaml
@@ -18,9 +18,16 @@ container:
       requests:
         cpu: 50m
         memory: 64Mi
+        ephemeral-storage: 1Gi
       limits:
         cpu: 200m
         memory: 256Mi
+        ephemeral-storage: 1Gi
+    # GKE Autopilot injects these security defaults
+    securityContext:
+      capabilities:
+        drop:
+        - NET_RAW
 
 reloader:
   merge:
@@ -28,9 +35,16 @@ reloader:
       requests:
         cpu: 10m
         memory: 16Mi
+        ephemeral-storage: 1Gi
       limits:
         cpu: 50m
         memory: 64Mi
+        ephemeral-storage: 1Gi
+    # GKE Autopilot injects these security defaults
+    securityContext:
+      capabilities:
+        drop:
+        - NET_RAW
 
 natsBox:
   enabled: false


### PR DESCRIPTION
## Related Issue
Closes #163

## Summary of Changes

Fix nats persistent OutOfSync by explicitly declaring GKE Autopilot-injected defaults in the Helm values and kustomize patch:

- **ephemeral-storage**: Add `1Gi` requests/limits to both `nats` and `reloader` containers
- **securityContext**: Add `capabilities.drop: [NET_RAW]` to both containers
- **seccompProfile**: Add `RuntimeDefault` at pod level

This replaces the previous `ignoreDifferences` + `RespectIgnoreDifferences` approach which failed because GKE Autopilot's mutating webhook mutations are attributed to the `argocd-controller` SSA field manager, causing ArgoCD's server-side diff to always detect changes.

## Affected Stacks
- [x] Dev
- [ ] Prod

## Pulumi Preview
No Pulumi changes — K8s manifests only.

## State Changes
None.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
