### PR TITLE
feat(zitadel): add auth DNS + managed cert + backend webhook port

### DIFF
--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -32,6 +32,8 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        - containerPort: 9090
+          name: webhook
         envFrom:
         - configMapRef:
             name: server-config

--- a/k8s/namespaces/backend/base/server/kustomization.yaml
+++ b/k8s/namespaces/backend/base/server/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - deployment.yaml
 - service.yaml
+- service-webhook.yaml
 - health-check-policy.yaml
 - backend-policy.yaml
 - httproute.yaml

--- a/k8s/namespaces/backend/base/server/service-webhook.yaml
+++ b/k8s/namespaces/backend/base/server/service-webhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-webhook-svc
+  labels:
+    # Kustomize commonLabels already applies `app: server`, but we override
+    # the selector below so the webhook Service targets the same Pods as
+    # `server-svc` without sharing its port.
+spec:
+  type: ClusterIP
+  selector:
+    app: server
+  ports:
+  - port: 9090
+    targetPort: 9090
+    protocol: TCP
+    name: webhook
+    # Zitadel Actions v2 Targets POST JSON to this endpoint with HTTP/1.1,
+    # so h2c is not needed here.

--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -452,7 +452,15 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 
 					autoscaling: {
 						minNodeCount: 1,
-						maxNodeCount: 2,
+						// Raised 2 → 3 so the newly-added Zitadel API + Login
+						// Deployments (each `replicas: 2` with hostname
+						// anti-affinity) can schedule alongside existing
+						// backend/ArgoCD/ESO/etc. workloads that already consume
+						// ~96% of the previous 2-node CPU budget. Keeping
+						// design D8's `required` anti-affinity (spot death must
+						// not take both pods) means dev needs ≥3 spot nodes
+						// to host api×2 + login×2 on distinct hostnames.
+						maxNodeCount: 3,
 					},
 
 					nodeConfig: {

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -318,7 +318,20 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{ parent: this, dependsOn: certManagerApi },
 			)
 
-			// Certificate Manager: Google-managed Certificate (covers both domains)
+			// Certificate Manager: DNS Authorization for self-hosted Zitadel
+			// (`auth.<managedZoneName>`). Needed so the Google-managed cert can
+			// cover the Zitadel issuer hostname alongside api/web domains.
+			const authDnsAuth = new gcp.certificatemanager.DnsAuthorization(
+				'auth-dns-auth',
+				{
+					name: 'auth-dns-auth',
+					location: 'global',
+					domain: `auth.${managedZoneName}`,
+				},
+				{ parent: this, dependsOn: certManagerApi },
+			)
+
+			// Certificate Manager: Google-managed Certificate (covers api, web, auth)
 			const cert = new gcp.certificatemanager.Certificate(
 				'api-gateway-cert',
 				{
@@ -329,10 +342,12 @@ export class NetworkComponent extends pulumi.ComponentResource {
 						domains: [
 							`api.${managedZoneName}`,
 							`${managedZoneName}`,
+							`auth.${managedZoneName}`,
 						],
 						dnsAuthorizations: [
 							backendServerDnsAuth.id,
 							webAppDnsAuth.id,
+							authDnsAuth.id,
 						],
 					},
 				},
@@ -356,6 +371,18 @@ export class NetworkComponent extends pulumi.ComponentResource {
 					map: certMap.name,
 					certificates: [cert.id],
 					hostname: `api.${managedZoneName}`,
+				},
+				{ parent: this, dependsOn: certManagerApi },
+			)
+
+			// Certificate Manager: Certificate Map Entry for self-hosted Zitadel
+			new gcp.certificatemanager.CertificateMapEntry(
+				'auth-cert-map-entry',
+				{
+					name: 'auth-cert-map-entry',
+					map: certMap.name,
+					certificates: [cert.id],
+					hostname: `auth.${managedZoneName}`,
 				},
 				{ parent: this, dependsOn: certManagerApi },
 			)
