### PR TITLE
fix(network): replace wildcard CNAME with A record for googleapis.com PGA zone

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -101,15 +101,23 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// Wildcard CNAME: *.googleapis.com → restricted.googleapis.com
+		// Wildcard A record: *.googleapis.com → 199.36.153.4/30 directly.
+		// A CNAME pointing to restricted.googleapis.com. (a separate private zone)
+		// does not resolve correctly — Cloud DNS does not follow cross-zone CNAMEs in
+		// private zones. Use A records instead per GCP documentation.
 		new gcp.dns.RecordSet(
-			'pga-googleapis-cname',
+			'pga-googleapis-a',
 			{
 				name: '*.googleapis.com.',
 				managedZone: pgaGoogleapisZone.name,
-				type: 'CNAME',
+				type: 'A',
 				ttl: 300,
-				rrdatas: ['restricted.googleapis.com.'],
+				rrdatas: [
+					'199.36.153.4',
+					'199.36.153.5',
+					'199.36.153.6',
+					'199.36.153.7',
+				],
 			},
 			{ parent: this, dependsOn: enabledApis },
 		)


### PR DESCRIPTION
## Summary

Fix PGA DNS configuration: replace wildcard CNAME with A record in `googleapis.com.` private zone.

## Problem

After merging #186, `consumer-app` entered CrashLoopBackOff. Root cause: Cloud DNS private zones do not follow cross-zone CNAME references. The wildcard `*.googleapis.com. CNAME restricted.googleapis.com.` was resolving to `restricted.googleapis.com` (the CNAME name) but not continuing to the A records in the separate `restricted.googleapis.com.` private zone. As a result, `sqladmin.googleapis.com` (used by Cloud SQL Connector for Workload Identity token exchange) failed to resolve, breaking DB connections.

Verified with `kubectl run busybox nslookup`:
- Before fix: `sts.googleapis.com → restricted.googleapis.com` (no IP returned)
- After fix: should resolve to `199.36.153.4–7` directly

## Fix

Replace `*.googleapis.com. CNAME restricted.googleapis.com.` with `*.googleapis.com. A 199.36.153.4–7` directly in the `googleapis.com.` private zone. The `restricted.googleapis.com.` zone is retained for completeness.

This matches the canonical GCP documentation pattern for PGA private DNS zones.

Refs: #179
