### PR TITLE
feat(zitadel): add Job granting DB ownership to IAM user

### DIFF
--- a/k8s/namespaces/zitadel/base/external-secret-postgres-admin.yaml
+++ b/k8s/namespaces/zitadel/base/external-secret-postgres-admin.yaml
@@ -1,0 +1,21 @@
+# Pulls the `postgres` built-in user's password from GCP Secret Manager
+# for the one-shot `zitadel-db-grant` Job to use. The same secret is
+# consumed by the atlas-operator namespace via a sibling ExternalSecret;
+# each namespace-scoped ESO pull produces its own opaque K8s Secret.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgres-admin-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: google-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: postgres-admin-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+  - secretKey: postgres-admin-password
+    remoteRef:
+      key: postgres-admin-password

--- a/k8s/namespaces/zitadel/base/job-grant-db.yaml
+++ b/k8s/namespaces/zitadel/base/job-grant-db.yaml
@@ -1,0 +1,117 @@
+# One-shot Job that grants database ownership to the IAM user Zitadel
+# connects as. Runs every sync via the ArgoCD `Sync` hook and is
+# idempotent (GRANT / ALTER OWNER are no-ops when already applied).
+#
+# Why this is needed:
+#   * Cloud SQL's CREATE DATABASE API runs as `cloudsqlsuperuser`, which
+#     owns the resulting database. IAM users created via `gcp.sql.User`
+#     get the `cloudsqliamuser` role but no ownership or CREATE on the
+#     pre-existing `zitadel` database.
+#   * Zitadel's `start-from-init` routine needs to CREATE SCHEMA
+#     (`projections`, `eventstore`, `system`, `auth`, `adminapi`) inside
+#     that database. Without ownership it fails with
+#     `permission denied for database zitadel (SQLSTATE 42501)`.
+#
+# Why not Pulumi:
+#   * Cloud SQL is PSC-only. Pulumi Cloud Deployments runs outside the
+#     VPC, so the `postgresql` provider can't reach the instance.
+#     Running grants from inside the cluster (this Job) mirrors the
+#     atlas-operator pattern backend already uses.
+#
+# The sidecar is a K8s 1.28+ native sidecar (`initContainers` with
+# `restartPolicy: Always`) so it terminates automatically when the main
+# container exits — required for Jobs.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zitadel-db-grant
+  annotations:
+    # ArgoCD re-runs this Job on every sync. The Job spec is immutable
+    # once created, so `Replace=true` is required for ArgoCD to delete
+    # and recreate it. `BeforeHookCreation` ensures the previous run is
+    # cleaned up before the new one starts.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-options: Replace=true
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: zitadel-db-grant
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: zitadel
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"
+      initContainers:
+      # Native sidecar. Terminates when the main container exits.
+      # No `--auto-iam-authn`: the Job authenticates as the built-in
+      # `postgres` superuser with a password (required to run
+      # `ALTER DATABASE OWNER` — IAM users lack that privilege).
+      - name: cloud-sql-proxy
+        restartPolicy: Always
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+        args:
+        - --psc
+        - --port=5432
+        - --address=127.0.0.1
+        - liverty-music-dev:asia-northeast2:postgres-osaka
+        ports:
+        - containerPort: 5432
+          name: postgres
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+      containers:
+      - name: psql
+        image: postgres:17-alpine
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          export PGPASSWORD="$POSTGRES_ADMIN_PASSWORD"
+
+          echo "db-grant: waiting for cloud-sql-proxy tunnel..."
+          for i in $(seq 1 30); do
+            if psql -h 127.0.0.1 -p 5432 -U postgres -d postgres \
+                 -c 'SELECT 1' >/dev/null 2>&1; then
+              echo "db-grant: tunnel ready"
+              break
+            fi
+            sleep 2
+          done
+
+          echo "db-grant: applying grants to 'zitadel' database..."
+          psql -h 127.0.0.1 -p 5432 -U postgres -d zitadel \
+               -v ON_ERROR_STOP=1 <<'SQL'
+          ALTER DATABASE zitadel OWNER TO "zitadel@liverty-music-dev.iam";
+          GRANT ALL ON SCHEMA public TO "zitadel@liverty-music-dev.iam";
+          SQL
+
+          echo "db-grant: done"
+        env:
+        - name: POSTGRES_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-admin-credentials
+              key: postgres-admin-password
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false

