### PR TITLE
feat(zitadel): auto-activate SmtpConfig via Pulumi Dynamic Resource

### DIFF
--- a/src/zitadel/components/smtp.ts
+++ b/src/zitadel/components/smtp.ts
@@ -1,12 +1,19 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../../config.js'
+import { ZitadelSmtpActivation } from '../dynamic/index.js'
 
 export interface SmtpComponentArgs {
 	env: Environment
 	/** Postmark Server API Token, used as both SMTP username and password. */
 	serverApiToken: string
 	provider: zitadel.Provider
+	/** Zitadel domain hosting the Admin API (e.g. `auth.dev.liverty-music.app`).
+	 *  Required by `ZitadelSmtpActivation` for the post-create `_activate` call. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON, used by `ZitadelSmtpActivation`
+	 *  for Admin API auth (separate from the @pulumiverse provider). */
+	jwtProfileJson: pulumi.Input<string>
 }
 
 // Sender address per environment using dedicated mail subdomains.
@@ -19,6 +26,7 @@ const senderAddressMap: Record<Environment, string> = {
 
 export class SmtpComponent extends pulumi.ComponentResource {
 	public readonly smtpConfig: zitadel.SmtpConfig
+	public readonly smtpActivation: ZitadelSmtpActivation
 
 	constructor(
 		name: string,
@@ -27,7 +35,7 @@ export class SmtpComponent extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:Smtp', name, {}, opts)
 
-		const { env, serverApiToken, provider } = args
+		const { env, serverApiToken, provider, domain, jwtProfileJson } = args
 		const resourceOptions = { provider, parent: this }
 
 		// Postmark uses the same Server API Token for both SMTP username and password.
@@ -44,8 +52,25 @@ export class SmtpComponent extends pulumi.ComponentResource {
 			resourceOptions,
 		)
 
+		// `@pulumiverse/zitadel.SmtpConfig` (v0.2.0) provisions the SMTP
+		// configuration but does NOT call the separate `_activate` admin
+		// endpoint that Zitadel v4 requires before SMTP traffic flows. Without
+		// this Dynamic Resource, every Zitadel rebuild silently re-introduces
+		// the cutover §13.16 incident (first-sign-up email verification
+		// failing) until an operator remembers to run the `_activate` curl.
+		this.smtpActivation = new ZitadelSmtpActivation(
+			'smtp-activation',
+			{
+				domain,
+				jwtProfileJson,
+				smtpConfigId: this.smtpConfig.id,
+			},
+			{ parent: this, dependsOn: [this.smtpConfig] },
+		)
+
 		this.registerOutputs({
 			smtpConfig: this.smtpConfig,
+			smtpActivation: this.smtpActivation,
 		})
 	}
 }

--- a/src/zitadel/dynamic/__tests__/smtp-activation.test.ts
+++ b/src/zitadel/dynamic/__tests__/smtp-activation.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../api-client.js', () => ({
+	zitadelApiCall: vi.fn(),
+}))
+
+const apiClient = await import('../api-client.js')
+const { smtpActivationProvider } = await import('../smtp-activation.js')
+
+const mockedCall = vi.mocked(apiClient.zitadelApiCall)
+
+// `ZitadelSmtpActivation` is a side-effect-only Dynamic Resource (per
+// `cutover-warning-fixes` design D2/D4): the only lifecycle handler that
+// touches the Zitadel REST surface is `create()`. `update()` / `delete()` /
+// `read()` are no-ops by design, so the test scaffold is intentionally
+// narrower than the four-case scaffold used for `targetProvider` and
+// `executionFunctionProvider`.
+const provider = smtpActivationProvider as Required<
+	typeof smtpActivationProvider
+>
+
+const baseProfile = {
+	type: 'serviceaccount' as const,
+	keyId: 'kid-1',
+	key: 'private-key-pem',
+	userId: 'user-1',
+}
+
+const baseInputs = {
+	domain: 'auth.example.test',
+	jwtProfileJson: JSON.stringify(baseProfile),
+	smtpConfigId: 'smtp-cfg-1',
+}
+
+const baseOutputs = {
+	...baseInputs,
+	activatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function lastCallArgs() {
+	return mockedCall.mock.calls[0][0]
+}
+
+describe('smtpActivationProvider.create', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('POSTs /admin/v1/smtp/{id}/_activate and returns an activatedAt timestamp', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
+
+		const result = await provider.create(baseInputs)
+
+		expect(mockedCall).toHaveBeenCalledOnce()
+		const args = lastCallArgs()
+		expect(args.method).toBe('POST')
+		expect(args.path).toBe('/admin/v1/smtp/smtp-cfg-1/_activate')
+		expect(args.domain).toBe('auth.example.test')
+		// Activation has no payload; body is intentionally undefined.
+		expect(args.body).toBeUndefined()
+		expect(result.id).toBe('smtp-activation:smtp-cfg-1')
+		expect(result.outs?.smtpConfigId).toBe('smtp-cfg-1')
+		expect(result.outs?.activatedAt).toMatch(
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+		)
+	})
+
+	it('treats an "already active" upstream response as success (idempotency on first apply against manually-activated SMTP)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 412,
+			body: '{"code":9,"message":"smtp config is already active"}',
+		})
+
+		await expect(provider.create(baseInputs)).resolves.toMatchObject({
+			id: 'smtp-activation:smtp-cfg-1',
+		})
+	})
+
+	it('throws on a genuine non-2xx error (not the already-active case)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel ActivateSmtpConfig failed \(500\)/,
+		)
+	})
+})
+
+describe('smtpActivationProvider.update', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests and preserves the original activatedAt', async () => {
+		const result = await provider.update(
+			'smtp-activation:smtp-cfg-1',
+			baseOutputs,
+			baseInputs,
+		)
+
+		expect(mockedCall).not.toHaveBeenCalled()
+		expect(result.outs?.activatedAt).toBe(baseOutputs.activatedAt)
+		expect(result.outs?.smtpConfigId).toBe('smtp-cfg-1')
+	})
+})
+
+describe('smtpActivationProvider.delete', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests', async () => {
+		await expect(
+			provider.delete('smtp-activation:smtp-cfg-1', baseOutputs),
+		).resolves.toBeUndefined()
+
+		expect(mockedCall).not.toHaveBeenCalled()
+	})
+})
+
+describe('smtpActivationProvider.read', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests and returns current outputs unchanged', async () => {
+		const result = await provider.read(
+			'smtp-activation:smtp-cfg-1',
+			baseOutputs,
+		)
+
+		expect(mockedCall).not.toHaveBeenCalled()
+		expect(result.id).toBe('smtp-activation:smtp-cfg-1')
+		expect(result.props).toEqual(baseOutputs)
+	})
+})

