### PR TITLE
fix(k8s): increase gateway timeout for ConcertService

### DIFF
--- a/k8s/namespaces/backend/base/server/backend-policy.yaml
+++ b/k8s/namespaces/backend/base/server/backend-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: server-policy
 spec:
   default:
-    timeoutSec: 60
+    timeoutSec: 150
     connectionDraining:
       drainingTimeoutSec: 60
   targetRef:

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -12,9 +12,11 @@ GCP_GEMINI_MODEL=gemini-3-flash-preview
 # Server
 SERVER_PORT=8080
 SERVER_HOST=0.0.0.0
-# Handler timeout: maximum duration for any single RPC request.
-# SearchNewConcerts (Gemini API) can take 16-25s per call.
+# Default handler timeout for most RPCs.
+# ConcertService has its own timeout (SERVER_CONCERT_HANDLER_TIMEOUT) because
+# Gemini API + Google Search grounding takes 25-110s per call.
 SERVER_HANDLER_TIMEOUT=60s
+SERVER_CONCERT_HANDLER_TIMEOUT=120s
 # Shutdown timeout must fit within: terminationGracePeriodSeconds(75) - preStop(5) - buffer(10) = 60s
 SHUTDOWN_TIMEOUT=60s
 # OIDC


### PR DESCRIPTION
## Summary

- Increase `GCPBackendPolicy.timeoutSec` from 60s to 150s to accommodate ConcertService's 120s handler timeout with network overhead buffer
- Add `SERVER_CONCERT_HANDLER_TIMEOUT=120s` to server configmap
- Update timeout comments to reflect actual Gemini response times (25-110s)

## Context

Part of the Gemini API retry/timeout fix. The backend now isolates ConcertService with a 120s handler timeout — the gateway must allow at least that long plus buffer.

## Test plan

- [ ] Verify kustomize renders correctly
- [ ] Verify ArgoCD sync applies the new timeout after merge

## Related PRs

- backend: liverty-music/backend#253
