### PR TITLE
feat(zitadel): add weekly restart CronJob in dev + hang-incident runbook

### DIFF
--- a/docs/runbooks/zitadel-hang.md
+++ b/docs/runbooks/zitadel-hang.md
@@ -1,0 +1,183 @@
+# Runbook: Zitadel API hang on `GetAuthRequest`
+
+> **Source of truth:** this runbook is derived from
+> `specification/openspec/specs/zitadel-observability/spec.md` →
+> "Operator runbook for the Zitadel hang incident shape" requirement.
+> If the spec is updated, regenerate this file in the same PR.
+
+## When this runbook applies
+
+You received the **Zitadel API latency p99** alert — `OIDCService/*`
+p99 above 10 seconds — and observe one or more of:
+
+- `GetAuthRequest` (or another `OIDCService/*` call) is timing out
+  at 30+ seconds.
+- Zitadel API responses include `code: internal` with no useful
+  message body.
+- `https://auth.dev.liverty-music.app/.well-known/openid-configuration`
+  takes seconds-to-tens-of-seconds to return (or doesn't return).
+- Backend JWT validation is failing in a correlated burst (the
+  **backend JWT validation error rate** alert may also be firing).
+- The Zitadel API pod's age is ≥ ~3 days (the hang precondition
+  empirically requires accumulated in-memory state, not just any
+  short-uptime hiccup).
+
+If only one of these symptoms is present without the others, it's
+probably **not** the §18.6 hang shape — investigate as a fresh
+incident before reaching for the mitigation below.
+
+The §18.6 cutover-incident chain that this runbook captures was:
+~30 minutes of high-density state-changing API operations
+(multiple `_activate`, MachineKey replace, Action delete, email
+change) against a 3.5-day-old Zitadel API pod. Two hypotheses are
+documented for the root cause; both are resolved by a pod restart:
+
+1. **Hypothesis A:** in-memory projection updater stuck on a write
+   lock during the burst.
+2. **Hypothesis B:** Cloud SQL connection-pool exhaustion from
+   leaked connections in async notification-worker retries.
+
+Capture forensic data **before** restarting — once the pod is
+recycled, all in-memory state is gone and we lose the only chance
+to disambiguate the two hypotheses.
+
+## Forensic data capture (BEFORE mitigation)
+
+Save everything to `/tmp/zitadel-hang-$(date -u +%Y%m%dT%H%M%SZ)/` so
+the captured artifacts survive your terminal session ending. The
+directory should be uploaded to the §18.6 follow-up issue once the
+incident is resolved.
+
+```bash
+INCIDENT_DIR="/tmp/zitadel-hang-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$INCIDENT_DIR"
+cd "$INCIDENT_DIR"
+
+# 1. Identify the affected pod.
+kubectl get pods -n zitadel -l component=api -o wide > pods.txt
+
+ZITADEL_POD=$(kubectl get pods -n zitadel -l component=api -o jsonpath='{.items[0].metadata.name}')
+echo "Affected pod: $ZITADEL_POD" | tee -a NOTES.md
+
+# 2. Pod state — uptime, restarts, recent events.
+kubectl describe pod -n zitadel "$ZITADEL_POD" > pod-describe.txt
+kubectl get events -n zitadel --sort-by=.lastTimestamp > events.txt
+
+# 3. Recent application logs (last 30 minutes).
+kubectl logs -n zitadel "$ZITADEL_POD" -c zitadel --since=30m > zitadel-logs.txt
+
+# 4. Cloud SQL Auth Proxy sidecar logs — if hypothesis B is right,
+#    the proxy will show connection saturation here.
+kubectl logs -n zitadel "$ZITADEL_POD" -c cloud-sql-proxy --since=30m > sql-proxy-logs.txt
+
+# 5. Cloud SQL connection-pool metric snapshot. The
+#    `zitadel-observability` dashboard panel shows the same data
+#    visually; this saves the underlying values for the issue tracker.
+gcloud monitoring time-series list \
+  --project=liverty-music-dev \
+  --filter='metric.type="cloudsql.googleapis.com/database/postgresql/num_backends" AND resource.label.database_id="liverty-music-dev:postgres-osaka"' \
+  --interval-end-time=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  --interval-start-time=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ) \
+  --format=json > sql-num-backends.json
+
+# 6. Recent Zitadel API request rate by gRPC method, to identify
+#    whether a state-changing API burst preceded the hang.
+gcloud logging read \
+  'resource.type="k8s_container" AND resource.labels.namespace_name="zitadel" AND resource.labels.container_name="zitadel" AND timestamp>="'$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)'"' \
+  --project=liverty-music-dev \
+  --limit=10000 \
+  --format=json > zitadel-recent-api-calls.json
+
+# 7. Live API smoke test from inside the cluster, to confirm the
+#    hang is reproducible at the moment of mitigation.
+kubectl run -n zitadel zitadel-smoke-$$ \
+  --rm -i --restart=Never \
+  --image=curlimages/curl:8.10.1 \
+  --command -- curl -sS -m 35 -o /dev/null -w 'http_code=%{http_code} time=%{time_total}\n' \
+  http://zitadel.zitadel.svc.cluster.local:8080/.well-known/openid-configuration \
+  > smoke-test.txt 2>&1
+
+ls -la "$INCIDENT_DIR"
+```
+
+## Mitigation
+
+After the forensic capture above completes, restart the Deployment.
+
+```bash
+# Confirm you're targeting the right cluster!
+kubectl config current-context
+# expected: gke_liverty-music-dev_asia-northeast2-a_standard-cluster-osaka
+
+kubectl rollout restart deployment/zitadel -n zitadel
+kubectl rollout status deployment/zitadel -n zitadel --timeout=120s
+```
+
+The default RollingUpdate strategy (`maxUnavailable: 0`,
+`maxSurge: 1`) rolls in a fresh pod before terminating the old one,
+so external auth traffic continues uninterrupted assuming at least
+one replica is healthy throughout. **In dev**, replicas are scaled
+to 1, so this becomes a brief (~30 s) outage; users on
+`auth.dev.liverty-music.app` may see 503s during the cutover.
+
+## Post-mitigation verification
+
+```bash
+# 1. The new pod is Ready.
+kubectl get pods -n zitadel -l component=api
+
+# 2. The healthz endpoint returns 200.
+curl -sS -m 5 -o /dev/null -w '%{http_code}\n' \
+  https://auth.dev.liverty-music.app/debug/healthz
+# expected: 200
+
+# 3. The OIDC discovery endpoint returns within steady-state latency
+#    (sub-second).
+time curl -sS -m 5 \
+  https://auth.dev.liverty-music.app/.well-known/openid-configuration \
+  > /dev/null
+# expected: real time well under 1 s
+
+# 4. The Cloud Monitoring p99 latency alert auto-closes within
+#    ~5 minutes of the new pod handling traffic at normal speed.
+gcloud alpha monitoring policies list \
+  --project=liverty-music-dev \
+  --filter='displayName="Zitadel OIDCService p99 latency"' \
+  --format='value(conditions[0].name,enabled)'
+# Visit Cloud Console → Monitoring → Alerting to confirm the
+# incident is resolved.
+```
+
+## Escalation
+
+Open an issue under `cloud-provisioning` (or comment on the existing
+`self-hosted-zitadel` §18.6 follow-up) with:
+
+1. Link to the alert in Cloud Monitoring.
+2. The `INCIDENT_DIR` artifacts (zip and attach, or upload to a GCS
+   bucket and link).
+3. The pod's prior uptime (from `pod-describe.txt`) and a one-line
+   summary of what state-changing API calls preceded the hang.
+
+Escalate to upstream Zitadel maintainers (`zitadel/zitadel` issue
+tracker) **only if**:
+
+- The same shape recurs within 24 hours of restart, **AND**
+- Forensic data captured does not match either §18.6 hypothesis A
+  or B (genuinely new failure mode).
+
+If the recurrence is consistent with hypothesis B and the
+connection-pool dashboard panel confirms saturation, file the issue
+with the connection-count time-series attached — that's the most
+upstream-actionable signal.
+
+## Related
+
+- `openspec/changes/archive/<date>-zitadel-observability/` — the
+  openspec change that introduced this runbook and the alerts that
+  surface the §18.6 shape.
+- `openspec/changes/self-hosted-zitadel/tasks.md` §18.6 — the
+  original incident write-up.
+- `k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml`
+  — the band-aid weekly restart CronJob (capped frequency to ≤ 7d).
+  Removing this band-aid is the goal of root-cause investigation.

