### PR TITLE
fix(zitadel): refresh backend-app MachineKey to align with self-hosted

### DIFF
--- a/src/zitadel/components/machine-user.ts
+++ b/src/zitadel/components/machine-user.ts
@@ -61,7 +61,27 @@ export class MachineUserComponent extends pulumi.ComponentResource {
 				orgId,
 				userId: this.machineUser.id,
 				keyType: 'KEY_TYPE_JSON',
-				expirationDate: '2519-04-01T08:45:00Z',
+				// Effectively never expires for dev. The far-future date
+				// avoids the "silent breakage on day N" failure mode that a
+				// short expiration would create — there is no automated
+				// rotation path here today, so an expired key would lock
+				// out the backend until manual rotation. For prod (when the
+				// self-hosted cutover extends beyond dev) this MUST be
+				// replaced with a real expiration + rotation runbook.
+				//
+				// Bumped from a magic placeholder ('2519-04-01T08:45:00Z',
+				// the upstream example value) to a clean far-future date.
+				// The change also force-replaces the MachineKey, which is
+				// intentional in this PR: state drift from the post-cutover
+				// merged-state import left GSM holding a stale Cloud-era
+				// key that does not match any AuthNKey row in the
+				// self-hosted Zitadel DB, so backend → Zitadel API calls
+				// (e.g. ResendEmailVerification) fail with `Errors.Internal
+				// (OIDC-AhX2u) parent: Errors.AuthNKey.NotFound`. Replacing
+				// the MachineKey re-mints the key, propagates fresh
+				// keyDetails into the GSM SecretVersion, and aligns all
+				// three sources of truth (Zitadel DB, GSM, Pulumi state).
+				expirationDate: '2099-01-01T00:00:00Z',
 			},
 			{ ...resourceOptions, dependsOn: [this.machineUser] },
 		)


### PR DESCRIPTION
## Summary

Force-replace the `backend-app` Zitadel `MachineKey` to fix a three-way state drift between **Zitadel DB**, **GSM**, and **Pulumi state** that was leaving the backend unable to authenticate to the Zitadel Management API.

## Symptom

Sign-up reaches the dashboard, but `ResendEmailVerification` (and any other outbound backend → Zitadel API call) returns HTTP 500:

- Backend logs:
  ```
  resend email verification code:
    ErrorType=server_error Description=Errors.Internal (internal)
  ```
- Zitadel API logs:
  ```
  Errors.Internal (OIDC-AhX2u)
    parent: invalid signature (error fetching keys:
            Errors.AuthNKey.NotFound
            Parent=(sql: no rows in result set))
  ```

## Root cause: state drift

The backend signs JWTs with a private key in GSM and presents them as Bearer tokens. Zitadel verifies by looking up the `kid` claim in its AuthNKey table — which returned no rows because the **GSM-stored key is from the old Zitadel Cloud era**, not the self-hosted instance.

| Location                     | keyId                    | Era                |
| ---------------------------- | ------------------------ | ------------------ |
| Zitadel DB MachineKey        | `370564347228848900`     | self-hosted (live) |
| GSM `zitadel-machine-key`    | `365044937655378985`     | **Cloud-era stale** |
| Pulumi state MachineKey output | `365044937655378985` (Cloud-era) | merged-state import preserved v246 outputs |

The cutover sequence:
1. v252 (#248): Pulumi created a fresh self-hosted MachineKey, GSM updated.
2. v250 (manual `pulumi state delete --target-dependents`): MachineKey state cascade-removed.
3. v254 (manual `pulumi stack import` of merged v246+current state): **re-injected v246's Cloud-era MachineKey output** into state.
4. v258 (#254): SecretVersion replace pulled `secretData` from the (now stale) `MachineKey.keyDetails`, writing Cloud-era key back into GSM. Zitadel DB still has the self-hosted key from step 1.

## Fix

Change `expirationDate` to force-replace the `MachineKey` resource. The replacement:
1. Deletes the dangling Zitadel-side MachineKey (`370564347228848900`).
2. Creates a fresh MachineKey on the same `backend-app` MachineUser.
3. Propagates the new `keyDetails` through `Zitadel.machineKeyDetails` → `Gcp.zitadelMachineKey` → `KubernetesComponent.secrets[zitadel-machine-key]` → GSM SecretVersion replace.
4. ESO syncs new K8s Secret; Reloader rolls backend; backend reads the new key on restart.

Also cleans up the magic placeholder date `2519-04-01T08:45:00Z` (the upstream `@pulumiverse/zitadel` example value carried verbatim) → `2099-01-01T00:00:00Z`. Inline comment records the dev-only "effectively never expires" rationale + flags that prod must adopt a real expiration + rotation runbook when self-hosted cutover extends beyond dev.

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [ ] After merge: Pulumi auto-deploy replaces MachineKey + SecretVersion
- [ ] After ESO sync + Reloader-driven restart: backend pod has new key file mounted
- [ ] Smoke test: settings page → Resend verification email → email arrives at the test user's inbox
- [ ] After OTP entry: user reaches verified state, JWT contains `email` claim

## Risk

Brief window (~30-60s) where backend cannot authenticate to Zitadel API:
- Old MachineKey delete → new SecretVersion → ESO sync (refresh interval up to 1h, may need manual `kubectl annotate ... force-sync=...`) → Reloader restart
- During this window, **inbound** flows (pre-access-token webhook, end-user access-token validation) are unaffected because they verify against Zitadel JWKS, not the machine-user key
- **Outbound** flows (ResendEmailVerification, user updates) fail until rolled
- Acceptable for dev. Prod would need an old/new key overlap window.

## Out of scope

- Investigating whether `pulumi stack import` should refuse to import outputs whose corresponding cloud resource has changed `id` (would have caught this drift)
- Migration to the `zitadel-backend-app-key` GSM rename — already tracked separately as PR-3
