### PR TITLE
feat(zitadel): auto-verify email on self-registration

### DIFF
--- a/src/zitadel/components/token-action.ts
+++ b/src/zitadel/components/token-action.ts
@@ -23,8 +23,14 @@ export class ActionsComponent extends pulumi.ComponentResource {
 	/** Injects the `email` claim into every JWT access token before issuance. */
 	public readonly addEmailClaimAction: zitadel.Action
 
+	/** Auto-verifies user email during Self-Registration to skip the OTP step. */
+	public readonly autoVerifyEmailAction: zitadel.Action
+
 	/** Wires pre-access-token-creation actions to the customise-token flow. */
 	public readonly preAccessTokenTrigger: zitadel.TriggerActions
+
+	/** Wires pre-creation actions to the internal-authentication flow. */
+	public readonly preCreationTrigger: zitadel.TriggerActions
 
 	constructor(
 		name: string,
@@ -65,6 +71,42 @@ export class ActionsComponent extends pulumi.ComponentResource {
 			resourceOptions,
 		)
 
+		// Auto-verify email during Self-Registration.
+		// When SMTP is configured, Zitadel's Hosted Login blocks the OIDC
+		// flow with an email OTP step. By calling setEmailVerified(true) in
+		// PRE_CREATION, the user is created with email already verified and
+		// the OTP step is skipped entirely.
+		const autoVerifyEmailScript = readFileSync(
+			resolve(__dirname, '../scripts/auto-verify-email.js'),
+			'utf-8',
+		)
+
+		this.autoVerifyEmailAction = new zitadel.Action(
+			'auto-verify-email',
+			{
+				orgId,
+				name: 'autoVerifyEmail',
+				script: autoVerifyEmailScript,
+				timeout: '10s',
+				allowedToFail,
+			},
+			resourceOptions,
+		)
+
+		// Wire auto-verify to the internal authentication flow's PRE_CREATION
+		// trigger. This fires after the user fills in the registration form
+		// and before Zitadel creates the user record.
+		this.preCreationTrigger = new zitadel.TriggerActions(
+			'internal-auth-pre-creation',
+			{
+				orgId,
+				flowType: 'FLOW_TYPE_INTERNAL_AUTHENTICATION',
+				triggerType: 'TRIGGER_TYPE_PRE_CREATION',
+				actionIds: [this.autoVerifyEmailAction.id],
+			},
+			{ ...resourceOptions, dependsOn: [this.autoVerifyEmailAction] },
+		)
+
 		// TriggerActions wires one or more Actions to a specific point in
 		// Zitadel's OIDC lifecycle (flow + trigger).
 		//
@@ -93,7 +135,9 @@ export class ActionsComponent extends pulumi.ComponentResource {
 
 		this.registerOutputs({
 			addEmailClaimAction: this.addEmailClaimAction,
+			autoVerifyEmailAction: this.autoVerifyEmailAction,
 			preAccessTokenTrigger: this.preAccessTokenTrigger,
+			preCreationTrigger: this.preCreationTrigger,
 		})
 	}
 }

--- a/src/zitadel/scripts/auto-verify-email.js
+++ b/src/zitadel/scripts/auto-verify-email.js
@@ -1,0 +1,29 @@
+// Internal Authentication Flow — auto-verifies the user's email before
+// account creation so that Zitadel skips the OTP verification step during
+// Self-Registration.
+//
+// Triggered at TRIGGER_TYPE_PRE_CREATION within FLOW_TYPE_INTERNAL_AUTHENTICATION.
+//
+// Why this is needed:
+//   When SMTP is configured, Zitadel's Hosted Login blocks the OIDC
+//   authorization flow with an email OTP step during Self-Registration.
+//   On mobile, switching to the mail app to copy a code causes user
+//   abandonment. Since no current feature requires a verified email,
+//   we auto-verify at creation time and skip the OTP step entirely.
+//
+// Trade-off:
+//   `email_verified` will be `true` for all new users from the start.
+//   If a future feature needs proof-of-email, a re-verification flow
+//   can be introduced at that point.
+//
+// References:
+//   Internal Authentication Flow:  https://zitadel.com/docs/apis/actions/internal-authentication
+//   Pre Creation trigger API:      https://zitadel.com/docs/apis/actions/external-authentication
+//
+var logger = require('zitadel/log')
+
+// biome-ignore lint/correctness/noUnusedVariables: called by Zitadel runtime by name, not imported
+function autoVerifyEmail(ctx, api) {
+	api.setEmailVerified(true)
+	logger.log('email auto-verified during self-registration')
+}


### PR DESCRIPTION
## Summary of Changes

Add a Zitadel Action that auto-verifies user email during Self-Registration, eliminating the OTP step that blocks the OIDC flow when SMTP is configured.

- Create `auto-verify-email.js` Action script calling `api.setEmailVerified(true)` on `PRE_CREATION`
- Wire the Action to `FLOW_TYPE_INTERNAL_AUTHENTICATION` / `TRIGGER_TYPE_PRE_CREATION` via `TriggerActions`
- `allowedToFail: true` in dev (fallback to OTP), `false` in staging/prod (block on failure)

## Commit Log

- feat(zitadel): auto-verify email on self-registration

## Self-Checklist

- [x] I have verified with `pulumi preview` that the new resources are created correctly.
- [x] My code follows the architecture and style guidelines of the project.