### PR TITLE
chore(zitadel): bump Zitadel stack to v4.14.0 and pin zitadel-login

### DIFF
--- a/k8s/namespaces/zitadel/base/deployment-api.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-api.yaml
@@ -54,7 +54,7 @@ spec:
       # runs setup (pending migrations) + start. FIRSTINSTANCE env vars in
       # the configmap are consumed only on the first run.
       - name: zitadel
-        image: ghcr.io/zitadel/zitadel:v4.13.1
+        image: ghcr.io/zitadel/zitadel:v4.14.0
         args:
         - start-from-init
         - --masterkeyFromEnv

--- a/k8s/namespaces/zitadel/base/deployment-login.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-login.yaml
@@ -42,15 +42,15 @@ spec:
       # `ghcr.io/zitadel/login` (the latter 404s). The upstream Helm chart
       # default is the same path (see zitadel-charts@main values.yaml).
       #
-      # Tag: `latest`. The zitadel-login container publishes semver tags only
-      # up to v4.7.3; v4.8+ ship as git-SHA tags only. The Helm chart's
-      # appVersion (v4.13.0) expects `login:v4.13.0`, but that tag does not
-      # exist. Using `latest` in dev accepts the risk of upstream drift in
-      # exchange for avoiding a SHA-pinning runbook. `imagePullPolicy:
-      # IfNotPresent` prevents every restart from re-pulling. For
-      # staging/prod, pin a specific SHA after validating compatibility.
+      # Tag: pinned to the same semver as the API container so Login UI and
+      # API ship from the same release cycle. The standalone `zitadel/typescript`
+      # repo was archived 2026-04-18; Login V2 source now lives in the main
+      # zitadel monorepo and the `zitadel-login` image now publishes the same
+      # semver tags as `zitadel` (verified via `docker manifest inspect
+      # ghcr.io/zitadel/zitadel-login:v4.14.0`). The earlier "semver-up-to-v4.7.3"
+      # gap is closed.
       - name: zitadel-login
-        image: ghcr.io/zitadel/zitadel-login:latest
+        image: ghcr.io/zitadel/zitadel-login:v4.14.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "public-cloud-scaffold",
       "dependencies": {
-        "@pulumi/cloudflare": "^6.13.0",
-        "@pulumi/gcp": "^9.10.0",
-        "@pulumi/github": "^6.11.0",
-        "@pulumi/pulumi": "^3.218.0",
+        "@pulumi/cloudflare": "^6.15.0",
+        "@pulumi/gcp": "^9.22.0",
+        "@pulumi/github": "^6.13.1",
+        "@pulumi/pulumi": "^3.234.0",
         "@pulumi/random": "^4.19.2",
         "@pulumiverse/zitadel": "^0.2.0"
       },
@@ -198,31 +198,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1557,9 +1532,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@pulumi/cloudflare": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/cloudflare/-/cloudflare-6.14.0.tgz",
-      "integrity": "sha512-YKH9x7UsNg5iI92g9hVL893MzF8VS4W7nANFvr1TN99mQczPKNi0Z1abTBxyZ4DcB/JWi5zq+va7rJuKkuVr6Q==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/cloudflare/-/cloudflare-6.15.0.tgz",
+      "integrity": "sha512-I2C1UA//YbkuGUV5O9skIMUu94StNSE4hiAU57GFtyL7WEqAMJLvV8Vpcu1192rI1/ZwFIJeR4MbAZfiYlPFqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pulumi/pulumi": "^3.142.0"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@pulumi/cloudflare": "^6.13.0",
-    "@pulumi/gcp": "^9.10.0",
-    "@pulumi/github": "^6.11.0",
-    "@pulumi/pulumi": "^3.218.0",
+    "@pulumi/cloudflare": "^6.15.0",
+    "@pulumi/gcp": "^9.22.0",
+    "@pulumi/github": "^6.13.1",
+    "@pulumi/pulumi": "^3.234.0",
     "@pulumi/random": "^4.19.2",
     "@pulumiverse/zitadel": "^0.2.0"
   }


### PR DESCRIPTION
## Summary

Routine version hygiene for the Zitadel stack. Three things bundled, with disjoint blast radius:

1. **Pin `zitadel-login` to `:v4.14.0`** — closes a long-standing spec violation. `self-hosted-zitadel` proposal §9 required pinning every container to a semver tag, but the `zitadel-login` Deployment shipped with `:latest` because at cutover time the image only published semver tags up to v4.7.3 (v4.8+ were SHA-tag only). The standalone `zitadel/typescript` repo was archived 2026-04-18; Login V2 source now lives in the main `zitadel/zitadel` monorepo and the `zitadel-login` image now publishes the same semver tags as the API container. **Verified:** `docker manifest inspect ghcr.io/zitadel/zitadel-login:v4.14.0` returns a multi-arch index.
2. **Bump `zitadel` container `v4.13.1` → `v4.14.0`** — picks up v4.14.0 fixes including `login: invite flow instead of email verification for users with no primary method`, which is adjacent to the post-cutover email-verification work in `cutover-warning-fixes`.
3. **Bump Pulumi providers** to latest minor versions:
   - `@pulumi/pulumi`: `3.218.0` → `3.234.0`
   - `@pulumi/gcp`: `9.10.0` → `9.22.0` (12 minors — biggest gap)
   - `@pulumi/cloudflare`: `6.13.0` → `6.15.0`
   - `@pulumi/github`: `6.11.0` → `6.13.1`

`@pulumi/random` and `@pulumiverse/zitadel` are already at the latest published version (4.19.2 and 0.2.0 respectively); no change.

## Pulumi preview impact

```
Resources:
    ~ 1 to update            ← Cloudflare provider 6.14.0 → 6.15.0 (metadata only)
    214 unchanged
```

Zero infra-level diffs. The K8s image bumps will be applied by ArgoCD on merge (Pulumi does not manage the manifests).

## Coordination with backend

Paired with [liverty-music/backend#TBD](#) (zitadel-go SDK v3.26.1 → v3.29.0). The two PRs are independent at the file level — they can land in either order, and the running system tolerates either being deployed first because the gRPC wire format is unchanged across this minor range.

## Test plan

- [x] `make check` (biome + tsc + 27 vitest tests) — green.
- [x] `kustomize build --enable-helm k8s/namespaces/zitadel/overlays/dev` — both images render at `v4.14.0`.
- [x] `pulumi preview --stack dev --diff` — `1 to update / 214 unchanged`.
- [ ] CI green on this branch.
- [ ] Post-merge: ArgoCD picks up image bumps; `kubectl rollout status deploy/zitadel deploy/zitadel-login -n zitadel` reaches Ready.
