### PR TITLE
fix(zitadel): correct Admin DB connection for IAM auth sidecar

### DIFF
--- a/k8s/namespaces/zitadel/base/configmap.env
+++ b/k8s/namespaces/zitadel/base/configmap.env
@@ -9,15 +9,26 @@ ZITADEL_EXTERNALSECURE=true
 ZITADEL_TLS_ENABLED=false
 
 # Database connection — sidecar Cloud SQL Auth Proxy brokers IAM auth, so
-# Zitadel connects to localhost with no password. `ExistingDatabase: true`
-# tells Zitadel to skip CREATE ROLE / CREATE DATABASE (superuser-only queries
-# the IAM user can't run); Pulumi pre-creates the database and user.
+# Zitadel connects to localhost with no password.
+#
+# Admin phase configuration:
+#  * `ExistingDatabase: zitadel` is a **string** holding the DB name that
+#    Zitadel should treat as already existing — when set, Zitadel skips
+#    CREATE DATABASE / CREATE ROLE superuser queries. The Zitadel binary
+#    still opens an Admin-scoped connection to that database to introspect
+#    schema state, so Admin.Username must be a user Cloud SQL accepts via
+#    the sidecar's IAM auth.
+#  * `Admin.Username` defaults to `postgres` (built-in superuser). Built-in
+#    users require password auth, which the IAM-authn sidecar rejects.
+#    Point Admin at the same IAM SA as User so the sidecar authenticates it.
 ZITADEL_DATABASE_POSTGRES_HOST=localhost
 ZITADEL_DATABASE_POSTGRES_PORT=5432
 ZITADEL_DATABASE_POSTGRES_DATABASE=zitadel
 ZITADEL_DATABASE_POSTGRES_USER_USERNAME=zitadel@liverty-music-dev.iam
 ZITADEL_DATABASE_POSTGRES_USER_SSL_MODE=disable
-ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE=true
+ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE=zitadel
+ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=zitadel@liverty-music-dev.iam
+ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable
 
 # First-boot admin machine user. These env vars are only honored when the
 # database is empty; subsequent boots ignore them. On first boot, Zitadel


### PR DESCRIPTION
## Summary

Third runtime fix after [#199](https://github.com/liverty-music/cloud-provisioning/pull/199) + [#200](https://github.com/liverty-music/cloud-provisioning/pull/200) + [#201](https://github.com/liverty-music/cloud-provisioning/pull/201). Once ESO delivered `zitadel-secrets` and the `zitadel-login` image resolved, the API pods reached init and crashed on first DB connect:

```
initialize database failed: failed to connect to
`user=postgres database=true`:
127.0.0.1:5432 (localhost):
failed SASL auth: FATAL: password authentication failed
for user "postgres" (SQLSTATE 28P01)
```

Two overlapping misconfigurations produced the `user=postgres database=true` DSN.

## Root causes

### 1. `ExistingDatabase` is a string (DB name), not a boolean

We set `ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE=true` assuming it was a toggle. In Zitadel's config, this field holds the **DB name** that Zitadel should treat as pre-existing so it skips `CREATE DATABASE` / `CREATE ROLE` (superuser-only queries the IAM user can't run). With `=true`, Zitadel interpreted `"true"` as the literal DB name — hence the `database=true` in the error.

Fix: `ZITADEL_DATABASE_POSTGRES_ADMIN_EXISTINGDATABASE=zitadel`.

### 2. `Admin.Username` defaulted to built-in `postgres` — Auth Proxy rejects that

Even with `ExistingDatabase` set, Zitadel still opens an Admin-scoped connection to introspect schema state. The default `Admin.Username: postgres` is the Cloud SQL built-in superuser, which requires **password** auth. The Cloud SQL Auth Proxy sidecar runs with `--auto-iam-authn`, which only accepts IAM SA identities — hence the `failed SASL auth for user "postgres"`.

Fix: point Admin at the same IAM SA as User:

```
ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=zitadel@liverty-music-dev.iam
ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable
```

In-cluster traffic from Zitadel → sidecar is plaintext (`localhost`); the sidecar terminates TLS to Cloud SQL itself.

## Inline docstring

Expanded the `# Database connection` block in `configmap.env` to document both traps so future readers don't re-hit them.

## Test plan

- [x] `kustomize build k8s/namespaces/zitadel/overlays/dev` renders with `ADMIN_EXISTINGDATABASE: zitadel`, `ADMIN_USERNAME: zitadel@liverty-music-dev.iam`, `ADMIN_SSL_MODE: disable`.
- [x] `make check` passes (`npx biome check src` + `npx tsc --noEmit`).
- [ ] Post-merge: ArgoCD re-syncs the ConfigMap, Reloader rolls the `zitadel` Deployment, pods reach Ready. First pod performs one-shot init (creates schema, writes machine key to `/var/zitadel/bootstrap/admin-sa.json`), `bootstrap-uploader` sidecar copies the key into GSM secret `zitadel-admin-sa-key`.

## Follow-up (not in this PR)

- Cutover PR: switch backend `OIDC_ISSUER_URL` to `https://auth.dev.liverty-music.app`, add Pulumi `Zitadel{Application,Actions}` resources on top of the self-hosted instance, rip out the Zitadel Cloud tenant.
- Pin `zitadel-login` image to a validated git SHA for staging/prod (see [#201](https://github.com/liverty-music/cloud-provisioning/pull/201)).
