### PR TITLE
feat(infra): enable Vertex AI API for ticket email parsing

### DIFF
--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -109,6 +109,7 @@ export class ProjectComponent extends pulumi.ComponentResource {
 			'recommender.googleapis.com', // Recommended for Gemini Cloud Assist.
 			'artifactregistry.googleapis.com', // Required for container images.
 			'clouderrorreporting.googleapis.com', // Required for error grouping and first-seen detection.
+			'aiplatform.googleapis.com', // Required for Vertex AI Gemini email parsing.
 		])
 
 		// Register outputs.


### PR DESCRIPTION
## Summary

- Enable `aiplatform.googleapis.com` at the project level to allow the backend service to call Vertex AI Gemini for parsing Japanese ticket confirmation emails

## Why

Part of the `ticket-email-import` OpenSpec change (task 6.1):
> 6.1 Verify Vertex AI API is enabled in GCP project

Current Gemini calls fail unless Vertex AI is explicitly enabled — the Google Cloud API gateway returns permission errors even for otherwise-authorized service accounts.

## Scope

- `src/gcp/components/project.ts`: append one entry to the `enableApis()` list
- Deploys automatically to dev on merge (per CLAUDE.md Pulumi Deployments policy)
- IAM for the backend service account is already covered elsewhere (task 6.2 — no changes needed here)

## Companion PRs

- [liverty-music/specification#414](https://github.com/liverty-music/specification/pull/414) — marks tasks 2.3/3.4/4.4/5.4/6.1/6.2 complete

## Test plan

- [x] `make check` passes (biome + tsc; existing unrelated warning in `network.ts` only)
- [ ] After merge: Pulumi Cloud Deployments runs `pulumi up` on dev, `aiplatform.googleapis.com` appears enabled in the GCP project
- [ ] After deploy: backend `CreateTicketEmail` handler successfully calls Vertex AI Gemini without permission errors
