### PR TITLE
feat(infra): override kube-dns-autoscaler in dev to drop replicas to 1

### DIFF
--- a/k8s/cluster/overlays/dev/kube-dns-autoscaler.yaml
+++ b/k8s/cluster/overlays/dev/kube-dns-autoscaler.yaml
@@ -1,0 +1,31 @@
+# Dev override for the GKE-managed kube-dns-autoscaler ConfigMap.
+#
+# The cluster-proportional-autoscaler reads `data.linear` as a single JSON
+# string. We replace the entire string here so all linear-policy fields are
+# explicit; the only behavioral change vs. GKE's default is flipping
+# `preventSinglePointFailure` from `true` to `false`.
+#
+# Why dev-only:
+#   - With 6 vCPU / 3 spot nodes, the formula
+#       max(ceil(6/256), ceil(3/16), 1)
+#     yields 1 desired kube-dns replica. GKE's `preventSinglePointFailure: true`
+#     forces ≥2 instead, costing ~270m CPU and pinning a 3rd spot node that
+#     the cluster autoscaler would otherwise retire.
+#   - Disabling the guard accepts brief DNS gaps during pod reschedule
+#     (Spot preemption, drain). `node-local-dns` cache + client retries
+#     hide this for typical dev workloads. Unacceptable for prod/staging,
+#     so this override stays scoped to the dev overlay.
+#
+# Source-of-truth notes:
+#   - GKE doc explicitly endorses ConfigMap edits for kube-dns scaling:
+#     https://cloud.google.com/kubernetes-engine/docs/concepts/kube-dns
+#   - ArgoCD's `core` Application syncs this overlay continuously
+#     (sync-wave: 1, automated.selfHeal: true), so any GKE-side reset
+#     during cluster upgrades is reverted within minutes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+data:
+  linear: '{"coresPerReplica":256,"includeUnschedulableNodes":true,"nodesPerReplica":16,"preventSinglePointFailure":false}'

--- a/k8s/cluster/overlays/dev/kustomization.yaml
+++ b/k8s/cluster/overlays/dev/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../../base
+- kube-dns-autoscaler.yaml
 
 patches:
 - path: cluster-secret-store-patch.yaml


### PR DESCRIPTION
## Summary

Override the GKE-managed `kube-dns-autoscaler` ConfigMap in the dev cluster overlay so that `preventSinglePointFailure: false`. Drops `kube-dns` from 2 → 1 replica (~270m CPU freed), unblocking the cluster autoscaler from retiring the 3rd spot node — the remaining ~¥1,300/month cost gap that [optimize-dev-gke-cost](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-04-28-optimize-dev-gke-cost) couldn't close on its own.

## Why ConfigMap edit (not a custom kube-dns Deployment)

GCP's [About kube-dns for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/kube-dns) explicitly documents the ConfigMap as the supported tuning knob:

> *"You can modify the number of kube-dns replicas by editing the kube-dns-autoscaler ConfigMap."*

The heavier alternative ([Set up a custom kube-dns Deployment](https://cloud.google.com/kubernetes-engine/docs/how-to/custom-kube-dns)) requires scaling GKE's managed kube-dns + autoscaler to 0 and accepting ongoing maintenance ownership — overkill for flipping a single boolean.

## Files

- `k8s/cluster/overlays/dev/kube-dns-autoscaler.yaml` (new) — full ConfigMap manifest with explicit `data.linear` JSON.
- `k8s/cluster/overlays/dev/kustomization.yaml` — register the new manifest in `resources`.

ArgoCD's existing `core` Application (path `k8s/cluster/overlays/dev`, `automated.selfHeal: true`) picks this up automatically and reconciles drift, so any GKE-side reset during cluster upgrades is corrected within minutes.

## Scope

- **Dev only**: prod and staging continue with GKE's default `preventSinglePointFailure: true`. The override is in the dev overlay only.
- **No Pulumi changes**: in-cluster manifest only.
- **No prod/staging touch**.

## Validation

- [x] `kubectl kustomize k8s/cluster/overlays/dev` renders the new ConfigMap with `preventSinglePointFailure:false`; existing 2 ClusterSecretStore resources unchanged.
- [x] `make check` (lint-ts) exits 0.
- [x] `kube-linter lint` on rendered overlay: zero errors.

## Test plan

- [ ] CI green
- [ ] Post-merge: ArgoCD `core` Application reaches Synced/Healthy
- [ ] Post-merge: `kubectl get configmap kube-dns-autoscaler -n kube-system -o jsonpath='{.data.linear}'` contains `"preventSinglePointFailure":false`
- [ ] Post-merge (within ~60 s): `kubectl get deployment kube-dns -n kube-system` shows `1/1` ready
- [ ] Post-merge (after ~10 min idle threshold): `kubectl get nodes -l cloud.google.com/gke-spot=true` shows 2 nodes
- [ ] Post-merge: `gcloud compute disks list --filter='name~^gke-standard-cluster--spot-pool'` shows 2 disks at 30 GB pd-standard

## Expected savings

~¥1,300/month from retiring the 3rd e2-medium spot VM + 30 GB pd-standard boot disk + external IPv4. Combined with the prior boot-disk shrink (~¥3,800/month already realized), this lands the dev Compute Engine SKU at ~¥4,400/month from the original ¥9,953/month — meeting the original ≥50% reduction target.

The 2026-05-04 09:00 JST scheduled remote agent ([routine](https://claude.ai/code/routines/trig_019bjiY5CoQUYsPkVfxnNGTW)) will pick up the combined effect in its verification issue.
