### PR TITLE
docs(agents): document Pulumi Deployments automation for dev/prod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,17 @@ Before executing `pulumi up` or any deployment command, follow this workflow:
 
 Never skip this workflow, even for small changes. Exception: the user has given explicit advance authorization for a specific deployment in the current session.
 
+### Pulumi Deployments (Automated)
+
+**dev**: Merging a PR to `main` with changes under `src/**` automatically
+triggers `pulumi up` via Pulumi Cloud Deployments.
+Never run `pulumi up` locally for dev — it conflicts with the automated job.
+Monitor: https://app.pulumi.com/pannpers/liverty-music/dev/deployments
+
+**prod**: PRs trigger `pulumi preview` only. `pulumi up` does not run
+automatically on merge. Trigger manually from the Pulumi Cloud console:
+https://app.pulumi.com/pannpers/liverty-music/prod/deployments
+
 ### Kubernetes Manifest Dry-Run
 
 Before committing any changes to `k8s/` manifests, run a Kustomize dry-run:


### PR DESCRIPTION
## Summary

Document Pulumi Deployments automation behavior in AGENTS.md to prevent confusion about when `pulumi up` runs automatically vs. requires manual intervention.

- **dev**: PR merge to `main` with `src/**` changes → `pulumi up` runs automatically via Pulumi Cloud Deployments
- **prod**: PR merge triggers `pulumi preview` only → manual trigger required from Pulumi Cloud console

## Why

Previously undocumented, leading to unnecessary `pulumi up` attempts locally for dev (which conflicts with the automated job) and unclear prod deployment path.

Refs: #179
