### PR TITLE
fix(zitadel): send Execution targets as array of strings

### DIFF
--- a/src/zitadel/dynamic/execution.ts
+++ b/src/zitadel/dynamic/execution.ts
@@ -46,7 +46,7 @@ async function setExecution(opts: {
 		path: '/v2/actions/executions',
 		body: {
 			condition: opts.condition,
-			targets: opts.targetIds.map((id) => ({ target: id })),
+			targets: opts.targetIds,
 		},
 	})
 	if (res.statusCode < 200 || res.statusCode >= 300) {


### PR DESCRIPTION
## Summary

Fix the `targets` field shape in our Pulumi Dynamic Resource for Zitadel Actions v2 Executions:

- The `setExecution` helper sent `targets: targetIds.map(id => ({ target: id }))`
- Zitadel's [SetExecution endpoint](https://zitadel.com/docs/apis/resources/action_service_v2/action-service-set-execution) expects `targets: string[]` (plain array of target IDs)
- Result: HTTP 400 `proto: invalid value for string field targets: {`

## Why now

This is the second bug surfaced by the post-cutover state recovery. PR #211 fixed the Targets PATCH→POST issue, which let deploy #252 progress to the Execution creates. The Executions then surfaced this latent shape bug — both `pre-access-token-execution` and `auto-verify-email-execution` failed with the same proto error.

Together these two fixes (#211 + this PR) complete the dynamic resource bring-up.

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [x] Verified Zitadel API spec: `targets?array<string>`
- [ ] Auto-deploy on merge: both Executions create successfully
- [ ] Pulumi state shows `+ 2 created` for the Executions

## Risk

- Single-line shape fix
- The two affected resources have never been successfully created — this is a CREATE path, no replacement risk
- If Update is called later with the new shape, Zitadel will accept it the same way as Create
