### PR TITLE
feat(monitoring): enable OTLP metrics pipeline + Zitadel OTEL push

### DIFF
--- a/k8s/namespaces/otel-collector/base/configmap.yaml
+++ b/k8s/namespaces/otel-collector/base/configmap.yaml
@@ -31,3 +31,14 @@ data:
           receivers: [otlp]
           processors: [batch]
           exporters: [googlecloud]
+        # Metrics pipeline: enables OTLP-pushed metrics from in-cluster
+        # services (Zitadel v4 native OTEL exporter; backend's existing OTLP
+        # push) to flow into Cloud Monitoring as custom metrics under
+        # `workload.googleapis.com/...`. Without this pipeline, metrics
+        # arriving on the OTLP receiver are silently dropped because no
+        # consumer is wired up. See openspec change `zitadel-observability`
+        # design D2 for the architecture rationale.
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [googlecloud]

--- a/k8s/namespaces/zitadel/base/configmap.env
+++ b/k8s/namespaces/zitadel/base/configmap.env
@@ -42,3 +42,26 @@ ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_TYPE=1
 # Logging
 ZITADEL_LOG_LEVEL=info
 ZITADEL_LOG_FORMATTER_FORMAT=json
+
+# OpenTelemetry — Zitadel v4.14.0 supports the standard OTEL_* env vars via
+# autoexport (see release notes for v4.14.0). Push metrics + traces to the
+# in-cluster OTLP collector; the collector's `metrics` and `traces` pipelines
+# (configured in `k8s/namespaces/otel-collector/`) export to Cloud Monitoring
+# and Cloud Trace respectively. Without these env vars Zitadel emits no
+# observability output — v4 has no `/debug/metrics` HTTP endpoint to scrape
+# (verified empirically: the path returns 404 on v4.14.0).
+#
+# OTLP gRPC port 4317 is preferred over HTTP 4318 because the SDK defaults
+# to gRPC and uses fewer connections; both ports are exposed by the collector
+# Service.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.otel-collector.svc.cluster.local:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_METRICS_EXPORTER=otlp
+OTEL_TRACES_EXPORTER=otlp
+OTEL_LOGS_EXPORTER=none
+OTEL_RESOURCE_ATTRIBUTES=service.name=zitadel,service.version=v4.14.0
+# 60s push interval matches `zitadel-observability` design D4 — alert
+# evaluation window is also 60s, so each evaluation cycle sees ~1 fresh
+# data point (the SDK aggregates the histogram in-process, so the pushed
+# value already contains a 60s sampling window).
+OTEL_METRIC_EXPORT_INTERVAL=60000


### PR DESCRIPTION
## Summary

Prerequisite K8s changes for the [`zitadel-observability`](../specification/openspec/changes/zitadel-observability) openspec change. Wires up the cluster's OTLP metrics pipeline so that Zitadel v4 (and incidentally the backend) push metrics flow into Cloud Monitoring. The actual `AlertPolicy` and `Dashboard` resources land in a follow-up PR (PR-1b) once the metric type names produced by the live `googlecloud` exporter are confirmed.

This is **PR-1a of 4** (PR-1b alerts, PR-2 band-aid + runbook, PR-3 archive).

## Why this is a separate PR

Recon during apply phase of `zitadel-observability` revealed that the original design D2 was wrong about Zitadel v4's metrics endpoint:

- `GET /debug/metrics` → `404 page not found`
- `GET /metrics` → `404 {"code":5,"message":"Not Found"}`
- `GET /debug/pprof/` → `404`

Zitadel v4 ships native OTEL SDK and pushes metrics via OTLP (release notes for v4.14.0: "support standard OTEL env vars via autoexport"). It has no scrape endpoint.

Meanwhile, the OTLP collector at `k8s/namespaces/otel-collector/` had only a `traces` pipeline. Metrics arriving on the `otlp` receiver were silently dropped. Backend, which already pushes OTLP metrics to the same collector, was also being silently dropped.

The design was updated to reflect this (see [`design.md` D2](../specification/openspec/changes/zitadel-observability/design.md) revision); this PR is the K8s-side prerequisite that the corrected design depends on.

## What changes

1. **`k8s/namespaces/otel-collector/base/configmap.yaml`** — add a `metrics` pipeline `[otlp → batch → googlecloud]` alongside the existing `traces` pipeline. No new exporter configuration needed; `googlecloud` reuses the existing Workload Identity auth path.
2. **`k8s/namespaces/zitadel/base/configmap.env`** — add the standard OTEL env vars that Zitadel v4.14.0 reads via autoexport:
   - `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.otel-collector.svc.cluster.local:4317`
   - `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`
   - `OTEL_METRICS_EXPORTER=otlp`
   - `OTEL_TRACES_EXPORTER=otlp`
   - `OTEL_LOGS_EXPORTER=none` (Zitadel logs already stream to stdout with `ZITADEL_LOG_FORMATTER_FORMAT=json`)
   - `OTEL_RESOURCE_ATTRIBUTES=service.name=zitadel,service.version=v4.14.0`
   - `OTEL_METRIC_EXPORT_INTERVAL=60000` (60s; matches design D4's evaluation window)

## Side benefit

Backend's OTLP metrics start flowing into Cloud Monitoring as a side effect — they were already being pushed but silently dropped before this change. Not the primary goal of `zitadel-observability` but an aligned correction.

## What lands in PR-1b

After this PR is merged and ArgoCD reconciles, the next PR will:

1. Snapshot the Cloud Monitoring metric types produced by the `googlecloud` exporter (likely `workload.googleapis.com/rpc.server.duration` or similar — the exact name depends on the exporter's translation rules).
2. Author `src/gcp/components/zitadel-monitoring.ts` (`ZitadelMonitoringComponent`) with the latency p99 alert, JWT-validation error rate alert, and Cloud SQL connection-pool dashboard panel.
3. Wire the component into the dev stack in `src/gcp/index.ts` with `env === 'dev'` guard.

## Test plan

- [x] `kustomize build --enable-helm k8s/namespaces/zitadel/overlays/dev` — renders without error; OTEL env vars present in the rendered configmap.
- [x] `kustomize build k8s/namespaces/otel-collector/overlays/dev` — renders without error; `metrics` pipeline visible.
- [x] `make check` — biome + tsc + 27 vitest tests green.
- [ ] CI green on this branch.
- [ ] Post-merge: ArgoCD reconciles. The `zitadel` Deployment rolls out a new pod (configmap change triggered by reloader). Confirm with:
  - `kubectl logs -n zitadel deploy/zitadel | grep -i otel` shows OTEL SDK init lines.
  - `gcloud monitoring metrics list --filter="metric.type:opentelemetry OR metric.type:workload.googleapis"` returns Zitadel + backend metrics.
- [ ] PR-1b can begin once the metric snapshot is captured.
