### PR TITLE
fix(zitadel): point Login V2 UI at public ZITADEL_API_URL

### DIFF
--- a/k8s/namespaces/zitadel/base/deployment-login.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-login.yaml
@@ -56,8 +56,28 @@ spec:
         - containerPort: 3000
           name: http
         env:
+        # ZITADEL_API_URL must be the **public** issuer URL, not the
+        # cluster-internal Service URL. Zitadel v4 selects the virtual
+        # instance from the request's Host header and matches it against
+        # the configured InstanceDomains; the cluster-internal hostname
+        # `zitadel.zitadel.svc.cluster.local` is not in that list, so
+        # internal calls return HTTP 404 ("Failed to fetch security
+        # settings from API ... status:404").
+        #
+        # Setting the public URL here makes the login UI's outbound calls
+        # carry `Host: auth.dev.liverty-music.app`. The request still stays
+        # within the cluster: it goes Gateway → HTTPRoute (`/` catch-all
+        # rule) → `zitadel` Service → API container. The Gateway round-trip
+        # adds ~10ms but avoids any cluster-DNS rewrite hacks.
+        #
+        # An alternative (not used) is registering the internal hostname
+        # as an InstanceDomain via the API; deferred because that adds an
+        # imperative bootstrap step outside of Pulumi/Kustomize.
+        #
+        # Refs:
+        #   https://zitadel.com/docs/self-hosting/manage/custom-domain
         - name: ZITADEL_API_URL
-          value: http://zitadel.zitadel.svc.cluster.local
+          value: https://auth.dev.liverty-music.app
         - name: NEXT_PUBLIC_BASE_PATH
           value: /ui/v2/login
         # Personal Access Token used by the Login V2 UI Next.js server to


### PR DESCRIPTION
## Summary

Set `ZITADEL_API_URL` on the `zitadel-login` deployment to the **public** issuer URL `https://auth.dev.liverty-music.app` instead of the cluster-internal Service URL.

## Why

After PR #213 mounted the PAT correctly, the Login V2 UI still returned HTTP 500 with:

```
Failed to fetch security settings from API ... status:404
fetch() returned undefined (Failed to load global settings / supported languages / custom translations)
```

Confirmed via `kubectl exec` probe: the API endpoint `GET /v2/settings/security` returns:
- `404` when called with the in-cluster Host header (`zitadel.zitadel.svc.cluster.local`)
- `401` (auth required, endpoint exists) when called with `Host: auth.dev.liverty-music.app`

Per [Zitadel docs](https://zitadel.com/docs/self-hosting/manage/custom-domain), Zitadel v4 selects the virtual instance from the request's Host header and matches it against the configured `InstanceDomains`. The cluster-internal hostname is not registered as an InstanceDomain, so internal calls fail with 404 before any auth check.

## What changes

Single env-var change in `deployment-login.yaml`:

```diff
 - name: ZITADEL_API_URL
-  value: http://zitadel.zitadel.svc.cluster.local
+  value: https://auth.dev.liverty-music.app
```

Traffic flow (still entirely in-cluster):
1. zitadel-login pod → DNS resolves `auth.dev.liverty-music.app` → Gateway external IP (reachable from cluster)
2. Gateway terminates TLS
3. HTTPRoute matches `/` catch-all → routes to `zitadel` Service (NOT `/ui/v2/login` which goes to `zitadel-login`)
4. zitadel-api receives request with correct Host header → matches InstanceDomain → handles request

Adds ~10ms Gateway round-trip overhead per call, acceptable for dev.

## Alternative considered

Register `zitadel.zitadel.svc.cluster.local` as an InstanceDomain via the Zitadel Management API. **Deferred** — it requires an imperative bootstrap step outside Pulumi/Kustomize, which would need a Pulumi Dynamic Resource or a one-shot Job. The performance gain (~10ms) doesn't justify that complexity for dev.

## Test plan

- [x] `kubectl kustomize` renders cleanly
- [x] In-cluster `kubectl exec` probe confirmed:
  - `wget http://zitadel/v2/settings/security` → 404 (without Host)
  - `wget --header "Host: auth.dev.liverty-music.app" http://zitadel/v2/settings/security` → 401 (with Host: endpoint exists)
- [ ] After merge: ArgoCD sync, zitadel-login Pod restart, no more `fetch() returned undefined` in logs
- [ ] After merge: `https://dev.liverty-music.app` login flow renders the actual login UI (not HTTP 500)

## Risk

- Single env var change, scoped to dev (deployment-login.yaml is shared across overlays but only dev currently runs self-hosted Zitadel)
- Rollback: revert this commit, ArgoCD reverts pod env in ~1 min
