### PR TITLE
fix(zitadel): grant IAM role to postgres before DB ownership transfer

### DIFF
--- a/k8s/namespaces/zitadel/base/job-grant-db.yaml
+++ b/k8s/namespaces/zitadel/base/job-grant-db.yaml
@@ -93,8 +93,15 @@ spec:
           done
 
           echo "db-grant: applying grants to 'zitadel' database..."
+          # Cloud SQL's built-in `postgres` is `cloudsqlsuperuser` — not
+          # a true PG SUPERUSER. ALTER DATABASE OWNER therefore requires
+          # the current user to be a member of the new owner role.
+          # `cloudsqlsuperuser` implicitly has ADMIN OPTION on
+          # `cloudsqliamuser` (which every IAM user inherits), so it can
+          # grant the IAM role to itself to unlock the ownership transfer.
           psql -h 127.0.0.1 -p 5432 -U postgres -d zitadel \
                -v ON_ERROR_STOP=1 <<'SQL'
+          GRANT "zitadel@liverty-music-dev.iam" TO postgres;
           ALTER DATABASE zitadel OWNER TO "zitadel@liverty-music-dev.iam";
           GRANT ALL ON SCHEMA public TO "zitadel@liverty-music-dev.iam";
           SQL


### PR DESCRIPTION
## Summary

Fixes the `zitadel-db-grant` Job from [#204](https://github.com/liverty-music/cloud-provisioning/pull/204) which failed on first run with:

```
db-grant: applying grants to 'zitadel' database...
ERROR:  must be able to SET ROLE "zitadel@liverty-music-dev.iam"
```

## Root cause

Cloud SQL's built-in `postgres` user is `cloudsqlsuperuser`, not a true PG SUPERUSER. PostgreSQL requires the session user to be a member of the target role before it can `ALTER DATABASE ... OWNER TO` that role. `cloudsqlsuperuser` is not implicitly a member of any IAM role.

## Fix

Grant `zitadel@liverty-music-dev.iam` to `postgres` before the ownership transfer. This is permitted because `cloudsqlsuperuser` has ADMIN OPTION implicit on `cloudsqliamuser`, which every IAM user inherits ([Cloud SQL IAM docs](https://cloud.google.com/sql/docs/postgres/add-manage-iam-users)). With membership in place, the ownership transfer and subsequent schema GRANT succeed.

The `GRANT role TO role` statement is idempotent (no-op on re-run).

## Test plan

- [x] `kustomize build` renders cleanly.
- [ ] Post-merge: ArgoCD re-syncs → Job re-runs → completes → `zitadel` API pods transition out of CrashLoopBackOff.