--- a/docs/runbooks/zitadel-hang.md
+++ b/docs/runbooks/zitadel-hang.md
@@ -53,6 +53,13 @@ INCIDENT_DIR="/tmp/zitadel-hang-$(date -u +%Y%m%dT%H%M%SZ)"
 mkdir -p "$INCIDENT_DIR"
 cd "$INCIDENT_DIR"
 
+# Cross-platform "1 hour ago" — GNU `date -d` on Linux, BSD `date -v`
+# on macOS. We try GNU first; if that errors (BSD does not understand
+# `-d`), the `||` falls through to the BSD form. Used by the gcloud
+# calls below.
+ONE_HOUR_AGO=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)
+
 # 1. Identify the affected pod.
 kubectl get pods -n zitadel -l component=api -o wide > pods.txt
 
@@ -77,13 +84,13 @@ gcloud monitoring time-series list \
   --project=liverty-music-dev \
   --filter='metric.type="cloudsql.googleapis.com/database/postgresql/num_backends" AND resource.label.database_id="liverty-music-dev:postgres-osaka"' \
   --interval-end-time=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-  --interval-start-time=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ) \
+  --interval-start-time="$ONE_HOUR_AGO" \
   --format=json > sql-num-backends.json
 
 # 6. Recent Zitadel API request rate by gRPC method, to identify
 #    whether a state-changing API burst preceded the hang.
 gcloud logging read \
