### PR TITLE
fix(infra): remove ConsumerQuotaOverride with non-existent limitIds

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -329,34 +329,6 @@ export class Gcp {
 					{ parent: this.project },
 				)
 			}
-
-			// Places API (New): 20 requests/day
-			new gcp.serviceusage.ConsumerQuotaOverride(
-				'dev-places-api-quota',
-				{
-					project: this.projectId,
-					service: 'places.googleapis.com',
-					metric: 'places.googleapis.com%2Fv1%2Fplaces_requests',
-					limit: '%2Fproject%2Fday',
-					overrideValue: '20',
-					force: true,
-				},
-				{ parent: this.project },
-			)
-
-			// Vertex AI (Gemini GenerateContent): 5 requests/minute
-			new gcp.serviceusage.ConsumerQuotaOverride(
-				'dev-vertex-ai-quota',
-				{
-					project: this.projectId,
-					service: 'aiplatform.googleapis.com',
-					metric: 'aiplatform.googleapis.com%2Fgenerate_content_requests',
-					limit: '%2Fproject%2Fregion%2Fbase_model%2Fminute',
-					overrideValue: '5',
-					force: true,
-				},
-				{ parent: this.project },
-			)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes Pulumi deployment failure introduced by PR#192 (cost guardrails).

The two `ConsumerQuotaOverride` resources were referencing quota limitIds that do not exist in GCP:

- `places.googleapis.com/v1/places_requests` — this aggregate metric does not exist. Places API (New) only exposes per-request-type metrics (`GetPlaceRequest`, `SearchTextRequest`, etc.)
- `aiplatform.googleapis.com/generate_content_requests` with limit `/project/region/base_model/minute` — the actual metric name is `generate_content_requests_per_minute_per_project_per_base_model` with a different limit format

Both resources are removed. The Billing Budget alert (50/90/100% of JPY 3,000/month) already provides the cost guardrail coverage that was intended.
