### PR TITLE
fix(zitadel): add GCP HealthCheckPolicy for API + Login backends

### DIFF
--- a/k8s/namespaces/zitadel/base/healthcheckpolicy.yaml
+++ b/k8s/namespaces/zitadel/base/healthcheckpolicy.yaml
@@ -1,0 +1,50 @@
+# GCP Gateway health checks for Zitadel API and Login V2 UI.
+#
+# The default GCLB health check for a NEG-backed Service probes `GET /`
+# expecting a 2xx response. Both Zitadel components serve non-2xx on `/`:
+#   * API (`/`)          → 302 (redirect to login)
+#   * Login V2 (`/`)     → 404 (only `/ui/v2/login/*` is served)
+# …so GCLB marks every endpoint UNHEALTHY and the Gateway returns 503
+# regardless of whether the pods are K8s-Ready.
+#
+# Explicit HealthCheckPolicy resources override the probe path to match
+# each component's actual health endpoint. Mirrors the pattern used by
+# `backend/server-policy` (see k8s/namespaces/backend/base/server/).
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: zitadel-api-policy
+  labels:
+    app: zitadel
+    component: api
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 8080
+        requestPath: /debug/healthz
+  targetRef:
+    group: ""
+    kind: Service
+    name: zitadel
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: zitadel-login-policy
+  labels:
+    app: zitadel
+    component: login
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 3000
+        requestPath: /ui/v2/login
+  targetRef:
+    group: ""
+    kind: Service
+    name: zitadel-login

--- a/k8s/namespaces/zitadel/base/kustomization.yaml
+++ b/k8s/namespaces/zitadel/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - service-api.yaml
 - service-login.yaml
 - httproute.yaml
+- healthcheckpolicy.yaml
 - pdb.yaml
 - external-secret.yaml
 - external-secret-postgres-admin.yaml


### PR DESCRIPTION
## Summary

With [#206](https://github.com/liverty-music/cloud-provisioning/pull/206) landed and both Zitadel pods at `3/3 Running`, the Gateway still returns 503:

```
$ curl -I https://auth.dev.liverty-music.app/debug/healthz
HTTP/2 503

$ gcloud compute backend-services get-health \
    gkegw1-2l4b-zitadel-zitadel-80-iw0k8akgne8t --global
healthState: UNHEALTHY (both endpoints)
```

## Root cause

GCLB's default health check for a NEG-backed Service probes `GET /` expecting a 2xx response. Neither Zitadel component returns 2xx on `/`:

| Component | `/` response |
|---|---|
| API (`zitadel` svc) | 302 (redirect to `/ui/console`) |
| Login V2 (`zitadel-login` svc) | 404 (only `/ui/v2/login/*` served) |

K8s readiness probes succeed on the pods' own specific paths (the pods show Ready 3/3), but GCLB uses its own HTTP probe and doesn't honor the Deployment's `readinessProbe` config.

## Fix

Explicit `HealthCheckPolicy` resources (`networking.gke.io/v1`) overriding the probe to match each component's health endpoint:

| Policy | Target Service | Probe |
|---|---|---|
| `zitadel-api-policy` | `zitadel` | `HTTP GET /debug/healthz` on :8080 |
| `zitadel-login-policy` | `zitadel-login` | `HTTP GET /ui/v2/login` on :3000 |

Mirrors the existing `backend/server-policy` pattern in the same cluster.

## Test plan

- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders both `HealthCheckPolicy` resources.
- [ ] Post-merge: ArgoCD syncs → GCLB applies new health check → `backend-services get-health` reports both endpoints `HEALTHY` → `curl -I https://auth.dev.liverty-music.app/debug/healthz` returns 200.