--- a/src/zitadel/dynamic/index.ts
+++ b/src/zitadel/dynamic/index.ts
@@ -1,2 +1,3 @@
 export * from './execution.js'
+export * from './smtp-activation.js'
 export * from './target.js'

--- a/src/zitadel/dynamic/smtp-activation.ts
+++ b/src/zitadel/dynamic/smtp-activation.ts
@@ -1,0 +1,148 @@
+import * as pulumi from '@pulumi/pulumi'
+import { type JwtProfile, zitadelApiCall } from './api-client.js'
+
+export interface ZitadelSmtpActivationArgs {
+	/** Zitadel domain, e.g. `auth.dev.liverty-music.app`. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (stringified) for Management API auth. */
+	jwtProfileJson: pulumi.Input<string>
+	/** ID of the `SmtpConfig` resource to activate. */
+	smtpConfigId: pulumi.Input<string>
+}
+
+interface SmtpActivationInputs {
+	domain: string
+	jwtProfileJson: string
+	smtpConfigId: string
+}
+
+interface SmtpActivationOutputs extends SmtpActivationInputs {
+	activatedAt: string
+}
+
+/**
+ * Provider for `ZitadelSmtpActivation`. Diverges from the standard four-case
+ * Dynamic Resource lifecycle (create/read/update/delete) because activation
+ * is a one-shot side effect at the Zitadel REST surface — there is no
+ * `GET /admin/v1/smtp/{id}/_activation` to read, no separate `_deactivate`
+ * verb to call on delete, and the only meaningful input
+ * (`smtpConfigId`) is a hard identity tied to the `SmtpConfig` resource.
+ *
+ * - `create()` POSTs `/admin/v1/smtp/{id}/_activate`. Treats the upstream
+ *   "already active" response as success (idempotency) so the first apply
+ *   against a manually-activated SMTP does not stall the stack.
+ * - `update()` is a no-op. Re-firing `_activate` would be a side effect
+ *   without any state change, and there are no other inputs to update.
+ * - `delete()` is a no-op. Removing the Pulumi resource record from state
+ *   should not deactivate the upstream SMTP — drift handling is explicitly
+ *   deferred per `cutover-warning-fixes` design D2.
+ * - `read()` is a no-op returning current outputs unchanged.
+ */
+export const smtpActivationProvider: pulumi.dynamic.ResourceProvider = {
+	async create(
+		inputs: SmtpActivationInputs,
+	): Promise<pulumi.dynamic.CreateResult<SmtpActivationOutputs>> {
+		const profile = JSON.parse(inputs.jwtProfileJson) as JwtProfile
+		const res = await zitadelApiCall({
+			domain: inputs.domain,
+			profile,
+			method: 'POST',
+			path: `/admin/v1/smtp/${inputs.smtpConfigId}/_activate`,
+		})
+		// 2xx covers the happy path. Zitadel returns the same shape for
+		// "newly activated" and "already active" cases on this endpoint
+		// (empirically verified during the cutover smoke test), so any 2xx
+		// is success. A non-2xx with an "already active" code in the body
+		// is treated as success too — see `isAlreadyActive`.
+		if (
+			(res.statusCode < 200 || res.statusCode >= 300) &&
+			!isAlreadyActive(res.body)
+		) {
+			throw new Error(
+				`Zitadel ActivateSmtpConfig failed (${res.statusCode}): ${res.body}`,
+			)
+		}
+		return {
+			id: `smtp-activation:${inputs.smtpConfigId}`,
+			outs: {
+				...inputs,
+				activatedAt: new Date().toISOString(),
+			},
+		}
+	},
+
+	async update(
+		_id: string,
+		olds: SmtpActivationOutputs,
+		news: SmtpActivationInputs,
+	): Promise<pulumi.dynamic.UpdateResult<SmtpActivationOutputs>> {
+		// No-op by design: the only meaningful input is `smtpConfigId`,
+		// which is a hard identity (Pulumi triggers `replace`, not `update`,
+		// when it changes). Anything reaching `update` is an input shape
+		// other than `smtpConfigId` (none exist today) and is therefore
+		// nothing to apply against the upstream API. Preserve `activatedAt`
+		// from `olds` so subsequent diffs stay clean.
+		return {
+			outs: {
+				...news,
+				activatedAt: olds.activatedAt,
+			},
+		}
+	},
+
+	async delete(_id: string, _state: SmtpActivationOutputs): Promise<void> {
+		// No-op by design: removing the Pulumi resource record should not
+		// deactivate the upstream SMTP. There is also no `_deactivate`
+		// admin endpoint we want to call here. If true drift handling is
+		// needed later, it should live elsewhere (see design D2 Risks).
+	},
+
+	async read(
+		id: string,
+		state: SmtpActivationOutputs,
+	): Promise<pulumi.dynamic.ReadResult<SmtpActivationOutputs>> {
+		// No-op: there is no per-activation GET endpoint. Drift detection
+		// against `SmtpConfig.state == SMTP_CONFIG_ACTIVE` is explicitly
+		// deferred per design D2.
+		return { id, props: state }
+	},
+}
+
+function isAlreadyActive(body: string): boolean {
+	// Zitadel returns a code/message envelope on errors; the
+	// "already active" state surfaces with a recognizable token.
+	// Match conservatively to avoid swallowing unrelated failures.
+	return /already.?active/i.test(body) || /SMTP_CONFIG_ACTIVE/.test(body)
+}
+
+/**
+ * `ZitadelSmtpActivation` activates a Zitadel `SmtpConfig` so SMTP traffic
+ * can flow. Without this resource, every Zitadel rebuild silently leaves
+ * SMTP `INACTIVE` (the `@pulumiverse/zitadel.SmtpConfig` v0.2.0 resource
+ * provisions configuration but does not call the separate `_activate`
+ * admin endpoint), and first-sign-up email verification fails until an
+ * operator runs `curl POST /admin/v1/smtp/{id}/_activate` manually.
+ *
+ * Reactivation is idempotent: the upstream returns success when called
+ * against an already-active SMTP, so this resource may be safely created
+ * after a manual activation.
+ */
+export class ZitadelSmtpActivation extends pulumi.dynamic.Resource {
+	public readonly activatedAt!: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: ZitadelSmtpActivationArgs,
+		opts?: pulumi.CustomResourceOptions,
+	) {
+		super(
+			smtpActivationProvider,
+			name,
+			{
+				...args,
+				activatedAt: undefined,
+			},
+			opts,
+		)
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -143,6 +143,8 @@ export class Zitadel {
 			env,
 			serverApiToken: postmarkServerApiToken,
 			provider: this.provider,
+			domain,
+			jwtProfileJson,
 		})
 
 		this.actionsV2 = new ActionsV2Component(name, {


### PR DESCRIPTION
## Summary

Makes Zitadel SMTP activation declarative. Adds `ZitadelSmtpActivation`, a Pulumi Dynamic Resource that calls `POST /admin/v1/smtp/{id}/_activate` after `SmtpConfig` creation, and wires it into `SmtpComponent`. Without this, every Zitadel rebuild silently leaves SMTP `INACTIVE` (the `@pulumiverse/zitadel.SmtpConfig` v0.2.0 resource does not call the separate `_activate` admin endpoint), and first-sign-up email verification fails until an operator runs `curl POST /admin/v1/smtp/{id}/_activate` manually — the §13.16 cutover incident path.

This is **PR-B2 of the openspec change [`cutover-warning-fixes`](../specification/openspec/changes/cutover-warning-fixes)** — last of 4. Depends on PR-B1 (#217) for the test scaffold and `vitest` infrastructure (already merged).

## Lifecycle (intentionally narrower than the four-case scaffold)

`ZitadelSmtpActivation` is a side-effect-only resource — there is no `GET /admin/v1/smtp/{id}/_activation` endpoint to read, no separate `_deactivate` verb to call on delete, and the only meaningful input (`smtpConfigId`) is a hard identity tied to the `SmtpConfig` resource. Per `design.md` D2 / D4:

| Handler | Behavior | Rationale |
|---|---|---|
| `create()` | POSTs `/admin/v1/smtp/{id}/_activate`. Treats `412 already-active` as success. | Idempotent on first apply against a manually-activated SMTP — the dev cutover state. |
| `update()` | No-op. Preserves `activatedAt` from `olds`. | Only meaningful input is a hard identity (triggers `replace`, not `update`). |
| `delete()` | No-op. | Removing the Pulumi record should not deactivate upstream SMTP. |
| `read()` | No-op returning current outputs unchanged. | No per-activation GET endpoint. Drift handling deferred per D2 Risks. |

## What changes

- **New file** `src/zitadel/dynamic/smtp-activation.ts` — `ZitadelSmtpActivation` class + `smtpActivationProvider` (exported for tests).
- **New file** `src/zitadel/dynamic/__tests__/smtp-activation.test.ts` — narrower side-effect-only test scaffold:
  - `create()` POSTs the documented path with the expected shape, succeeds on 200 and on the "already active" 412.
  - `create()` throws on genuine non-2xx errors.
  - `update()` / `delete()` / `read()` make **ZERO** HTTP requests.
- **`src/zitadel/dynamic/index.ts`** — re-export the new module.
- **`src/zitadel/components/smtp.ts`** — now takes `domain` + `jwtProfileJson` and instantiates `ZitadelSmtpActivation` with `smtpConfigId: smtpConfig.id` and `dependsOn: [smtpConfig]`.
- **`src/zitadel/index.ts`** — threads the existing `domain` + `jwtProfileJson` through to `SmtpComponent`.

## Pulumi preview impact

Expected `pulumi preview --stack dev` diff:

```
+ create urn:pulumi:dev::liverty-music::...:ZitadelSmtpActivation::smtp-activation
```

Zero replacements, zero deletes. The first `pulumi up` on dev fires `_activate`; Zitadel returns the "already active" response (SMTP was activated by the cutover manual curl on 2026-04-30); the operation succeeds idempotently. Subsequent applies execute `update()` as a no-op with zero HTTP traffic.

## Test plan

- [x] `npm test` — 27/27 tests pass locally (PR-B1's 21 + PR-B2's 6).
- [x] `make check` — biome + tsc + vitest all green.
- [ ] CI green on this branch.
- [ ] Pulumi Cloud Deployments runs `pulumi up` on dev after merge — confirm new `ZitadelSmtpActivation` resource appears in state.
- [ ] `GET /admin/v1/smtp/{id}` against dev Zitadel returns `state: SMTP_CONFIG_ACTIVE` post-merge.

## Dependency

Depends on PR-B1 (#217) for `vitest` setup, the exported provider pattern, and the test scaffold conventions. PR-B1 is already merged; this branch is rebased on the latest `main`.