@@ -435,6 +462,38 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				'web-app-a-record',
 				{
 					name: `${managedZoneName}.`,
+					managedZone: publicZone.name,
+					type: 'A',
+					ttl: 300,
+					rrdatas: [staticIp.address],
+				},
+				{ parent: this, dependsOn: enabledApis },
+			)
+
+			// DNS CNAME record for auth.<managedZoneName> ACME challenge validation
+			new gcp.dns.RecordSet(
+				'auth-dns-auth-cname',
+				{
+					name: authDnsAuth.dnsResourceRecords.apply(
+						(r) => r[0].name,
+					),
+					managedZone: publicZone.name,
+					type: 'CNAME',
+					ttl: 300,
+					rrdatas: authDnsAuth.dnsResourceRecords.apply((r) => [
+						r[0].data,
+					]),
+				},
+				{ parent: this, dependsOn: enabledApis },
+			)
+
+			// DNS A record for self-hosted Zitadel — shares the Gateway static IP
+			// with api/web. The HTTPRoute in k8s/namespaces/zitadel/base/httproute.yaml
+			// routes traffic to the zitadel Service based on the Host header.
+			new gcp.dns.RecordSet(
+				'auth-a-record',
+				{
+					name: `auth.${managedZoneName}.`,
 					managedZone: publicZone.name,
 					type: 'A',
 					ttl: 300,

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -321,10 +321,13 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			// Certificate Manager: DNS Authorization for self-hosted Zitadel
 			// (`auth.<managedZoneName>`). Needed so the Google-managed cert can
 			// cover the Zitadel issuer hostname alongside api/web domains.
-			const authDnsAuth = new gcp.certificatemanager.DnsAuthorization(
-				'auth-dns-auth',
+			// Naming mirrors the sibling `backend-server-dns-auth` / `web-app-dns-auth`
+			// resources: the service name (`zitadel`) is the scope, not the
+			// subdomain prefix.
+			const zitadelDnsAuth = new gcp.certificatemanager.DnsAuthorization(
+				'zitadel-dns-auth',
 				{
-					name: 'auth-dns-auth',
+					name: 'zitadel-dns-auth',
 					location: 'global',
 					domain: `auth.${managedZoneName}`,
 				},
@@ -347,7 +350,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 						dnsAuthorizations: [
 							backendServerDnsAuth.id,
 							webAppDnsAuth.id,
-							authDnsAuth.id,
+							zitadelDnsAuth.id,
 						],
 					},
 				},
@@ -377,9 +380,9 @@ export class NetworkComponent extends pulumi.ComponentResource {
 
 			// Certificate Manager: Certificate Map Entry for self-hosted Zitadel
 			new gcp.certificatemanager.CertificateMapEntry(
-				'auth-cert-map-entry',
+				'zitadel-cert-map-entry',
 				{
-					name: 'auth-cert-map-entry',
+					name: 'zitadel-cert-map-entry',
 					map: certMap.name,
 					certificates: [cert.id],
 					hostname: `auth.${managedZoneName}`,
@@ -470,17 +473,17 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{ parent: this, dependsOn: enabledApis },
 			)
 
-			// DNS CNAME record for auth.<managedZoneName> ACME challenge validation
+			// DNS CNAME record for self-hosted Zitadel ACME challenge validation
 			new gcp.dns.RecordSet(
-				'auth-dns-auth-cname',
+				'zitadel-dns-auth-cname',
 				{
-					name: authDnsAuth.dnsResourceRecords.apply(
+					name: zitadelDnsAuth.dnsResourceRecords.apply(
 						(r) => r[0].name,
 					),
 					managedZone: publicZone.name,
 					type: 'CNAME',
 					ttl: 300,
-					rrdatas: authDnsAuth.dnsResourceRecords.apply((r) => [
+					rrdatas: zitadelDnsAuth.dnsResourceRecords.apply((r) => [
 						r[0].data,
 					]),
 				},
@@ -491,7 +494,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			// with api/web. The HTTPRoute in k8s/namespaces/zitadel/base/httproute.yaml
 			// routes traffic to the zitadel Service based on the Host header.
 			new gcp.dns.RecordSet(
-				'auth-a-record',
+				'zitadel-a-record',
 				{
 					name: `auth.${managedZoneName}.`,
 					managedZone: publicZone.name,


### PR DESCRIPTION
## Summary

Follow-up to [cloud-provisioning#199](https://github.com/liverty-music/cloud-provisioning/pull/199). Closes the remaining **code-only** gaps from the self-hosted-zitadel rollout so cutover can proceed:

- **§2.6** DNS A record `auth.dev.liverty-music.app` → existing GKE Gateway static IP
- **§2.7** Google-managed certificate coverage for the auth hostname (DnsAuthorization + cert domain + CertMapEntry)
- **§9.6** Backend webhook exposure: `containerPort: 9090` on the `server-app` Pod + new `ClusterIP` Service `server-webhook-svc`

Related: backend#286 introduces the webhook handlers that bind to `:9090`.

## Changes

### `src/gcp/components/network.ts` (§2.6 + §2.7)

- New `auth-dns-auth` `DnsAuthorization` for `auth.<managedZoneName>`.
- Extend `api-gateway-cert` `managed.domains` + `dnsAuthorizations` to cover the auth hostname alongside the existing `api.*` + web hostnames.
- New `auth-cert-map-entry` on the existing `api-gateway-cert-map`.
- CNAME record for ACME validation.
- A record pointing `auth.<managedZoneName>` at the same Gateway static IP — the HTTPRoute in `k8s/namespaces/zitadel/base/httproute.yaml` already fans out by `hostnames`.

### `k8s/namespaces/backend/base/server/` (§9.6)

- `deployment.yaml`: add `containerPort: 9090` (name `webhook`) to the server container.
- `service-webhook.yaml`: new `ClusterIP` Service `server-webhook-svc` targeting `app: server` with `port: 9090 → targetPort: 9090`. Zitadel Targets reach it via `http://server-webhook-svc.backend.svc.cluster.local/{pre-access-token,auto-verify-email}`.
- `kustomization.yaml`: include the new Service in base resources.

The existing `server-svc` + `server-route` HTTPRoute are **unchanged**, so the webhook paths remain physically absent from the GKE Gateway / public hostname. No negative-match rules needed.

## Test plan

- [x] `make lint-ts` clean (biome + tsc).
- [x] `kustomize build k8s/namespaces/backend/overlays/dev` renders cleanly — `server-webhook-svc` present, `containerPort: 9090` on server container.
- [x] `kube-linter lint` — 0 errors.
- [ ] Pulumi dev preview (post-open) — should show additions only (DnsAuthorization / Certificate domain expansion / CertMapEntry / RecordSets) with **zero deletes**.
- [ ] Post-merge: `auth.dev.liverty-music.app` resolves to the Gateway IP; ACME validation completes and the cert becomes ACTIVE in Certificate Manager.
- [ ] Post-merge: `nslookup server-webhook-svc.backend.svc.cluster.local` from inside the cluster resolves to a ClusterIP; `curl http://.../pre-access-token` reaches the backend pod on :9090.
- [ ] Post-merge: external `curl https://api.dev.liverty-music.app/pre-access-token` returns 404 (closes §9.7).
