### PR TITLE
fix(network): switch PGA from restricted to private VIP to unblock FCM

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -83,14 +83,24 @@ export class NetworkComponent extends pulumi.ComponentResource {
 		// Completes the PGA configuration (subnet flag is already set in kubernetes.ts).
 		// Without these zones, *.googleapis.com resolves to public IPs and traffic is
 		// forced through Cloud NAT even though privateIpGoogleAccess: true is set.
-		// Note: dev nodes have external IPs (enablePrivateNodes: false) so PGA has no
-		// effect there per GCP docs — zones are added to all environments for code
-		// simplicity but only benefit staging/prod (private nodes + NAT).
+		//
+		// VIP selection: private.googleapis.com (199.36.153.8/30)
+		//   - Allows access to most Google APIs including services NOT protected by
+		//     VPC Service Controls (e.g., Firebase Cloud Messaging).
+		//   - Switch to restricted.googleapis.com (199.36.153.4/30) only if/when
+		//     adopting VPC Service Controls — the restricted VIP actively blocks
+		//     services not on the VPC-SC supported product list.
+		//   - This project does not use VPC-SC; the restricted VIP was previously
+		//     configured by mistake, causing FCM Web Push delivery to return 403.
+		//
+		// The private DNS zone redirects traffic for ALL nodes regardless of whether
+		// they have external IPs. Cloud DNS resolution is consulted before public DNS,
+		// so even dev nodes (enablePrivateNodes: false) are affected.
 		//
 		// Structure follows GCP documentation exactly (one zone, CNAME + A records):
 		// https://cloud.google.com/vpc/docs/configure-private-google-access
-		//   *.googleapis.com  CNAME  restricted.googleapis.com.    (in googleapis.com zone)
-		//   restricted.googleapis.com  A  199.36.153.4/30           (same zone)
+		//   *.googleapis.com  CNAME  private.googleapis.com.    (in googleapis.com zone)
+		//   private.googleapis.com  A  199.36.153.8/30           (same zone)
 		// Both records MUST be in the same zone — Cloud DNS does not follow CNAMEs
 		// that point to names in a different private zone.
 		const pgaGoogleapisZone = new gcp.dns.ManagedZone(
@@ -99,7 +109,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				name: 'pga-googleapis-zone',
 				dnsName: 'googleapis.com.',
 				description:
-					'Private zone for Private Google Access (restricted VIP). Contains CNAME + A records per https://cloud.google.com/vpc/docs/configure-private-google-access',
+					'Private zone for Private Google Access (private VIP). Contains CNAME + A records per https://cloud.google.com/vpc/docs/configure-private-google-access',
 				visibility: 'private',
 				privateVisibilityConfig: {
 					networks: [{ networkUrl: this.network.id }],
@@ -108,7 +118,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// Wildcard CNAME: *.googleapis.com → restricted.googleapis.com (same zone)
+		// Wildcard CNAME: *.googleapis.com → private.googleapis.com (same zone)
 		new gcp.dns.RecordSet(
 			'pga-googleapis-cname',
 			{
@@ -116,26 +126,26 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				managedZone: pgaGoogleapisZone.name,
 				type: 'CNAME',
 				ttl: 300,
-				rrdatas: ['restricted.googleapis.com.'],
+				rrdatas: ['private.googleapis.com.'],
 			},
 			{ parent: this, dependsOn: enabledApis },
 		)
 
-		// A record for restricted.googleapis.com in the SAME googleapis.com zone.
+		// A record for private.googleapis.com in the SAME googleapis.com zone.
 		// Must be in the same zone as the CNAME above — intra-zone resolution works,
 		// cross-zone CNAME resolution does not in Cloud DNS private zones.
 		new gcp.dns.RecordSet(
-			'pga-restricted-googleapis-a',
+			'pga-private-googleapis-a',
 			{
-				name: 'restricted.googleapis.com.',
+				name: 'private.googleapis.com.',
 				managedZone: pgaGoogleapisZone.name,
 				type: 'A',
 				ttl: 300,
 				rrdatas: [
-					'199.36.153.4',
-					'199.36.153.5',
-					'199.36.153.6',
-					'199.36.153.7',
+					'199.36.153.8',
+					'199.36.153.9',
+					'199.36.153.10',
+					'199.36.153.11',
 				],
 			},
 			{ parent: this, dependsOn: enabledApis },


### PR DESCRIPTION
## Summary

Switch the Private Google Access wildcard DNS zone from `restricted.googleapis.com` (199.36.153.4/30) to `private.googleapis.com` (199.36.153.8/30) per [GCP official documentation](https://cloud.google.com/vpc/docs/configure-private-google-access).

## Root cause

Every webpush delivery from GKE pods returned HTTP 403 because the restricted VIP actively blocks non-VPC-SC services, and Firebase Cloud Messaging is [not on the VPC-SC supported product list](https://cloud.google.com/vpc-service-controls/docs/supported-products). This project does not use VPC Service Controls, so the restricted VIP provided no security benefit.

## What changes

- `src/gcp/components/network.ts`:
  - CNAME target: `restricted.googleapis.com.` → `private.googleapis.com.`
  - A record: resource renamed, IPs changed from `199.36.153.4-7` to `199.36.153.8-11`
  - Comment block rewritten with the correct rationale and VIP selection guidance
- Pulumi state diff: exactly 2 DNS record replaces (no other resource changes expected)

## Works for all environments

| Environment | Node type | How FCM is reached after fix |
|---|---|---|
| dev | public nodes | PGA private VIP (DNS zone overrides public DNS for all nodes) |
| staging | private nodes + Cloud NAT | PGA private VIP (same DNS zone; Cloud NAT only for non-googleapis traffic) |
| prod | private nodes + Cloud NAT | Same as staging |

## Companion PR

- liverty-music/backend#282 — adds HTTP error body capture + runbook update (ships independently)

## Test plan

- [ ] Pulumi preview (via CI) shows exactly 2 DNS record changes
- [ ] After dev deploy: pod-internal `curl` to `fcm.googleapis.com` no longer returns the generic PGA 403 body
- [ ] After dev deploy: `NotifyNewConcerts` smoke test returns `RecordPushSend("success")` in server-app logs
- [ ] Spot-check: existing googleapis callers (Cloud SQL, Maps, Gemini) still work

Refs: #195
