### PR TITLE
fix(k8s): enable ServerSideDiff for accurate ArgoCD sync status

### DIFF
--- a/k8s/namespaces/argocd/base/values.yaml
+++ b/k8s/namespaces/argocd/base/values.yaml
@@ -7,6 +7,11 @@ configs:
     # Enable Helm template rendering inside kustomize overlays that use helmCharts:.
     # Required for external-secrets and reloader overlays.
     kustomize.buildOptions: "--enable-helm"
+  params:
+    # Use server-side diff for accurate sync status on GKE Autopilot.
+    # Without this, ArgoCD uses legacy 3-way diff which reports false
+    # OutOfSync for K8s server-side defaults (protocol, imagePullPolicy, etc.).
+    controller.diff.server.side: "true"
 
 server:
   service:


### PR DESCRIPTION
## Related Issue
Refs #163

## Summary of Changes

Enable `ServerSideDiff` globally for ArgoCD by setting `controller.diff.server.side: "true"` in the Helm values.

### Root Cause

`ServerSideApply=true` (syncOption) only controls **how resources are applied** — it does not change **how diffs are calculated**. Without `ServerSideDiff`, ArgoCD uses the legacy 3-way diff strategy, which reports false OutOfSync for standard Kubernetes server-side defaults (`protocol: TCP`, `imagePullPolicy: IfNotPresent`, `scheme: HTTP`, `terminationMessagePath`, `volumeMode: Filesystem`, etc.).

This was the root cause of the persistent OutOfSync on both `argocd` and `nats` applications. The `argocd app diff` CLI showed no differences (it uses a different diff path), but the controller's legacy diff always detected server-side defaults as changes.

### References
- [ArgoCD Diff Strategies docs](https://argo-cd.readthedocs.io/en/stable/user-guide/diff-strategies/)
- [#26588](https://github.com/argoproj/argo-cd/issues/26588) — RespectIgnoreDifferences + SSA bug in v3.3.x

## Affected Stacks
- [x] Dev
- [ ] Prod

## Pulumi Preview
No Pulumi changes — K8s manifests only.

## State Changes
None.

## Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
