### PR TITLE
fix(network): use single googleapis.com zone with CNAME+A per GCP docs

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -86,13 +86,20 @@ export class NetworkComponent extends pulumi.ComponentResource {
 		// Note: dev nodes have external IPs (enablePrivateNodes: false) so PGA has no
 		// effect there per GCP docs — zones are added to all environments for code
 		// simplicity but only benefit staging/prod (private nodes + NAT).
+		//
+		// Structure follows GCP documentation exactly (one zone, CNAME + A records):
+		// https://cloud.google.com/vpc/docs/configure-private-google-access
+		//   *.googleapis.com  CNAME  restricted.googleapis.com.    (in googleapis.com zone)
+		//   restricted.googleapis.com  A  199.36.153.4/30           (same zone)
+		// Both records MUST be in the same zone — Cloud DNS does not follow CNAMEs
+		// that point to names in a different private zone.
 		const pgaGoogleapisZone = new gcp.dns.ManagedZone(
 			'pga-googleapis-zone',
 			{
 				name: 'pga-googleapis-zone',
 				dnsName: 'googleapis.com.',
 				description:
-					'Private zone for Private Google Access — routes *.googleapis.com to restricted.googleapis.com VIP',
+					'Private zone for Private Google Access (restricted VIP). Contains CNAME + A records per https://cloud.google.com/vpc/docs/configure-private-google-access',
 				visibility: 'private',
 				privateVisibilityConfig: {
 					networks: [{ networkUrl: this.network.id }],
@@ -101,49 +108,27 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// Wildcard A record: *.googleapis.com → 199.36.153.4/30 directly.
-		// A CNAME pointing to restricted.googleapis.com. (a separate private zone)
-		// does not resolve correctly — Cloud DNS does not follow cross-zone CNAMEs in
-		// private zones. Use A records instead per GCP documentation.
+		// Wildcard CNAME: *.googleapis.com → restricted.googleapis.com (same zone)
 		new gcp.dns.RecordSet(
-			'pga-googleapis-a',
+			'pga-googleapis-cname',
 			{
 				name: '*.googleapis.com.',
 				managedZone: pgaGoogleapisZone.name,
-				type: 'A',
+				type: 'CNAME',
 				ttl: 300,
-				rrdatas: [
-					'199.36.153.4',
-					'199.36.153.5',
-					'199.36.153.6',
-					'199.36.153.7',
-				],
+				rrdatas: ['restricted.googleapis.com.'],
 			},
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// Private zone for restricted.googleapis.com VIP resolution
-		const pgaRestrictedZone = new gcp.dns.ManagedZone(
-			'pga-restricted-googleapis-zone',
-			{
-				name: 'pga-restricted-googleapis-zone',
-				dnsName: 'restricted.googleapis.com.',
-				description:
-					'Private zone for restricted.googleapis.com — A records pointing to 199.36.153.4/30 (VPC SC-compatible APIs only)',
-				visibility: 'private',
-				privateVisibilityConfig: {
-					networks: [{ networkUrl: this.network.id }],
-				},
-			},
-			{ parent: this, dependsOn: enabledApis },
-		)
-
-		// A record: restricted.googleapis.com → 199.36.153.4/30 (all 4 IPs in the range)
+		// A record for restricted.googleapis.com in the SAME googleapis.com zone.
+		// Must be in the same zone as the CNAME above — intra-zone resolution works,
+		// cross-zone CNAME resolution does not in Cloud DNS private zones.
 		new gcp.dns.RecordSet(
 			'pga-restricted-googleapis-a',
 			{
 				name: 'restricted.googleapis.com.',
-				managedZone: pgaRestrictedZone.name,
+				managedZone: pgaGoogleapisZone.name,
 				type: 'A',
 				ttl: 300,
 				rrdatas: [


### PR DESCRIPTION
## Summary

Fix Private Google Access DNS configuration to follow GCP documentation exactly.

## Problem (PR #186 + #187)

PR #186 split the CNAME and A records across two separate private zones (`googleapis.com.` and `restricted.googleapis.com.`). Cloud DNS does not follow CNAME records that point to names in a *different* private zone — it returned `restricted.googleapis.com` as the CNAME target but no IP address, causing `sts.googleapis.com` to fail resolution. This broke Workload Identity token exchange and crashed `consumer-app`.

PR #187 worked around this with a direct wildcard A record, but that deviates from GCP's documented approach.

## Fix

Per [GCP documentation](https://cloud.google.com/vpc/docs/configure-private-google-access), both records must be in the **same `googleapis.com.` private zone**:

```
googleapis.com. (private zone)
  ├── *.googleapis.com.          CNAME  restricted.googleapis.com.
  └── restricted.googleapis.com  A      199.36.153.4, .5, .6, .7
```

Intra-zone CNAME resolution works correctly. The separate `restricted.googleapis.com.` zone is removed.

Refs: #179
