### PR TITLE
fix(monitoring): grant otel-collector metricWriter + reloader annotation

### DIFF
--- a/k8s/namespaces/otel-collector/base/deployment.yaml
+++ b/k8s/namespaces/otel-collector/base/deployment.yaml
@@ -4,6 +4,12 @@ metadata:
   name: otel-collector
   labels:
     app: otel-collector
+  annotations:
+    # Restart the Pod when `otel-collector-config` ConfigMap changes so
+    # pipeline edits (adding receivers, processors, new exporters) land
+    # without an operator running `kubectl rollout restart` by hand.
+    # Pairs with the same annotation on the `zitadel` Deployment.
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -296,12 +296,19 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 			otelCollectorName,
 			otelCollectorName,
 			'OTel Collector Service Account',
-			'Service account for OpenTelemetry Collector to export traces to Cloud Trace',
+			'Service account for OpenTelemetry Collector to export traces to Cloud Trace and metrics to Cloud Monitoring',
 			this,
 		)
 		this.otelCollectorServiceAccountEmail = otelCollectorSa.email
+		// `MetricWriter` covers `monitoring.metricDescriptors.create` and
+		// `monitoring.timeSeries.create`, both required by the
+		// `googlecloud` exporter when pushing custom metrics from OTLP.
+		// Without this role the exporter logs `PermissionDenied desc =
+		// Permission monitoring.metricDescriptors.create denied` for every
+		// new metric Zitadel/backend pushes (verified empirically during
+		// `zitadel-observability` PR-1a deploy).
 		iamSvc.bindProjectRoles(
-			[Roles.CloudTrace.Agent],
+			[Roles.CloudTrace.Agent, Roles.Monitoring.MetricWriter],
 			otelCollectorName,
 			otelCollectorSa.email,
 			this,


### PR DESCRIPTION
## Summary

Two follow-ups from validating `zitadel-observability` PR-1a (#220) live in dev — both gaps existed before #220 but were only exercised once metrics started flowing. Pulumi preview shows `+1 IAM bind / ~1 SA description / 213 unchanged`; no destructive ops.

This is **PR-1a-fix of the [`zitadel-observability`](../specification/openspec/changes/zitadel-observability) openspec change** (sits between the merged PR-1a #220 and the upcoming PR-1b alerts).

## Symptoms observed in dev after PR-1a deploy

After PR-1a merged + ArgoCD reconciled + the otel-collector pod was manually restarted (see Gap 2), the collector logs streamed:

```
error  collector@v0.50.0/metrics.go:768  Unable to send metric descriptor.
  otelcol.component.id=googlecloud, otelcol.signal=metrics
  error: rpc error: code = PermissionDenied desc = Permission monitoring.metricDescriptors.create denied
  metric_descriptor: type:"workload.googleapis.com/rpc.server.duration" ...
```

Zitadel was correctly pushing OTLP metrics; the collector was correctly translating them to `workload.googleapis.com/...` types; but the GCP API call to register the new metric descriptors was denied. Metrics never reached Cloud Monitoring.

Separately, after PR-1a updated `otel-collector-config`, the running Pod did not restart. The new metrics pipeline only became active after a manual `kubectl rollout restart`. The `zitadel` Deployment already had reloader auto-watching its configmap; the collector did not.

## Gap 1: missing `roles/monitoring.metricWriter` on otel-collector GSA

`src/gcp/components/kubernetes.ts` previously granted only `Roles.CloudTrace.Agent` to the collector SA — sufficient for traces (which use `cloudtrace.spans.create`) but insufficient for the new metrics path which calls:

- `monitoring.metricDescriptors.create`
- `monitoring.timeSeries.create`

Both are bundled in `roles/monitoring.metricWriter` (the same role GKE node SAs already use for kube/system metrics; established pattern in `kubernetes.ts:106` for the GKE node service account).

**Fix:** add `Roles.Monitoring.MetricWriter` to the `bindProjectRoles` array (line 304). One-line array extension; no new resource type, no signature changes.

## Gap 2: missing `reloader.stakater.com/auto` on `otel-collector` Deployment

The `zitadel` Deployment carries `reloader.stakater.com/auto: "true"` so configmap edits trigger a rolling restart. The `otel-collector` Deployment did not. Because PR-1a's primary change was a configmap edit (the new `metrics` pipeline), the collector pod silently kept running the old config until manual restart.

**Fix:** add the same annotation to `k8s/namespaces/otel-collector/base/deployment.yaml` so future pipeline edits (new receivers / processors / exporters) auto-apply on configmap change without operator memory.

## Pulumi preview

```
@ Previewing update
 ~ gcp:serviceaccount:Account otel-collector update [diff: ~description]
 +  gcp:projects:IAMMember otel-collector-x-monitoring-metric-writer create

Resources:
    + 1 to create
    ~ 2 to update
    213 unchanged
```

The `~` on the SA itself is just the description-string update we made (added "and metrics to Cloud Monitoring"); the `+` is the new IAM bind. K8s manifest change is not Pulumi-managed (ArgoCD reconciles).

## Test plan

- [x] `make check` (biome + tsc + 27 vitest tests) — green.
- [x] `kustomize build k8s/namespaces/otel-collector/overlays/dev` — `reloader.stakater.com/auto: "true"` visible on Deployment metadata.
- [x] `pulumi preview --stack dev` — clean diff (1 IAM bind create + 1 SA description update + 213 unchanged).
- [ ] CI green on this branch.
- [ ] Post-merge: Pulumi Cloud auto-applies the IAM bind. ArgoCD reconciles the Deployment annotation. The collector pod is rolled by reloader (this commit's reloader annotation is itself a configmap-watching trigger; the rollout happens because the Deployment template changed). Confirm metric flow:

  ```bash
  kubectl logs -n otel-collector deploy/otel-collector --tail=100 | grep -i error
  # expect: no PermissionDenied errors
  curl --header "Authorization: Bearer $(gcloud auth print-access-token)" \
    'https://monitoring.googleapis.com/v3/projects/liverty-music-dev/metricDescriptors?filter=metric.type%3Dhas_substring(%22rpc.server.duration%22)'
  # expect: returns the metric descriptor
  ```

## Coordination with other PRs in this change

- **PR-1a** (#220, MERGED): wired up the OTLP metrics pipeline + Zitadel OTEL env vars. This PR-1a-fix repairs the IAM and reloader gaps that PR-1a's deploy exposed.
- **PR-2** (#221, OPEN): independent dev band-aid CronJob + runbook. Not blocked by this PR.
- **PR-1b** (next): the actual `ZitadelMonitoringComponent` (Pulumi `AlertPolicy` + `Dashboard`) — depends on this PR-1a-fix for metrics to reach Cloud Monitoring.
- **PR-3**: archive.
