### PR TITLE
fix(zitadel): unblock ExternalSecret + correct zitadel-login image

### DIFF
--- a/k8s/cluster/base/cluster-secret-store.yaml
+++ b/k8s/cluster/base/cluster-secret-store.yaml
@@ -3,12 +3,13 @@ kind: ClusterSecretStore
 metadata:
   name: google-secret-manager
 spec:
-  # Restrict ExternalSecret access to the backend namespace only.
+  # Restrict ExternalSecret access to an allow-list of namespaces.
   # Without this, any namespace could read secrets via this ClusterSecretStore.
   conditions:
   - namespaces:
     - backend
     - atlas-operator
+    - zitadel
   provider:
     gcpsm:
       # Replaced by overlay patch per environment

--- a/k8s/namespaces/zitadel/base/deployment-login.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-login.yaml
@@ -36,8 +36,22 @@ spec:
       # splits traffic so non-login paths reach the API container instead.
       # ZITADEL_API_URL points at the in-cluster API Service so the login UI
       # can call the API without egressing the cluster.
+      #
+      # Image path: `zitadel-login`, not `login`. The Zitadel monorepo
+      # publishes the Login V2 UI at `ghcr.io/zitadel/zitadel-login`, not
+      # `ghcr.io/zitadel/login` (the latter 404s). The upstream Helm chart
+      # default is the same path (see zitadel-charts@main values.yaml).
+      #
+      # Tag: `latest`. The zitadel-login container publishes semver tags only
+      # up to v4.7.3; v4.8+ ship as git-SHA tags only. The Helm chart's
+      # appVersion (v4.13.0) expects `login:v4.13.0`, but that tag does not
+      # exist. Using `latest` in dev accepts the risk of upstream drift in
+      # exchange for avoiding a SHA-pinning runbook. `imagePullPolicy:
+      # IfNotPresent` prevents every restart from re-pulling. For
+      # staging/prod, pin a specific SHA after validating compatibility.
       - name: zitadel-login
-        image: ghcr.io/zitadel/login:v4.13.1
+        image: ghcr.io/zitadel/zitadel-login:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
           name: http


### PR DESCRIPTION
## Summary

Runtime fixes discovered post-merge of [#199](https://github.com/liverty-music/cloud-provisioning/pull/199) + [#200](https://github.com/liverty-music/cloud-provisioning/pull/200). Pulumi applied cleanly but 4 Zitadel pods landed in error states:

- `zitadel-*`: `CreateContainerConfigError` — `secret "zitadel-secrets" not found`
- `zitadel-login-*`: `ErrImagePull` — `ghcr.io/zitadel/login:v4.13.1` not found

## Root causes

### 1. ExternalSecret denied by ClusterSecretStore condition

`conditions.namespaces` on `google-secret-manager` allow-listed only `backend` + `atlas-operator`. The zitadel namespace was added to the cluster (via #199) but never added to the allow-list, so ESO returned `SecretSyncedError` and never materialized the `zitadel-secrets` K8s Secret — causing every Zitadel API pod to crash at `CreateContainerConfigError`.

Fix: add `zitadel` to the allow-list in `k8s/cluster/base/cluster-secret-store.yaml`.

### 2. Wrong login image path (plus no semver tag exists for v4.13.1)

#199 used `ghcr.io/zitadel/login:v4.13.1`. Two issues:

- The canonical image path is `ghcr.io/zitadel/zitadel-login` (the `/login` path returns 404). Matches the upstream Helm chart default.
- `zitadel-login` publishes semver tags **only up to `v4.7.3`**. v4.8+ publish as git-SHA tags only. The chart's `appVersion: v4.13.0` would dangle at that path too.

Fix: switch to `ghcr.io/zitadel/zitadel-login:latest` with `imagePullPolicy: IfNotPresent` for dev. The inline comment flags the need to pin a SHA for staging/prod.

## Test plan

- [x] `kustomize build` for both cluster and zitadel overlays renders cleanly.
- [x] Rendered manifests contain `namespaces: - backend - atlas-operator - zitadel` and `image: ghcr.io/zitadel/zitadel-login:latest`.
- [ ] Post-merge: ArgoCD re-syncs the ClusterSecretStore + zitadel-login Deployment. The 4 pods transition from error → Running. `zitadel-secrets` K8s Secret exists in the zitadel namespace. `zitadel-admin-sa-key` GSM secret gains its first version (bootstrap-uploader).

## Out of scope

- Pinning a specific SHA for zitadel-login (deferred to a staging/prod hardening PR).
