### PR TITLE
fix(argocd): bump health-degraded alert threshold 5m → 30m in dev

### DIFF
--- a/k8s/namespaces/argocd/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/kustomization.yaml
@@ -16,7 +16,7 @@ patches:
 - path: spot-vm_patch_job.yaml
   target:
     kind: Job
-# Override health-degraded notification trigger grace period (5 min for dev)
+# Override health-degraded notification trigger grace period (30 min for dev to filter Spot preemption noise)
 - path: notification-trigger_patch.yaml
   target:
     kind: ConfigMap

--- a/k8s/namespaces/argocd/overlays/dev/notification-trigger_patch.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/notification-trigger_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-notifications-cm
 data:
   trigger.on-health-degraded: |
-    - description: Application has degraded (fires after 5 minutes)
+    - description: Application has degraded (fires after 30 minutes to filter transient Spot VM preemption noise)
       send:
       - app-health-degraded
-      when: app.status.health.status == 'Degraded' && now() - date(app.status.health.lastTransitionTime) >= duration("5m")
+      when: app.status.health.status == 'Degraded' && now() - date(app.status.health.lastTransitionTime) >= duration("30m")


### PR DESCRIPTION
## Summary

- Bump ArgoCD `on-health-degraded` notification threshold from **5 min → 30 min** in the dev overlay
- Goal: filter transient Spot VM preemption noise without suppressing real incidents

## Root cause (incident on 2026-04-20)

The `backend-migrations` ArgoCD app went Degraded for ~2 hours. Timeline from atlas-operator logs:

```
2026-04-19 18:23:17Z  ✓ last successful reconcile (Applied)
2026-04-19 23:00:03Z  ✗ devDB Pod "no running pods found" (GettingDevDB) — loop starts
              ~ ~2h GettingDevDB loop ~
2026-04-20 00:56:26Z  ✗ same error, last occurrence
2026-04-20 00:56:34Z  → reconcile re-engages (devDB Pod became schedulable)
2026-04-20 00:56:39Z  ✓ "Version 20260406120000 applied" — Healthy
```

The dev cluster runs **only 2 Spot nodes**. When one gets preempted, new node provisioning + image pull + Pod schedule can keep the Atlas operator's ephemeral devDB Pod Pending for minutes-to-hours. ArgoCD's `selfHeal` eventually recovers without human action, but the 5-minute alert fires during the transient degraded window.

## Why 30 min

| Threshold | Dev "flaky" noise | Real 2h incident | Trade-off |
|---|---|---|---|
| 5m (current) | fires (noise) | fires | too sensitive |
| **30m (proposed)** | suppressed | fires | balanced |
| 1h | suppressed | fires late | conservative |
| 3h | suppressed | suppressed too long | masks real issues |

30 min filters typical preemption cycles (usually <20 min) but still fires promptly for genuine stuck-reconcile incidents that deserve investigation.

## Scope

- dev overlay only (`k8s/namespaces/argocd/overlays/dev/notification-trigger_patch.yaml`)
- Staging/prod unchanged
- No behavior change for successful apps — only affects when `Degraded` alerts fire

## Test plan

- [x] `make check` passes (kustomize render + biome + tsc)
- [x] Kustomize render contains `duration("30m")` in `trigger.on-health-degraded`
- [ ] After merge: ArgoCD ConfigMap `argocd-notifications-cm` in dev cluster reflects `30m`
- [ ] After merge: next Spot-preemption-driven transient Degraded event does **not** page
