### PR TITLE
fix(github): enforce CI Success as required check for frontend and cloud-provisioning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.FRONTEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: [], // No required checks (only Gemini Review which is optional)
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Specification Repository
@@ -120,7 +120,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.CLOUD_PROVISIONING,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: [], // No required checks (only Gemini Review which is optional)
+	requiredStatusCheckContexts: ['CI Success'],
 	requireUpToDateBranch: true,
 })
 


### PR DESCRIPTION
## Summary

- Enforce `CI Success` as a required status check for **frontend** and **cloud-provisioning** repos
- Previously both had empty `requiredStatusCheckContexts`, allowing PRs to merge with failing CI
- Now all 4 repos (backend, frontend, specification, cloud-provisioning) consistently require `CI Success`

Already applied via `pulumi up -s prod` and verified via GitHub API.

## Test plan

- [x] `make check` passes
- [x] `pulumi preview -s prod` shows correct diff
- [x] `pulumi up -s prod` applied successfully
- [x] GitHub API confirms `CI Success` is required for both repos
