### PR TITLE
feat(network): add Private Google Access DNS zones for googleapis.com

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -79,7 +79,76 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// 3. Postmark Email DNS Records (prod: Cloudflare DNS)
+		// 3. Private Google Access DNS zones
+		// Completes the PGA configuration (subnet flag is already set in kubernetes.ts).
+		// Without these zones, *.googleapis.com resolves to public IPs and traffic is
+		// forced through Cloud NAT even though privateIpGoogleAccess: true is set.
+		// Note: dev nodes have external IPs (enablePrivateNodes: false) so PGA has no
+		// effect there per GCP docs — zones are added to all environments for code
+		// simplicity but only benefit staging/prod (private nodes + NAT).
+		const pgaGoogleapisZone = new gcp.dns.ManagedZone(
+			'pga-googleapis-zone',
+			{
+				name: 'pga-googleapis-zone',
+				dnsName: 'googleapis.com.',
+				description:
+					'Private zone for Private Google Access — routes *.googleapis.com to restricted.googleapis.com VIP',
+				visibility: 'private',
+				privateVisibilityConfig: {
+					networks: [{ networkUrl: this.network.id }],
+				},
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		// Wildcard CNAME: *.googleapis.com → restricted.googleapis.com
+		new gcp.dns.RecordSet(
+			'pga-googleapis-cname',
+			{
+				name: '*.googleapis.com.',
+				managedZone: pgaGoogleapisZone.name,
+				type: 'CNAME',
+				ttl: 300,
+				rrdatas: ['restricted.googleapis.com.'],
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		// Private zone for restricted.googleapis.com VIP resolution
+		const pgaRestrictedZone = new gcp.dns.ManagedZone(
+			'pga-restricted-googleapis-zone',
+			{
+				name: 'pga-restricted-googleapis-zone',
+				dnsName: 'restricted.googleapis.com.',
+				description:
+					'Private zone for restricted.googleapis.com — A records pointing to 199.36.153.4/30 (VPC SC-compatible APIs only)',
+				visibility: 'private',
+				privateVisibilityConfig: {
+					networks: [{ networkUrl: this.network.id }],
+				},
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		// A record: restricted.googleapis.com → 199.36.153.4/30 (all 4 IPs in the range)
+		new gcp.dns.RecordSet(
+			'pga-restricted-googleapis-a',
+			{
+				name: 'restricted.googleapis.com.',
+				managedZone: pgaRestrictedZone.name,
+				type: 'A',
+				ttl: 300,
+				rrdatas: [
+					'199.36.153.4',
+					'199.36.153.5',
+					'199.36.153.6',
+					'199.36.153.7',
+				],
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		// 4. Postmark Email DNS Records (prod: Cloudflare DNS)
 		if (environment === 'prod') {
 			const cfProvider = new cloudflare.Provider(
 				'postmark-cloudflare-provider',


### PR DESCRIPTION
## Summary

Complete the Private Google Access configuration for staging/prod clusters by adding private Cloud DNS zones for `googleapis.com` and `restricted.googleapis.com`.

The subnet has had `privateIpGoogleAccess: true` set since initial provisioning, but without the corresponding DNS zones `*.googleapis.com` still resolves to public IPs — forcing all Google API traffic (Logging, Monitoring, Trace, Gemini, Secret Manager, Artifact Registry) through Cloud NAT and incurring $0.045/GiB data processing charges unnecessarily.

**Changes:**
- Add private `ManagedZone` for `googleapis.com.` bound to `global-vpc`
- Add wildcard CNAME `*.googleapis.com.` → `restricted.googleapis.com.`
- Add private `ManagedZone` for `restricted.googleapis.com.` bound to `global-vpc`
- Add A record `restricted.googleapis.com.` → `199.36.153.4–7` (VPC SC-compatible APIs only)

**Why `restricted.googleapis.com`:** All services used in this project (Vertex AI, Logging, Monitoring, Trace, Secret Manager, Artifact Registry) are VPC Service Controls-compatible. Using the restricted VIP provides a stricter security posture — non-VPC-SC services are blocked at the network layer.

**Dev note:** Dev nodes use `enablePrivateNodes: false` so PGA has no effect there per GCP documentation. DNS zones are added to all environments for code simplicity but only benefit staging/prod.

close: #179
