### PR TITLE
fix(zitadel): use POST for UpdateTarget API call

### DIFF
--- a/src/zitadel/dynamic/target.ts
+++ b/src/zitadel/dynamic/target.ts
@@ -124,7 +124,7 @@ const targetProvider: pulumi.dynamic.ResourceProvider = {
 		const res = await zitadelApiCall({
 			domain: news.domain,
 			profile,
-			method: 'PATCH',
+			method: 'POST',
 			path: `/v2/actions/targets/${id}`,
 			body: {
 				name: news.name,


### PR DESCRIPTION
## Summary

Fix HTTP method bug in our Pulumi Dynamic Resource for Zitadel Actions v2 Targets:

- The `update` handler used `PATCH` against `/v2/actions/targets/{id}`
- Zitadel's [UpdateTarget endpoint](https://zitadel.com/docs/reference/api/action/zitadel.action.v2.ActionService.UpdateTarget) expects `POST`
- Result: every Target update returned HTTP 405 Method Not Allowed

## Why now

The post-cutover state recovery (PR #209 + manual `pulumi stack import`) introduced a re-encryption diff on the `jwtProfileJson` input — secret ciphertexts rotate on each ESC encrypt operation, so Pulumi's diff layer flagged it as `[secret] => [secret]` even though the plaintext is identical. That triggered the first ever UpdateTarget call against this code path, which surfaced the latent PATCH→POST bug.

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [x] Verified Zitadel v2 API docs require POST for `/v2/actions/targets/{id}` update
- [ ] Auto-deploy on merge: `pre-access-token-webhook` and `auto-verify-email-webhook` updates succeed (no more 405)
- [ ] Pulumi state stops reporting these two resources as `updating failed`

## Risk

- Diff-only fix, no resource recreation
- The two affected dynamic resources have already been created successfully via POST in deployments #248/#249 — only the Update path is changed here