--- a/k8s/namespaces/zitadel/base/kustomization.yaml
+++ b/k8s/namespaces/zitadel/base/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
 - httproute.yaml
 - pdb.yaml
 - external-secret.yaml
+- external-secret-postgres-admin.yaml
+- job-grant-db.yaml
 
 configMapGenerator:
 - name: zitadel-config


### PR DESCRIPTION
## Summary

Unblocks Zitadel init by granting `zitadel@liverty-music-dev.iam` ownership of the `zitadel` database. Addresses OpenSpec §2.3 (IAM user DB ownership grant).

## Why

After [#200](https://github.com/liverty-music/cloud-provisioning/pull/200) + [#202](https://github.com/liverty-music/cloud-provisioning/pull/202), Zitadel connects successfully as the IAM user but crashes at schema init:

```
INFO  config.database.postgres.user.username is same as admin.username, skipping create user
INFO  database is same as admin.ExistingDatabase, skipping creation
INFO  verify zitadel
ERROR initialize ZITADEL failed: ERROR: permission denied for database zitadel (SQLSTATE 42501)
```

Root cause: Cloud SQL's `CREATE DATABASE` API runs as `cloudsqlsuperuser`, which becomes the owner. IAM users (created via `gcp.sql.User`) get `cloudsqliamuser` but no ownership or CREATE on pre-existing databases. Zitadel cannot create its schemas (`projections`, `eventstore`, `system`, `auth`, `adminapi`).

## How

A one-shot K8s Job authenticates as the built-in `postgres` superuser (password from GSM via ESO) and runs:

```sql
ALTER DATABASE zitadel OWNER TO "zitadel@liverty-music-dev.iam";
GRANT ALL ON SCHEMA public TO "zitadel@liverty-music-dev.iam";
```

Both statements are idempotent, so the Job can re-run on every sync without side effects.

### Key design choices

| Choice | Reason |
|---|---|
| K8s Job (not Pulumi) | Cloud SQL is PSC-only. Pulumi Cloud Deployments runs outside the VPC, so its `postgresql` provider cannot reach the instance. Mirrors the atlas-operator pattern already used by backend. |
| Cloud SQL Auth Proxy **without** `--auto-iam-authn` | IAM users cannot run `ALTER DATABASE OWNER`. The Job must authenticate as the built-in `postgres` superuser, which requires password auth at the Postgres protocol level. The proxy still uses the zitadel KSA's Workload Identity to reach Cloud SQL via PSC. |
| Native sidecar (`initContainers` + `restartPolicy: Always`) | Cloud SQL Auth Proxy runs as a sidecar for the psql container. Without native sidecar semantics (K8s 1.28+; cluster is 1.35), the Job would never reach `Completed` because a regular sidecar container wouldn't terminate when the main container exits. |
| ArgoCD `Sync` hook + `Replace=true` | Job spec is immutable once created. The `Replace=true` + `BeforeHookCreation` combo lets ArgoCD delete and re-create the Job on each sync. |

## Files

- `k8s/namespaces/zitadel/base/external-secret-postgres-admin.yaml` — ExternalSecret pulling `postgres-admin-password` from GSM into the zitadel namespace (sibling to the atlas-operator namespace's existing ExternalSecret).
- `k8s/namespaces/zitadel/base/job-grant-db.yaml` — the one-shot Job.
- `k8s/namespaces/zitadel/base/kustomization.yaml` — register both new resources.

## Test plan

- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders cleanly (Job + ExternalSecret appear with correct nodeSelector, resources, securityContext).
- [x] `make check` passes.
- [ ] Post-merge: ArgoCD syncs → `zitadel-db-grant` Job runs → `psql` logs `db-grant: done` → Job reaches `Completed`. Next zitadel Deployment restart proceeds past the schema-init phase.
- [ ] `zitadel-admin-sa-key` GSM secret gains its first version (bootstrap-uploader sidecar on the first successful zitadel pod).

## Independence from #203

This PR and [#203](https://github.com/liverty-music/cloud-provisioning/pull/203) (per-service cert refactor) address two independent blockers:
- #203: TLS cert for `auth.dev.liverty-music.app` (ingress layer).
- This PR: DB ownership for `zitadel@...iam` (data layer).

They can merge in any order. Zitadel won't serve TLS until #203 lands; Zitadel pods won't reach `Ready` until this PR lands.