-  'resource.type="k8s_container" AND resource.labels.namespace_name="zitadel" AND resource.labels.container_name="zitadel" AND timestamp>="'$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)'"' \
+  'resource.type="k8s_container" AND resource.labels.namespace_name="zitadel" AND resource.labels.container_name="zitadel" AND timestamp>="'"$ONE_HOUR_AGO"'"' \
   --project=liverty-music-dev \
   --limit=10000 \
   --format=json > zitadel-recent-api-calls.json
@@ -115,10 +122,17 @@ kubectl rollout status deployment/zitadel -n zitadel --timeout=120s
 
 The default RollingUpdate strategy (`maxUnavailable: 0`,
 `maxSurge: 1`) rolls in a fresh pod before terminating the old one,
-so external auth traffic continues uninterrupted assuming at least
-one replica is healthy throughout. **In dev**, replicas are scaled
-to 1, so this becomes a brief (~30 s) outage; users on
-`auth.dev.liverty-music.app` may see 503s during the cutover.
+so external auth traffic continues uninterrupted regardless of
+replica count — the Service always has at least one Ready endpoint.
+**In dev**, replicas are scaled to 1, but the rollout is still
+zero-downtime for the same reason: the old pod is only terminated
+after the surge pod is Ready. The dev-specific risk is the inverse:
+if the spot pool has only one node and pod anti-affinity prevents
+co-location, the surge pod will be Pending and the rollout will
+stall while the old pod keeps serving (no 503s, but stuck
+Deployment). The `--timeout=120s` on `rollout status` above will
+catch this. If it expires, run `kubectl get events -n zitadel`
+and look for `FailedScheduling`.
 
 ## Post-mitigation verification
 

