### PR TITLE
refactor(network): split api-gateway-cert into per-service certs

### DIFF
--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -334,30 +334,64 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{ parent: this, dependsOn: certManagerApi },
 			)
 
-			// Certificate Manager: Google-managed Certificate (covers api, web, auth)
-			const cert = new gcp.certificatemanager.Certificate(
-				'api-gateway-cert',
+			// Certificate Manager: per-service Google-managed Certificates.
+			//
+			// Each service owns a single-hostname Certificate rather than a
+			// shared SAN cert. Rationale:
+			//   - GCP managed certs treat `domains` / `dnsAuthorizations` as
+			//     immutable — adding a hostname forces a replace (delete+create).
+			//     Delete is blocked by any CertificateMapEntry still pointing at
+			//     the cert, producing a hard deadlock when onboarding a new
+			//     hostname (as we hit when adding `auth.<tld>` for Zitadel).
+			//   - Matches the per-service granularity already established for
+			//     DnsAuthorization, CertificateMapEntry, and DNS records.
+			//   - Isolates ACME provisioning / rate-limit / rotation failures to
+			//     a single hostname.
+			const backendServerCert = new gcp.certificatemanager.Certificate(
+				'backend-server-cert',
 				{
-					name: 'api-gateway-cert',
+					name: 'backend-server-cert',
 					location: 'global',
 					scope: 'DEFAULT',
 					managed: {
-						domains: [
-							`api.${managedZoneName}`,
-							`${managedZoneName}`,
-							`auth.${managedZoneName}`,
-						],
-						dnsAuthorizations: [
-							backendServerDnsAuth.id,
-							webAppDnsAuth.id,
-							zitadelDnsAuth.id,
-						],
+						domains: [`api.${managedZoneName}`],
+						dnsAuthorizations: [backendServerDnsAuth.id],
 					},
 				},
 				{ parent: this, dependsOn: certManagerApi },
 			)
 
-			// Certificate Manager: Certificate Map
+			const webAppCert = new gcp.certificatemanager.Certificate(
+				'web-app-cert',
+				{
+					name: 'web-app-cert',
+					location: 'global',
+					scope: 'DEFAULT',
+					managed: {
+						domains: [`${managedZoneName}`],
+						dnsAuthorizations: [webAppDnsAuth.id],
+					},
+				},
+				{ parent: this, dependsOn: certManagerApi },
+			)
+
+			const zitadelCert = new gcp.certificatemanager.Certificate(
+				'zitadel-cert',
+				{
+					name: 'zitadel-cert',
+					location: 'global',
+					scope: 'DEFAULT',
+					managed: {
+						domains: [`auth.${managedZoneName}`],
+						dnsAuthorizations: [zitadelDnsAuth.id],
+					},
+				},
+				{ parent: this, dependsOn: certManagerApi },
+			)
+
+			// Certificate Manager: Certificate Map. The map itself is shared
+			// across services — it is the binding between the Gateway listener
+			// and the per-hostname certs below.
 			const certMap = new gcp.certificatemanager.CertificateMap(
 				'api-gateway-cert-map',
 				{
@@ -372,7 +406,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{
 					name: 'backend-server-cert-map-entry',
 					map: certMap.name,
-					certificates: [cert.id],
+					certificates: [backendServerCert.id],
 					hostname: `api.${managedZoneName}`,
 				},
 				{ parent: this, dependsOn: certManagerApi },
@@ -384,7 +418,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{
 					name: 'zitadel-cert-map-entry',
 					map: certMap.name,
-					certificates: [cert.id],
+					certificates: [zitadelCert.id],
 					hostname: `auth.${managedZoneName}`,
 				},
 				{ parent: this, dependsOn: certManagerApi },
@@ -396,7 +430,7 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{
 					name: 'web-app-cert-map-entry',
 					map: certMap.name,
-					certificates: [cert.id],
+					certificates: [webAppCert.id],
 					hostname: `${managedZoneName}`,
 				},
 				{ parent: this, dependsOn: certManagerApi },
@@ -536,7 +570,6 @@ export class NetworkComponent extends pulumi.ComponentResource {
 
 			this.registerOutputs({
 				publicZoneNameservers: publicZone.nameServers,
-				certificate: cert.id,
 			})
 		}
 


### PR DESCRIPTION
## Summary

Fixes the `RESOURCE_STILL_IN_USE` failure that has blocked the dev Pulumi deployment since [#200](https://github.com/liverty-music/cloud-provisioning/pull/200) merged. Splits the shared SAN cert `api-gateway-cert` into three per-service Certificates (`backend-server-cert`, `web-app-cert`, `zitadel-cert`) and points each `CertificateMapEntry` at its own cert.

## Why

GCP Certificate Manager treats `managed.domains` / `managed.dnsAuthorizations` as immutable — adding a hostname forces a cert **replace (delete + create)**. Delete is blocked while any `CertificateMapEntry` still references the cert, producing a hard deadlock the first time a new service is onboarded to the shared cert.

PR #200 hit this deadlock when adding `auth.dev.liverty-music.app`:

```
gcp:certificatemanager:Certificate (api-gateway-cert):
  error: googleapi: Error 400: can't delete certificate that is referenced
  by a CertificateMapEntry or other resources
  RESOURCE_STILL_IN_USE
```

All other cert-related resources were already per-service (DnsAuthorization, MapEntry, DNS records). The Certificate was the sole shared piece; splitting it restores symmetry and prevents this deadlock from recurring when new services are added.

## Pulumi plan (preview verified)

```
+ backend-server-cert            (create)
+ web-app-cert                   (create)
+ zitadel-cert                   (create)
+ zitadel-cert-map-entry         (create, points to zitadel-cert)
~ backend-server-cert-map-entry  (in-place update: certificates)
~ web-app-cert-map-entry         (in-place update: certificates)
- api-gateway-cert               (delete after refs drop)

Totals: +4, ~2, -1, 201 unchanged
```

**Key safety point**: `CertificateMapEntry.certificates` is in-place updatable (preview shows `~ update`, **not** `+- replace`). Pulumi's dependency graph flips both existing MapEntries to their new per-service cert *before* deleting `api-gateway-cert`. No TLS downtime on `api.dev.liverty-music.app` or `dev.liverty-music.app`.

## State cleanliness

`pulumi stack export` confirms `api-gateway-cert` state is `[api.dev.liverty-music.app, dev.liverty-music.app]` only — `auth.` from PR #200 never made it into state because the failed run rolled back. No state surgery needed.

## Test plan

- [x] `pulumi preview --diff` matches the table above — no `replace`, no `RESOURCE_STILL_IN_USE`.
- [x] `make check` (biome + tsc) passes.
- [ ] After merge: Pulumi Cloud Deployments triggers automatically; monitor at https://app.pulumi.com/pannpers/liverty-music/dev/deployments.
- [ ] New certs transition to `ACTIVE` (`gcloud certificate-manager certificates list`).
- [ ] `curl -I https://auth.dev.liverty-music.app/debug/healthz` presents the new `zitadel-cert` (SAN = `auth.dev.liverty-music.app`).
- [ ] `api.dev.liverty-music.app` + `dev.liverty-music.app` continue to serve TLS during the cutover (no user-visible interruption).

## Follow-up (not in this PR)

- Zitadel pod init still blocks on `permission denied for database zitadel` (IAM user lacks DB ownership). Addressed in a separate K8s Job PR (OpenSpec §2.3).
