### PR TITLE
feat(zitadel): provision login-client PAT for self-hosted Login V2 UI

### DIFF
--- a/k8s/namespaces/zitadel/base/deployment-login.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-login.yaml
@@ -60,6 +60,21 @@ spec:
           value: http://zitadel.zitadel.svc.cluster.local
         - name: NEXT_PUBLIC_BASE_PATH
           value: /ui/v2/login
+        # Personal Access Token used by the Login V2 UI Next.js server to
+        # authenticate against the Zitadel API for SSR-side calls (instance
+        # settings, cross-org user search, session management). Provisioned
+        # by Pulumi `LoginClientComponent`, mirrored from GSM into a K8s
+        # Secret by `external-secret-login-pat.yaml`, mounted as a file —
+        # not as an env var — so it does not appear in `kubectl describe pod`
+        # output.
+        # Upstream contract:
+        #   https://zitadel.com/docs/self-hosting/manage/login-client
+        - name: ZITADEL_SERVICE_USER_TOKEN_FILE
+          value: /var/run/zitadel/login-client.pat
+        volumeMounts:
+        - name: login-pat
+          mountPath: /var/run/zitadel
+          readOnly: true
         readinessProbe:
           httpGet:
             path: /ui/v2/login
@@ -83,3 +98,13 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+      volumes:
+      - name: login-pat
+        secret:
+          secretName: zitadel-login-pat
+          # `secretKey: token` (set in external-secret-login-pat.yaml) lands
+          # the PAT at /var/run/zitadel/token by default. Project it to
+          # `login-client.pat` to match ZITADEL_SERVICE_USER_TOKEN_FILE.
+          items:
+          - key: token
+            path: login-client.pat

--- a/k8s/namespaces/zitadel/base/external-secret-login-pat.yaml
+++ b/k8s/namespaces/zitadel/base/external-secret-login-pat.yaml
@@ -1,0 +1,27 @@
+# Pulls the Login V2 client's Personal Access Token from GCP Secret Manager
+# (provisioned by Pulumi `LoginClientComponent` → KubernetesComponent
+# `esoOnlySecrets`) and exposes it as a Kubernetes Secret in the zitadel
+# namespace. The `zitadel-login` Pod mounts this Secret as a file referenced
+# by `ZITADEL_SERVICE_USER_TOKEN_FILE`, per the upstream Login V2 contract:
+#   https://zitadel.com/docs/self-hosting/manage/login-client
+#
+# `secretKey: token` is the in-cluster K8s Secret key. The file path
+# `/var/run/zitadel/login-client.pat` (set on deployment-login.yaml) is what
+# the env var ZITADEL_SERVICE_USER_TOKEN_FILE points at.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: zitadel-login-pat
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: google-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: zitadel-login-pat
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+  - secretKey: token
+    remoteRef:
+      key: zitadel-login-pat

--- a/k8s/namespaces/zitadel/base/kustomization.yaml
+++ b/k8s/namespaces/zitadel/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - pdb.yaml
 - external-secret.yaml
 - external-secret-postgres-admin.yaml
