### PR TITLE
feat(infra): shrink dev GKE boot disks and Zitadel replicas to cut Compute Engine cost

### DIFF
--- a/k8s/namespaces/zitadel/overlays/dev/deployment-login-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/deployment-login-patch.yaml
@@ -1,11 +1,12 @@
-# Dev overlay for the Zitadel Login V2 Deployment — same spot posture as the
-# API deployment.
+# Dev overlay for the Zitadel Login V2 Deployment — same posture as the
+# API deployment: replicaCount 1 + spot-pool nodeSelector. The base PDB is
+# relaxed to minAvailable=0 in pdb-patch.yaml.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zitadel-login
 spec:
-  replicas: 2
+  replicas: 1
   template:
     spec:
       nodeSelector:

--- a/k8s/namespaces/zitadel/overlays/dev/deployment-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/deployment-patch.yaml
@@ -1,12 +1,14 @@
 # Dev overlay for the Zitadel API Deployment:
-#   - replicaCount 2 to satisfy PDB minAvailable=1 + honor D8 design
-#   - spot-pool nodeSelector to match the cluster cost posture
+#   - replicaCount 1 to keep dev Compute Engine cost low; the base PDB is
+#     relaxed to minAvailable=0 in pdb-patch.yaml so a single replica can
+#     still be voluntarily evicted (Spot preemption, node drain, rollouts).
+#   - spot-pool nodeSelector to match the cluster cost posture.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zitadel
 spec:
-  replicas: 2
+  replicas: 1
   template:
     spec:
       nodeSelector:

--- a/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
@@ -20,3 +20,6 @@ patches:
   target:
     kind: Deployment
     name: zitadel-login
+# Relax both PDBs to minAvailable=0 so the single dev replica can be
+# voluntarily evicted (rollout, drain, Spot preemption).
+- path: pdb-patch.yaml

--- a/k8s/namespaces/zitadel/overlays/dev/pdb-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/pdb-patch.yaml
@@ -1,0 +1,23 @@
+# Dev overlay relaxes both Zitadel PDBs to minAvailable=0. With dev replicas
+# reduced to 1 (deployment-patch.yaml, deployment-login-patch.yaml), the base
+# minAvailable=1 would permanently block voluntary disruption — Spot
+# preemption graceful drain, node auto-upgrade, and rolling updates would all
+# stall waiting for a second pod that never exists.
+#
+# Setting minAvailable=0 keeps the PDB resource present (so prod/staging
+# still inherit the base minAvailable=1) while letting dev evict its single
+# pod cleanly. The next pod starts on whichever node satisfies the spot
+# nodeSelector; brief (≤90s) downtime per disruption is acceptable for dev.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zitadel
+spec:
+  minAvailable: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zitadel-login
+spec:
+  minAvailable: 0

--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -466,6 +466,18 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 					nodeConfig: {
 						machineType: 'e2-medium',
 						spot: true,
+						// 30 GB pd-standard. The GKE default is 100 GB pd-balanced,
+						// which dominated dev Compute Engine cost (~45% of the SKU
+						// at 3 nodes). E2 does not support any Hyperdisk variant
+						// (per cloud.google.com/compute/docs/disks/hyperdisks), so
+						// pd-standard is the cheapest available type for this
+						// machine series. 30 GB is GKE's recommended minimum and
+						// comfortably fits the cluster's image cache (Zitadel +
+						// cloud-sql-proxy + backend + frontend + ArgoCD + KEDA +
+						// Atlas + ESO + Reloader + OTel) without triggering
+						// DiskPressure evictions.
+						diskSizeGb: 30,
+						diskType: 'pd-standard',
 						serviceAccount: gkeNodeSa.email,
 						oauthScopes: [
 							'https://www.googleapis.com/auth/cloud-platform',


### PR DESCRIPTION
## Summary

- Shrink dev GKE Spot node pool boot disks: 100 GB pd-balanced → **30 GB pd-standard** (E2 doesn't support Hyperdisk; pd-standard is the cheapest E2-compatible type).
- Drop Zitadel API + Login replicas in the dev overlay: 2 → 1, plus relax both PDBs to `minAvailable: 0` so the single replica can still be drained.
- Targets ~¥5,500/month savings on dev Compute Engine SKU (currently ¥9,953/month, ↑1403% in last 30 days).

## Context

Investigation traced the Apr 16+ Compute Engine spike to: (a) GKE NodePool boot disk defaults of 100 GB pd-balanced × 3 nodes ≈ ¥4,500/month, and (b) the Apr 21–22 self-hosted Zitadel deployment (4 replicas with `requiredDuringSchedulingIgnoredDuringExecution` hostname anti-affinity) forcing `maxNodeCount: 2 → 3`. With dev replicas dropped to 1, the autoscaler should be able to compact back to 2 nodes once load is idle.

Full proposal / design / specs: [openspec/changes/optimize-dev-gke-cost](https://github.com/liverty-music/specification/tree/main/openspec/changes/optimize-dev-gke-cost) (separate PR on the specification repo).

## Deployment behavior (verified)

`pulumi preview --stack dev` showed:

```
~ gcp:container/nodePool:NodePool: (update) spot-pool-osaka
  ~ nodeConfig: {
      ~ diskSizeGb: 100 => 30
      ~ diskType  : "pd-balanced" => "pd-standard"
    }
Resources: 1 to update, 206 unchanged
```

The change is `~ update` (in-place), not `+- replace`. GKE will roll out the new disk template via surge upgrade — one node at a time, respecting PDBs. With dev PDBs relaxed to `minAvailable: 0`, the single Zitadel/backend/frontend replica drains cleanly. Expected user-visible downtime per pod: <90s during its eviction window.

## Test plan

- [x] `make check` (lint-ts) passes
- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders correct diff: replicas=1, minAvailable=0, spot nodeSelector + `enableServiceLinks: false` preserved
- [x] `kube-linter` on rendered zitadel overlay: zero errors
- [x] `pulumi preview --stack dev` shows 1 update, 206 unchanged — diff scoped exclusively to spot-pool-osaka.nodeConfig
- [ ] Post-merge: monitor auto-`pulumi up` on Pulumi Cloud Deployments
- [ ] Post-merge: `gcloud compute disks list` shows all spot node disks at SIZE_GB=30 / TYPE=pd-standard
- [ ] Post-merge: `kubectl get deploy -n zitadel` shows both Deployments at 1/1
- [ ] Post-merge: `kubectl get pdb -n zitadel` shows both PDBs at MIN AVAILABLE=0
- [ ] Post-merge (after autoscaler idle threshold ~15 min): node count = 2 (target) or 3 (acceptable if other workloads pin a 3rd)
- [ ] +7 days: GCP Billing report shows Compute Engine SKU ≥50% reduction
