### PR TITLE
feat(zitadel): bootstrap admin role org via FIRSTINSTANCE_ORG_NAME

### DIFF
--- a/k8s/namespaces/zitadel/base/configmap.env
+++ b/k8s/namespaces/zitadel/base/configmap.env
@@ -34,7 +34,16 @@ ZITADEL_DATABASE_POSTGRES_ADMIN_SSL_MODE=disable
 # database is empty; subsequent boots ignore them. On first boot, Zitadel
 # writes a JSON key at MACHINEKEYPATH which the bootstrap sidecar uploads to
 # GCP Secret Manager for Pulumi's provider to consume on the next stack apply.
+#
+# ORG_NAME pins the bootstrap-created role org name (the org that holds
+# pulumi-admin) so every environment's first-instance bootstrap produces
+# the same `admin` org topology. Pulumi then creates a separate
+# `liverty-music` product org via `zitadel.Org` for product resources and
+# end-user accounts. This two-org split mirrors the pattern Zitadel Cloud
+# used (see OpenSpec change `add-zitadel-console-admin-via-google-idp`,
+# decisions D1–D3).
 ZITADEL_FIRSTINSTANCE_MACHINEKEYPATH=/var/zitadel/bootstrap/admin-sa.json
+ZITADEL_FIRSTINSTANCE_ORG_NAME=admin
 ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME=pulumi-admin
 ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME=Pulumi Admin
 ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINEKEY_TYPE=1


### PR DESCRIPTION
## Summary

- Set `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` in the Zitadel ConfigMap so every
  environment's first-instance bootstrap produces an `admin` role org instead
  of the default `ZITADEL`.
- This is the **PR 1 of 2** for OpenSpec change
  `add-zitadel-console-admin-via-google-idp`. The env var is only honored
  when the DB is empty, so this PR alone is a no-op against the running dev
  instance — Reloader restarts the pod, the new ENV is read but discarded
  because the DB already has data.
- The follow-up Pulumi PR (PR 2) wires the two-org structure
  (`admin` + `liverty-music`), the Google IdP, and the human admin user.

## Why this is a separate PR

ArgoCD `selfHeal=true` would revert any out-of-band ConfigMap edit. The dev
DB wipe + re-bootstrap step needs the new ENV to be in effect first, so we
push the ConfigMap through the normal git → ArgoCD path, then wipe + reboot
manually, then ship the Pulumi changes in PR 2 (which references the new
admin org id captured during bootstrap).

## Test plan

- [x] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` confirms
  `ZITADEL_FIRSTINSTANCE_ORG_NAME: admin` is rendered into the ConfigMap.
- [ ] After merge, ArgoCD syncs the new ConfigMap (`zitadel` app stays
  Healthy/Synced).
- [ ] Reloader auto-restarts the `zitadel` deployment; pod starts cleanly
  against the existing DB (the new ENV is read but ignored).
- [ ] `kubectl -n zitadel get configmap -o yaml | grep ORG_NAME` shows the
  new key.