+- external-secret-login-pat.yaml
 - job-grant-db.yaml
 
 configMapGenerator:

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -29,6 +29,10 @@ export interface GcpArgs {
 	postmarkConfig: PostmarkDnsConfig
 	/** Zitadel machine key JWT profile JSON. Stored in Secret Manager for backend use. */
 	zitadelMachineKey?: pulumi.Output<string>
+	/** Personal Access Token for the zitadel-login (Login V2 UI) container.
+	 *  Stored in Secret Manager and mounted into the zitadel-login pod via
+	 *  ExternalSecret as a file referenced by `ZITADEL_SERVICE_USER_TOKEN_FILE`. */
+	zitadelLoginPat?: pulumi.Output<string>
 }
 
 export const NetworkConfig = {
@@ -79,6 +83,7 @@ export class Gcp {
 			cloudflareConfig,
 			postmarkConfig,
 			zitadelMachineKey,
+			zitadelLoginPat,
 		} = args
 
 		const cloudSqlUsers = gcpConfig.cloudSqlUsers ?? []
@@ -234,6 +239,19 @@ export class Gcp {
 								value: pulumi.secret(
 									gcpConfig.argocdGoogleChatWebhookUrl,
 								),
+							},
+						]
+					: []),
+				// PAT consumed only by the zitadel-login pod (Login V2 UI). ESO in
+				// the `zitadel` namespace mirrors this into a K8s Secret which the
+				// pod mounts as a file referenced by ZITADEL_SERVICE_USER_TOKEN_FILE.
+				// Backend-app does not need access — the backend talks to Zitadel
+				// via its own JWT-key (zitadel-machine-key), not this PAT.
+				...(zitadelLoginPat
+					? [
+							{
+								name: 'zitadel-login-pat',
+								value: pulumi.secret(zitadelLoginPat),
 							},
 						]
 					: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ if (env === 'prod') {
 // the env guard inside the Zitadel class throws if invoked from staging /
 // prod until those environments get their own self-hosted instance.
 let zitadelMachineKey: pulumi.Output<string> | undefined
+let zitadelLoginPat: pulumi.Output<string> | undefined
 if (env === 'dev') {
 	const zitadel = new Zitadel('liverty-music', {
 		env,
@@ -61,6 +62,7 @@ if (env === 'dev') {
 		postmarkServerApiToken: postmarkConfig.serverApiToken,
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails
+	zitadelLoginPat = zitadel.loginClientToken
 }
 
 // 2. GCP Infrastructure (All Environments)
@@ -75,6 +77,7 @@ const gcp = new Gcp({
 	cloudflareConfig,
 	postmarkConfig,
 	zitadelMachineKey,
+	zitadelLoginPat,
 })
 
 // 5. Self-hosted Zitadel infra phase (dev only).

--- a/src/zitadel/components/login-client.ts
+++ b/src/zitadel/components/login-client.ts
@@ -1,0 +1,115 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface LoginClientComponentArgs {
+	/** Org to host the machine user. The role granted below is instance-wide,
+	 *  so org choice is purely organizational. We use the same org as the
+	 *  application machine users to keep service identities co-located. */
+	orgId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * LoginClientComponent provisions a Zitadel Machine User with a Personal
+ * Access Token (PAT) for the self-hosted `zitadel-login` (Login V2 UI
+ * Next.js) container to authenticate against the Zitadel API.
+ *
+ * Required by Zitadel for self-hosted Login V2 — the Login UI must call
+ * privileged settings + cross-org user-search APIs at SSR time, which a
+ * regular OIDC end-user token cannot do. See:
+ *   https://zitadel.com/docs/self-hosting/manage/login-client
+ *
+ * Permissions: `IAM_LOGIN_CLIENT` granted at instance level (not org).
+ *   - Limited but elevated: instance settings read, cross-org user
+ *     lookups, session creation, password / IDP intent verification.
+ *   - Strictly less than `IAM_OWNER` (which the bootstrap admin SA holds).
+ *
+ * Authentication: Personal Access Token with **no expirationDate** (dev
+ * only). Rationale:
+ *   - Zitadel's PAT is the upstream-supported auth method for the Login
+ *     V2 container. JWT-key auth is not implemented in `zitadel-login`.
+ *   - Setting an expiration on dev would create a "silent breakage on day
+ *     N" failure mode that's strictly worse than no expiration here. The
+ *     dev blast radius (no real user data) makes long-lived OK.
+ *   - Production must set `expirationDate` and implement rotation —
+ *     either via Cloud Monitoring alert + manual runbook, or via a
+ *     CronJob that mints + revokes PATs. Not implemented here; tracked
+ *     separately when self-hosted Zitadel extends to staging / prod.
+ *
+ * The PAT value is exposed as `token: pulumi.Output<string>`. Callers
+ * MUST wrap further uses in `pulumi.secret()` and store it in GCP Secret
+ * Manager — never log or expose directly.
+ */
+export class LoginClientComponent extends pulumi.ComponentResource {
+	public readonly machineUser: zitadel.MachineUser
+	public readonly instanceMember: zitadel.InstanceMember
+	public readonly pat: zitadel.PersonalAccessToken
+
+	/** Personal Access Token value. Bearer-prefix it as
+	 *  `Authorization: Bearer ${token}` when calling Zitadel APIs. */
+	public readonly token: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: LoginClientComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:LoginClient', name, {}, opts)
+
+		const { orgId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		this.machineUser = new zitadel.MachineUser(
+			'login-client',
+			{
+				orgId,
+				userName: 'login-client',
+				name: 'Zitadel Login V2 Client',
+				description:
+					'Service user for the self-hosted zitadel-login (Login V2 UI) ' +
+					'container. Authenticated via PAT, granted IAM_LOGIN_CLIENT at ' +
+					'instance level. Required per Zitadel self-hosted login docs.',
+				// PAT is always opaque regardless of this setting; using BEARER for
+				// clarity — JWT mode here would only affect OAuth2 token requests
+				// which the login UI does not perform with this user.
+				accessTokenType: 'ACCESS_TOKEN_TYPE_BEARER',
+			},
+			resourceOptions,
+		)
+
+		// Grant IAM_LOGIN_CLIENT at instance level. This is the role specifically
+		// designed for the Login UI's permission needs (cross-org user search,
+		// settings read, session management). It is strictly less powerful than
+		// IAM_OWNER (held by the bootstrap admin SA used by Pulumi).
+		this.instanceMember = new zitadel.InstanceMember(
+			'login-client-member',
+			{
+				userId: this.machineUser.id,
+				roles: ['IAM_LOGIN_CLIENT'],
+			},
+			{ ...resourceOptions, dependsOn: [this.machineUser] },
+		)
+
+		// PAT with no expirationDate — see component docstring for rationale.
+		// Depend on the InstanceMember so the role is granted before the token
+		// is minted (otherwise the first API call from zitadel-login could race
+		// the role propagation and 403).
+		this.pat = new zitadel.PersonalAccessToken(
+			'login-client-pat',
+			{
+				orgId,
+				userId: this.machineUser.id,
+			},
+			{ ...resourceOptions, dependsOn: [this.instanceMember] },
+		)
+
+		this.token = this.pat.token
+
+		this.registerOutputs({
+			machineUser: this.machineUser,
+			instanceMember: this.instanceMember,
+			pat: this.pat,
+			token: this.token,
+		})
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -4,6 +4,7 @@ import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../config.js'
 import { ActionsV2Component } from './components/actions-v2.js'
 import { FrontendComponent } from './components/frontend.js'
+import { LoginClientComponent } from './components/login-client.js'
 import { MachineUserComponent } from './components/machine-user.js'
 import { SmtpComponent } from './components/smtp.js'
 import {
@@ -16,6 +17,7 @@ import {
 
 export * from './components/actions-v2.js'
 export * from './components/frontend.js'
+export * from './components/login-client.js'
 export * from './components/machine-user.js'
 export * from './components/secrets.js'
 export * from './components/smtp.js'
@@ -59,9 +61,15 @@ export class Zitadel {
 	public readonly smtp: SmtpComponent
 	public readonly actionsV2: ActionsV2Component
 	public readonly machineUser: MachineUserComponent
+	public readonly loginClient: LoginClientComponent
 
 	/** JWT profile JSON for the backend-app machine user. Store in Secret Manager. */
 	public readonly machineKeyDetails: pulumi.Output<string>
+
+	/** Personal Access Token for the zitadel-login (Login V2 UI) container.
+	 *  Store in Secret Manager and mount via ExternalSecret as a file
+	 *  (consumed by `ZITADEL_SERVICE_USER_TOKEN_FILE`). */
+	public readonly loginClientToken: pulumi.Output<string>
 
 	constructor(name: string, args: ZitadelArgs) {
 		const { env, gcpProjectId, postmarkServerApiToken } = args
@@ -153,5 +161,12 @@ export class Zitadel {
 		})
 
 		this.machineKeyDetails = this.machineUser.keyDetails
+
+		this.loginClient = new LoginClientComponent(name, {
+			orgId,
+			provider: this.provider,
+		})
+
+		this.loginClientToken = this.loginClient.token
 	}
 }


### PR DESCRIPTION
## Summary

Provision a Zitadel Machine User + Personal Access Token (PAT) for the self-hosted `zitadel-login` (Login V2 UI Next.js) container, mounted as a file via `ZITADEL_SERVICE_USER_TOKEN_FILE`. This unblocks the cutover smoke test — without it, every login attempt returns HTTP 500 because the Login UI's SSR cannot fetch instance settings.

## Why now

After the Pulumi cutover (#209/#211/#212) and the frontend cutover (frontend#342), the first manual sign-in attempt hit `https://auth.dev.liverty-music.app/ui/v2/login/...` and got HTTP 500. zitadel-login pod logs:

```
Failed to load global settings Error: fetch() returned undefined
Error fetching custom translations: Error: fetch() returned undefined
Failed to load supported languages
```

Root cause: the Login V2 UI's Next.js SSR needs instance-level Zitadel API access (cross-org user search, session creation, settings read) which a regular OIDC user token cannot do. Zitadel's docs require a **service user PAT with `IAM_LOGIN_CLIENT`** for this — see [Login Client](https://zitadel.com/docs/self-hosting/manage/login-client). This was missing from the original cutover spec.

## What this PR adds

### Pulumi
- New `LoginClientComponent` (`src/zitadel/components/login-client.ts`):
  - `MachineUser` `login-client` (liverty-music org)
  - `InstanceMember` granting `IAM_LOGIN_CLIENT` (instance level, strictly less powerful than IAM_OWNER held by bootstrap admin SA)
  - `PersonalAccessToken` with no `expirationDate` — dev-only choice; prod must implement rotation
- `Zitadel` class exposes `loginClientToken: Output<string>`
- Routed through `Gcp` → `KubernetesComponent.esoOnlySecrets` → GSM secret `zitadel-login-pat` + ESO accessor (no backend-app accessor — backend uses its own JWT key)

### K8s manifests
- New `external-secret-login-pat.yaml` (ESO mirrors GSM → K8s Secret)
- `deployment-login.yaml`: file mount at `/var/run/zitadel/login-client.pat`, env `ZITADEL_SERVICE_USER_TOKEN_FILE` (file mode keeps the token out of `kubectl describe pod`)
- `kustomization.yaml`: register the new ExternalSecret

## Security notes

- **PAT, not env var**: mounted as a file (`projected items.path`) so the PAT does not appear in pod env dumps
- **Instance-level role, not org-level**: `IAM_LOGIN_CLIENT` is the documented minimum for the Login UI's needs; not `IAM_OWNER`
- **No expirationDate (dev only)**: avoids "silent breakage on day N" failure mode. Documented in component docstring; staging/prod must rotate. Tracked as follow-up.
- **Cross-secret isolation**: backend-app SA does NOT receive accessor on this secret; only the ESO controller does

## Test plan

- [x] `make check` passes (biome + tsc)
- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders cleanly with the new ExternalSecret + the deployment volume mount
- [ ] Auto-deploy on merge: Pulumi creates the MachineUser + InstanceMember + PAT + GSM secret + IAM bindings
- [ ] ArgoCD sync: ExternalSecret reconciles K8s Secret `zitadel-login-pat` in zitadel namespace; `zitadel-login` pod restarts with the file mounted
- [ ] Login flow at `https://dev.liverty-music.app` returns the actual Login UI (not HTTP 500)
- [ ] zitadel-login pod logs no longer show `fetch() returned undefined`

## Out of scope (follow-up PRs)

- **PR-2**: K8s rename (`zitadel` → `zitadel-api`, `zitadel-login` → `zitadel-web`) for naming consistency
- **PR-3**: GSM rename `zitadel-machine-key` → `zitadel-backend-app-key` (cross-repo, zero-downtime split)
- **prod follow-up**: PAT rotation strategy (Cloud Monitoring alert + manual runbook OR CronJob auto-rotation)