--- a/k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml
@@ -1,0 +1,131 @@
+# Weekly Zitadel API restart band-aid (dev only).
+#
+# Caps the upper bound on §18.6 hang incident frequency to ≤ 7 days.
+# The §18.6 cutover-incident hang shape (Zitadel API hung on
+# `GetAuthRequest` for 30+ seconds, returning `code: internal`) only
+# manifested after ~3.5 days of pod uptime + a high-density burst of
+# state-changing API calls. A weekly forced restart resets in-memory
+# state before the precondition for the hang accumulates.
+#
+# This is EXPLICITLY a band-aid — to be removed once a root cause is
+# found. The `liverty-music.app/temporary` annotation lets future ops
+# grep find this manifest for cleanup. See openspec change
+# `zitadel-observability` design D6 and `self-hosted-zitadel` §18.6.
+#
+# Schedule: Sundays 03:00 UTC = 12:00 JST = low-traffic window in
+# the only environment that runs (dev), no user-facing downtime.
+#
+# Why a separate ServiceAccount + RBAC: the CronJob calls `kubectl
+# rollout restart deploy/zitadel` which requires `patch` on
+# `deployments`. The default `zitadel` ServiceAccount has no such
+# permission (it's scoped to running Zitadel itself, not mutating
+# its own Deployment). A dedicated minimum-privilege identity keeps
+# the privilege scope auditable.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zitadel-restart
+  annotations:
+    liverty-music.app/temporary: "until-rootcause-self-hosted-zitadel-§18.6"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: zitadel-restart
+  annotations:
+    liverty-music.app/temporary: "until-rootcause-self-hosted-zitadel-§18.6"
+# Minimum-privilege: only `patch` on the specific `zitadel`
+# Deployment (resourceNames pin), nothing else in the namespace.
+# `patch` is what `kubectl rollout restart` issues — it sets the
+# `kubectl.kubernetes.io/restartedAt` annotation on the pod template.
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["zitadel"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zitadel-restart
+  annotations:
+    liverty-music.app/temporary: "until-rootcause-self-hosted-zitadel-§18.6"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: zitadel-restart
+subjects:
+- kind: ServiceAccount
+  name: zitadel-restart
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: zitadel-restart
+  annotations:
+    liverty-music.app/temporary: "until-rootcause-self-hosted-zitadel-§18.6"
+  labels:
+    app: zitadel
+    component: maintenance
+spec:
+  # Sundays 03:00 UTC. cron syntax: minute hour day-of-month month day-of-week
+  schedule: "0 3 * * 0"
+  timeZone: "Etc/UTC"
+  # Don't queue overlapping runs — if a previous restart job is still
+  # finishing when the next schedule fires (unlikely; rollout takes
+  # < 60 s), skip the new one.
+  concurrencyPolicy: Forbid
+  # Keep just enough history for ops to confirm "yes, last week ran":
+  # 1 successful + 1 failed entry covers the eyeball test.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  # If the cluster's offline at the scheduled time (e.g., dev cluster
+  # destroyed for cost optimization), don't try to backfill once it
+  # comes back — the next weekly fire is fine.
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400  # 24 h
+      template:
+        metadata:
+          labels:
+            app: zitadel
+            component: maintenance
+        spec:
+          serviceAccountName: zitadel-restart
+          restartPolicy: OnFailure
+          # Spot pool per `cloud-provisioning/CLAUDE.md` Dev Cost
+          # Optimization. The job is short-lived and idempotent, so
+          # spot eviction during the restart is acceptable.
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+          containers:
+          - name: kubectl
+            # bitnami/kubectl ships a minimal image with kubectl on
+            # the PATH. The :1.32 tag is pinned to match the cluster
+            # control-plane minor (1.35 minor diff is within the
+            # supported skew). Updates are a one-line bump in this
+            # file when the cluster bumps.
+            image: bitnami/kubectl:1.32
+            command:
+            - kubectl
+            args:
+            - rollout
+            - restart
+            - deployment/zitadel
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                cpu: 100m
+                memory: 64Mi
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 65532
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true

--- a/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
@@ -1,6 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Apply `zitadel` namespace to overlay-added resources (the base's
+# `namespace:` field only covers resources defined in the base; the
+# CronJob + RBAC below are introduced here, so we set it explicitly).
+namespace: zitadel
+
 resources:
 - ../../base
 # Dev-only band-aid for `self-hosted-zitadel` §18.6 hang. NOT in base,

--- a/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/kustomization.yaml
@@ -3,6 +3,11 @@ kind: Kustomization
 
 resources:
 - ../../base
+# Dev-only band-aid for `self-hosted-zitadel` §18.6 hang. NOT in base,
+# so staging / prod overlays do not silently inherit the weekly
+# restart. To be removed once the root cause is found — search the
+# `liverty-music.app/temporary` annotation to locate.
+- cronjob-restart-zitadel.yaml
 
 configMapGenerator:
 - name: zitadel-config


### PR DESCRIPTION
## Summary

Caps the upper-bound on the `self-hosted-zitadel` §18.6 hang incident frequency to ≤ 7 days by force-restarting the Zitadel API Deployment weekly in dev. Adds a first-responder runbook for the same incident shape so the next operator does not have to re-derive the response.

This is **PR-2 of the [`zitadel-observability`](../specification/openspec/changes/zitadel-observability) openspec change** (PR-1a #220 was the OTLP metrics pipeline prerequisite, PR-1b is the alerts, PR-3 is archive).

## Why this is a band-aid

The §18.6 incident shape — Zitadel API hung on `GetAuthRequest` for 30+ seconds with `code: internal` — only manifested after ~3.5 days of pod uptime + a high-density burst of state-changing API calls. Two hypotheses for the root cause are documented in `self-hosted-zitadel/tasks.md` §18.6.1:

1. **Hypothesis A**: in-memory projection updater stuck on a write lock.
2. **Hypothesis B**: Cloud SQL connection-pool exhaustion from leaked connections in async notification-worker retries.

Both resolve on pod restart, so a weekly restart covers both without committing to a root cause. The forensic-capture step in the runbook is what eventually disambiguates the two hypotheses.

The band-aid is **explicitly temporary**. Each resource carries `liverty-music.app/temporary: "until-rootcause-self-hosted-zitadel-§18.6"` so a future grep finds it for cleanup.

## What changes

### `k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml` (new)

Single multi-document YAML containing 4 resources (all in the `zitadel` namespace via `kustomization.yaml`):

| Resource | Purpose |
|---|---|
| `ServiceAccount/zitadel-restart` | Dedicated identity for the CronJob |
| `Role/zitadel-restart` | Minimum-privilege: `get`/`patch` on the `zitadel` Deployment only (`resourceNames` pin). `patch` is what `kubectl rollout restart` issues. |
| `RoleBinding/zitadel-restart` | Binds Role to ServiceAccount |
| `CronJob/zitadel-restart` | Schedule `0 3 * * 0` (Sun 03:00 UTC). Image `bitnami/kubectl:1.32`. Command `kubectl rollout restart deployment/zitadel`. |

CronJob spec respects `cloud-provisioning/CLAUDE.md` Dev Cost Optimization:
- Spot pool nodeSelector
- Explicit `resources.requests` + `resources.limits`
- `securityContext`: `runAsNonRoot`, `readOnlyRootFilesystem`, all caps dropped
- `concurrencyPolicy: Forbid`, history limited to 1 success + 1 failure
- `startingDeadlineSeconds: 600` so a transient cluster outage doesn't try to backfill missed runs

### `k8s/namespaces/zitadel/overlays/dev/kustomization.yaml`

Adds `cronjob-restart-zitadel.yaml` to `resources:` with an inline comment explaining the temporary nature. The base `kustomization.yaml` is **not** modified — staging / prod overlays will not silently inherit the band-aid.

### `docs/runbooks/zitadel-hang.md` (new)

First-responder runbook for the §18.6 hang incident shape. Sections:

1. **When this runbook applies** — symptom recognition checklist to confirm the incident matches §18.6 vs. a fresh incident.
2. **Forensic data capture (BEFORE mitigation)** — bash block that snapshots pod state, recent logs, Cloud SQL connection-count time-series, and an in-cluster API smoke test, all to `/tmp/zitadel-hang-<ISO-timestamp>/`. Capturing **before** restart is critical because in-memory state is lost on pod recycle.
3. **Mitigation** — exact `kubectl rollout restart` command + cluster-context confirmation.
4. **Post-mitigation verification** — `/debug/healthz`, OIDC discovery latency, alert auto-close confirmation.
5. **Escalation** — when to file an upstream Zitadel issue (consistent recurrence within 24h that doesn't match either documented hypothesis).

Source of truth is the `zitadel-observability` spec ("Operator runbook for the Zitadel hang incident shape" requirement); the docs file is a convenience export so ops doesn't need to know about openspec.

## Pulumi preview impact

None. This PR contains only K8s manifest + docs changes. ArgoCD picks them up on merge:

```
expected ArgoCD diff:
  + ServiceAccount/zitadel-restart        (new)
  + Role/zitadel-restart                  (new)
  + RoleBinding/zitadel-restart           (new)
  + CronJob/zitadel-restart               (new)
```

## Test plan

- [x] `kustomize build --enable-helm k8s/namespaces/zitadel/overlays/dev` — renders successfully; new resources visible.
- [x] `kube-linter lint` — no findings.
- [x] `scripts/check-spot-nodeselector.sh` — passes.
- [x] `make check` — biome + tsc + 27 vitest tests green.
- [ ] CI green on this branch.
- [ ] Post-merge: ArgoCD reconciles `zitadel` Application; `kubectl get cronjob -n zitadel zitadel-restart` returns the new resource.
- [ ] Manually trigger a one-off run: `kubectl create job --from=cronjob/zitadel-restart -n zitadel test-restart-1` then watch `kubectl rollout status deployment/zitadel -n zitadel` complete with no downtime.
- [ ] Verify the next scheduled fire (next Sunday 03:00 UTC) leaves a successful Job entry in `kubectl get jobs -n zitadel`.

## Coordination with other PRs in this change

- **PR-1a** (#220, MERGED): OTLP metrics pipeline prerequisite. Not blocking this PR — the CronJob does not depend on metrics.
- **PR-1b** (next): `ZitadelMonitoringComponent` Pulumi alert + dashboard. Will land after metric type names are confirmed live in Cloud Monitoring (Zitadel pod still rolling out post-#220 merge at PR-2 author time).
- **PR-3**: archive once the above three are merged + verified.
