### PR TITLE
fix(zitadel): disable K8s service-env injection on API Deployment

### DIFF
--- a/k8s/namespaces/zitadel/base/deployment-api.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-api.yaml
@@ -27,6 +27,14 @@ spec:
     spec:
       serviceAccountName: zitadel
       terminationGracePeriodSeconds: 60
+      # Disable K8s legacy service-discovery env vars. Without this, the
+      # `zitadel` Service in this namespace injects `ZITADEL_PORT=tcp://<ip>:80`
+      # into every pod, which Viper then parses as the top-level Zitadel
+      # config field `Port` (expected uint16) — causing startup to fail with
+      # `'Port' cannot parse value as 'uint16': strconv.ParseUint: invalid syntax`.
+      # DNS-based service discovery (zitadel.zitadel.svc.cluster.local) works
+      # regardless of this flag.
+      enableServiceLinks: false
       # Keep both replicas on different nodes so a single Spot preemption
       # cannot take the entire API plane down.
       affinity:


### PR DESCRIPTION
## Summary

Fixes a Zitadel startup crash that surfaces after the DB-grant Job from [#204](https://github.com/liverty-music/cloud-provisioning/pull/204) + [#205](https://github.com/liverty-music/cloud-provisioning/pull/205) unblocks schema init. Zitadel now reaches `setup completed`, then dies with:

```
unable to read config: decoding failed due to the following error(s):
'Port' cannot parse value as 'uint16': strconv.ParseUint: invalid syntax
```

## Root cause

Kubernetes legacy service-discovery env injection. The `zitadel` Service in the same namespace auto-injects env vars into every pod in the namespace. Confirmed via `printenv` inside the bootstrap-uploader sidecar:

```
ZITADEL_PORT=tcp://10.30.2.221:80
ZITADEL_SERVICE_HOST=10.30.2.221
ZITADEL_SERVICE_PORT=80
ZITADEL_PORT_80_TCP=tcp://10.30.2.221:80
```

The main Zitadel binary uses Viper with `envPrefix: ZITADEL`. The top-level `Port` field (default `8080`, a `uint16`) binds to `ZITADEL_PORT` — so the K8s-injected value `tcp://<ip>:80` overrides it and fails the uint16 parse before the server can start.

The init phase succeeds because `start-from-init` only evaluates `Port` on the `start` sub-phase (after migrations run), which is why we see "setup completed" and then the crash.

## Fix

Set `enableServiceLinks: false` on the API pod spec. This disables K8s legacy env injection for that pod. DNS-based service discovery (`zitadel.zitadel.svc.cluster.local`) keeps working — the login Deployment already uses that DNS form explicitly in `ZITADEL_API_URL`.

## Scope

Only the API Deployment. The login container reads its own `ZITADEL_API_URL` explicitly and is already Running, so its behavior is unaffected by the env injection.

## Test plan

- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders `enableServiceLinks: false` on the API pod spec.
- [ ] Post-merge: ArgoCD re-syncs → API pods restart → `start` sub-phase completes → pods reach Ready.
- [ ] `curl -sk https://auth.dev.liverty-music.app/debug/healthz` returns 200 (after `zitadel-cert` reaches ACTIVE).
