### PR TITLE
revert(nats): remove ephemeral-storage coupling to GKE Autopilot defaults

### DIFF
--- a/k8s/namespaces/nats/overlays/dev/values.yaml
+++ b/k8s/namespaces/nats/overlays/dev/values.yaml
@@ -18,11 +18,9 @@ container:
       requests:
         cpu: 50m
         memory: 64Mi
-        ephemeral-storage: 1Gi
       limits:
         cpu: 200m
         memory: 256Mi
-        ephemeral-storage: 1Gi
     # GKE Autopilot injects these security defaults
     securityContext:
       capabilities:
@@ -35,11 +33,9 @@ reloader:
       requests:
         cpu: 10m
         memory: 16Mi
-        ephemeral-storage: 1Gi
       limits:
         cpu: 50m
         memory: 64Mi
-        ephemeral-storage: 1Gi
     # GKE Autopilot injects these security defaults
     securityContext:
       capabilities:


### PR DESCRIPTION
## 🔗 Related Issue
Closes #163

## 📝 Summary of Changes
Remove `ephemeral-storage: 1Gi` from nats Helm values (container and reloader sections).

These values were added in PR #167 to mirror GKE Autopilot's injected defaults and suppress false ArgoCD OutOfSync. With `ServerSideDiff` enabled (PR #168), ArgoCD now correctly compares desired vs live state server-side, making this coupling unnecessary.

Keeping these values is fragile — if GKE Autopilot changes its defaults, our manifests would diverge from live state and cause real OutOfSync.

Security settings (`securityContext.capabilities.drop: [NET_RAW]`) are retained as they are best practices independent of the diff mechanism.

## 🌍 Affected Stacks
- [x] Dev
- [ ] Prod

## 🔮 Pulumi Preview
No Pulumi changes — K8s manifests only (ArgoCD managed).

## 📦 State Changes
None.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.