### PR TITLE
fix(k8s): add missing NATS JetStream triggers to consumer ScaledObject

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -18,3 +18,27 @@ spec:
       consumer: "CONCERT_discovered"
       lagThreshold: "10"
       activationLagThreshold: "1"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "CONCERT"
+      consumer: "CONCERT_created"
+      lagThreshold: "10"
+      activationLagThreshold: "1"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ARTIST"
+      consumer: "ARTIST_created"
+      lagThreshold: "1"
+      activationLagThreshold: "1"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "USER"
+      consumer: "USER_created"
+      lagThreshold: "1"
+      activationLagThreshold: "1"


### PR DESCRIPTION
## Summary

- Add NATS JetStream triggers for `CONCERT.created`, `ARTIST.created`, and `USER.created` to the consumer-app KEDA ScaledObject
- `USER` and `ARTIST` triggers use `lagThreshold: "1"` for immediate scale-up; `CONCERT.created` keeps `lagThreshold: "10"` consistent with existing pattern

## Problem

The ScaledObject only monitored `CONCERT.discovered`. With `minReplicaCount: 0`, the consumer pod stayed at zero replicas whenever no concert discovery was running. Events on `USER.created` (email verification), `CONCERT.created` (fan notifications), and `ARTIST.created` (name/image resolution) were never consumed.

Root cause of the email verification bug: users signed up, `USER.created` was published to NATS, but the consumer pod never started — so `SendEmailCode` was never called and `ResendEmailCode` returned `FailedPrecondition: Code is empty`.

## Test plan

- [ ] ArgoCD syncs the updated ScaledObject
- [ ] Sign up a new user → consumer pod scales up → `"sending email verification"` appears in logs
- [ ] Verification email is received
