### PR TITLE
fix(k8s): extend server timeout chain to 60s

### DIFF
--- a/k8s/namespaces/backend/base/server/backend-policy.yaml
+++ b/k8s/namespaces/backend/base/server/backend-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: server-policy
 spec:
   default:
-    timeoutSec: 30
+    timeoutSec: 60
     connectionDraining:
       drainingTimeoutSec: 60
   targetRef:

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -12,8 +12,11 @@ GCP_GEMINI_MODEL=gemini-3-flash-preview
 # Server
 SERVER_PORT=8080
 SERVER_HOST=0.0.0.0
-# Shutdown timeout must fit within: terminationGracePeriodSeconds(60) - preStop(5) - buffer(10) = 45s
-SHUTDOWN_TIMEOUT=45s
+# Handler timeout: maximum duration for any single RPC request.
+# SearchNewConcerts (Gemini API) can take 16-25s per call.
+SERVER_HANDLER_TIMEOUT=60s
+# Shutdown timeout must fit within: terminationGracePeriodSeconds(75) - preStop(5) - buffer(10) = 60s
+SHUTDOWN_TIMEOUT=60s
 # OIDC
 OIDC_ISSUER_URL=TO_REPLACE_BY_OVERLAY
 # Database (Defaults)

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       # Labels handled by commonLabels
     spec:
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 75
       serviceAccountName: backend-app
       volumes:
       - name: zkp-verification-key


### PR DESCRIPTION
## Summary

- Extend GCP Backend Policy `timeoutSec` from 30 to 60 to accommodate synchronous SearchNewConcerts RPC (Gemini API calls take 16-25s)
- Set `SERVER_HANDLER_TIMEOUT=60s` explicitly (was using 30s default)
- Extend `SHUTDOWN_TIMEOUT` from 45s to 60s to drain in-flight 60s requests during pod shutdown
- Increase `terminationGracePeriodSeconds` from 60 to 75 to fit the new shutdown budget (60s + 5s preStop + 10s buffer)

## Test plan

- [x] Kustomize dry-run renders all values correctly
- [ ] ArgoCD syncs successfully after merge
- [ ] Backend pod restarts with new config
- [ ] SearchNewConcerts completes without 504 on dev environment
