### PR TITLE
feat(zitadel): two-org topology with Google IdP for admin Console sign-in

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,14 @@ const postmarkConfig = config.requireObject(
 // ESC: `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext) and
 // `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (encrypted).
 // See OpenSpec change `add-zitadel-console-admin-via-google-idp`.
-const zitadelConfig = new pulumi.Config('zitadel')
+//
+// Read via the project-level config (matching the existing pattern
+// `config.requireObject('postmark')`) — `pulumi.Config()` defaults to the
+// `liverty-music` project namespace. A `pulumi.Config('zitadel')` would
+// look in the unrelated `zitadel:` provider namespace and fail.
+const zitadelConfig = config.requireSecretObject<{
+	googleAdminIdp: { clientId: string; clientSecret: string }
+}>('zitadel')
 
 const env = pulumi.getStack() as Environment
 
@@ -63,21 +70,19 @@ if (env === 'prod') {
 let zitadelMachineKey: pulumi.Output<string> | undefined
 let zitadelLoginPat: pulumi.Output<string> | undefined
 if (env === 'dev') {
-	// `requireSecretObject` marks the entire object's values as secret in
-	// Pulumi state and previews, which is conservative for an OAuth client
-	// (the client_id is not strictly a secret but treating it the same
-	// avoids accidental disclosure in state).
-	const googleAdminIdp = zitadelConfig.requireSecretObject<{
-		clientId: string
-		clientSecret: string
-	}>('googleAdminIdp')
-
 	const zitadel = new Zitadel('liverty-music', {
 		env,
 		gcpProjectId: `${brandId}-${env}`,
 		postmarkServerApiToken: postmarkConfig.serverApiToken,
-		googleAdminIdpClientId: googleAdminIdp.apply((o) => o.clientId),
-		googleAdminIdpClientSecret: googleAdminIdp.apply((o) => o.clientSecret),
+		// `zitadelConfig` is `pulumi.Output<{ googleAdminIdp: ... }>` because
+		// `requireSecretObject` marks the entire object as secret. Both
+		// derived values are therefore secret-marked Outputs in Pulumi state.
+		googleAdminIdpClientId: zitadelConfig.apply(
+			(z) => z.googleAdminIdp.clientId,
+		),
+		googleAdminIdpClientSecret: zitadelConfig.apply(
+			(z) => z.googleAdminIdp.clientSecret,
+		),
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails
 	zitadelLoginPat = zitadel.loginClientToken

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,13 @@ const postmarkConfig = config.requireObject(
 	serverApiToken: string
 }
 
+// Google OAuth 2.0 Web Application client credentials for the admin
+// Google IdP that gates Zitadel Admin Console sign-in. Set per-env via
+// ESC: `pulumiConfig.zitadel.googleAdminIdp.clientId` (plaintext) and
+// `pulumiConfig.zitadel.googleAdminIdp.clientSecret` (encrypted).
+// See OpenSpec change `add-zitadel-console-admin-via-google-idp`.
+const zitadelConfig = new pulumi.Config('zitadel')
+
 const env = pulumi.getStack() as Environment
 
 // 1. GitHub Organization Configuration (Prod Only)
@@ -56,10 +63,21 @@ if (env === 'prod') {
 let zitadelMachineKey: pulumi.Output<string> | undefined
 let zitadelLoginPat: pulumi.Output<string> | undefined
 if (env === 'dev') {
+	// `requireSecretObject` marks the entire object's values as secret in
+	// Pulumi state and previews, which is conservative for an OAuth client
+	// (the client_id is not strictly a secret but treating it the same
+	// avoids accidental disclosure in state).
+	const googleAdminIdp = zitadelConfig.requireSecretObject<{
+		clientId: string
+		clientSecret: string
+	}>('googleAdminIdp')
+
 	const zitadel = new Zitadel('liverty-music', {
 		env,
 		gcpProjectId: `${brandId}-${env}`,
 		postmarkServerApiToken: postmarkConfig.serverApiToken,
+		googleAdminIdpClientId: googleAdminIdp.apply((o) => o.clientId),
+		googleAdminIdpClientSecret: googleAdminIdp.apply((o) => o.clientSecret),
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails
 	zitadelLoginPat = zitadel.loginClientToken

--- a/src/zitadel/components/admin-org-config.ts
+++ b/src/zitadel/components/admin-org-config.ts
@@ -1,0 +1,126 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface AdminOrgConfigComponentArgs {
+	/** ID of the bootstrap-created `admin` role org. */
+	adminOrgId: pulumi.Input<string>
+	/** ID of the instance-level Google IdP that admins sign in with. */
+	googleIdpId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * AdminOrgConfigComponent provisions login-policy resources that govern
+ * how human admins authenticate to the Zitadel Admin Console:
+ *
+ * 1. `LoginPolicy` on the `admin` org — explicit override that disables
+ *    username + password sign-in (`userLogin = false`) and exposes the
+ *    Google IdP as the only sign-in method.
+ *
+ * 2. `DefaultLoginPolicy` (instance-level) — mirror of the admin org's
+ *    policy. Acts as the fallback Login V2 uses when an OIDC AuthN
+ *    arrives without a specific org context (e.g., Console login). The
+ *    `liverty-music` product org has its own explicit `LoginPolicy`
+ *    override (passkey-only) that takes precedence over this default for
+ *    end-user app sign-in.
+ *
+ * Why both: Login V2's exact routing rule between "instance default" and
+ * "user's home org" is under-documented in Zitadel v4. Configuring both
+ * layers identically converges on the same correct outcome regardless of
+ * which path Zitadel takes (see OpenSpec design D8).
+ *
+ * `allowDomainDiscovery = true` is set on the admin org policy so that
+ * future explicit verified-domain registration (e.g. `pannpers.dev` as a
+ * verified org domain) just works for email-domain routing.
+ *
+ * `userLogin = false` is the linchpin that makes the random
+ * `initialPassword` we set on the human admin (required to unlock
+ * `isEmailVerified = true` at creation per @pulumiverse/zitadel) totally
+ * unreachable for sign-in.
+ */
+export class AdminOrgConfigComponent extends pulumi.ComponentResource {
+	public readonly adminLoginPolicy: zitadel.LoginPolicy
+	public readonly defaultLoginPolicy: zitadel.DefaultLoginPolicy
+
+	constructor(
+		name: string,
+		args: AdminOrgConfigComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:AdminOrgConfig', name, {}, opts)
+
+		const { adminOrgId, googleIdpId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		// Shared policy fields. Most lifetimes are the same as the existing
+		// product-org LoginPolicy in `frontend.ts` for consistency. NOT
+		// declared with `as const` because @pulumiverse/zitadel's
+		// `idps?: pulumi.Input<pulumi.Input<string>[]>` requires a mutable
+		// array — a readonly tuple would not assign.
+		const sharedPolicyFields = {
+			// Disable username + password sign-in. The random initialPassword
+			// on the human admin (required so isEmailVerified can be true at
+			// creation) is unreachable because of this flag.
+			userLogin: false,
+			// Disallow self-registration. Only Pulumi-provisioned HumanUsers
+			// may exist in this org; auto-register would let any Google
+			// identity become a Zitadel user.
+			allowRegister: false,
+			// Permit the IdP buttons to appear on the Login UI.
+			allowExternalIdp: true,
+			// Multi-factor controls — not enforced; passkey or Google's own
+			// MFA covers the strong-auth side. Revisit when adding more
+			// admins or when prod follows.
+			forceMfa: false,
+			forceMfaLocalOnly: false,
+			// Passkey allowed as a separate flow alongside Google IdP for
+			// future flexibility (e.g. an admin enrolls a passkey directly).
+			passwordlessType: 'PASSWORDLESS_TYPE_ALLOWED',
+			// Hide password reset link — there is no usable password to reset.
+			hidePasswordReset: true,
+			// User convenience: do not 404 on unknown usernames at the first
+			// step (mirrors product-org policy).
+			ignoreUnknownUsernames: true,
+			// Default redirect after a context-less login completes. Send to
+			// the Console UI so admins land somewhere meaningful.
+			defaultRedirectUri: 'https://auth.dev.liverty-music.app/ui/console',
+			// Standard session lifetimes (mirrored from product org policy).
+			passwordCheckLifetime: '240h0m0s',
+			externalLoginCheckLifetime: '240h0m0s',
+			multiFactorCheckLifetime: '24h0m0s',
+			mfaInitSkipLifetime: '720h0m0s',
+			secondFactorCheckLifetime: '24h0m0s',
+			// IdP buttons to display.
+			idps: [googleIdpId],
+		}
+
+		// Admin org explicit LoginPolicy override.
+		this.adminLoginPolicy = new zitadel.LoginPolicy(
+			'admin-org-login-policy',
+			{
+				...sharedPolicyFields,
+				orgId: adminOrgId,
+				// Future-proof email-domain routing. Does not require a
+				// verified domain to be registered today.
+				allowDomainDiscovery: true,
+			},
+			resourceOptions,
+		)
+
+		// Instance-level DefaultLoginPolicy. Used as fallback when no org
+		// override applies (notably Console login per design D8).
+		this.defaultLoginPolicy = new zitadel.DefaultLoginPolicy(
+			'instance-default-login-policy',
+			{
+				...sharedPolicyFields,
+				allowDomainDiscovery: true,
+			},
+			resourceOptions,
+		)
+
+		this.registerOutputs({
+			adminLoginPolicy: this.adminLoginPolicy,
+			defaultLoginPolicy: this.defaultLoginPolicy,
+		})
+	}
+}

--- a/src/zitadel/components/google-admin-idp.ts
+++ b/src/zitadel/components/google-admin-idp.ts
@@ -1,0 +1,82 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface GoogleAdminIdpComponentArgs {
+	/** OAuth 2.0 Web Application client_id from the Google Cloud project
+	 *  hosting the consent screen for `pannpers.dev` Workspace admins. */
+	clientId: pulumi.Input<string>
+	/** OAuth 2.0 Web Application client_secret. MUST be passed as a
+	 *  `pulumi.Output<string>` wrapped in `pulumi.secret()` upstream so it
+	 *  is masked in state and previews. */
+	clientSecret: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * GoogleAdminIdpComponent provisions the instance-level Google IdP that
+ * the `admin` role org's `LoginPolicy` references for human admin
+ * sign-in to the Zitadel Admin Console.
+ *
+ * Identity flow on first sign-in:
+ *   1. Pannpers visits `/ui/console`.
+ *   2. Login V2 shows the IdP buttons listed in the admin org's policy.
+ *   3. Pannpers clicks "Sign in with Google", completes Google OAuth.
+ *   4. Zitadel receives the verified email `pannpers@pannpers.dev`.
+ *   5. Because `isLinkingAllowed = true` and a local `HumanUser` with
+ *      that email already exists in the admin org (provisioned by
+ *      `HumanAdminComponent`), Zitadel links the IdP identity to the
+ *      local user without creating a duplicate.
+ *   6. The local user holds `IAM_OWNER` via `InstanceMember`, so Console
+ *      loads with full instance-level access.
+ *
+ * Why instance-level (not org-level): the admin org's `LoginPolicy`
+ * references this IdP via the instance-level id. Org-level IdPs would
+ * couple the IdP lifecycle to one org and make it harder to reuse for a
+ * future second admin org or for other instance-level IdPs.
+ *
+ * Why `isCreationAllowed = false` and `isAutoCreation = false`: only
+ * pre-provisioned local human users (declared in Pulumi) may receive
+ * `IAM_OWNER`. Allowing auto-creation would let anyone with a
+ * pannpers.dev Google account become a Zitadel user implicitly.
+ *
+ * Why `isAutoUpdate = true`: keep first/last name and email fresh on
+ * each sign-in, so display names in audit logs match Workspace.
+ */
+export class GoogleAdminIdpComponent extends pulumi.ComponentResource {
+	public readonly idp: zitadel.IdpGoogle
+
+	constructor(
+		name: string,
+		args: GoogleAdminIdpComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:GoogleAdminIdp', name, {}, opts)
+
+		const { clientId, clientSecret, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		this.idp = new zitadel.IdpGoogle(
+			'admin-google',
+			{
+				name: 'Google (admin)',
+				clientId,
+				clientSecret,
+				scopes: ['openid', 'profile', 'email'],
+				// Allow linking incoming Google identity to a pre-provisioned
+				// local human user with matching verified email. This is the
+				// auto-link mechanism for the admin Console sign-in flow.
+				isLinkingAllowed: true,
+				// Disallow auto-create of new local users from external sign-in.
+				// Only Pulumi-declared HumanUsers may receive IAM_OWNER.
+				isCreationAllowed: false,
+				isAutoCreation: false,
+				// Keep first/last name + email fresh on each sign-in so audit
+				// logs show the current Workspace display name.
+				isAutoUpdate: true,
+			},
+			resourceOptions,
+		)
+
+		this.registerOutputs({ idp: this.idp })
+	}
+}

--- a/src/zitadel/components/human-admin.ts
+++ b/src/zitadel/components/human-admin.ts
@@ -1,0 +1,117 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as random from '@pulumi/random'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface HumanAdminComponentArgs {
+	/** ID of the bootstrap-created `admin` role org. */
+	adminOrgId: pulumi.Input<string>
+	/** Admin's verified email address (also used as the local userName so
+	 *  that the Login V2 username field accepts the email directly). */
+	email: pulumi.Input<string>
+	/** Admin's first name (Workspace profile). */
+	firstName: pulumi.Input<string>
+	/** Admin's last name (Workspace profile). */
+	lastName: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * HumanAdminComponent provisions a single human admin user in the
+ * `admin` role org and grants them `IAM_OWNER` at the instance level.
+ *
+ * Sign-in flow: the admin signs in via Google IdP. Zitadel matches the
+ * verified Google email to the local user provisioned here and links
+ * the IdP identity (see `GoogleAdminIdpComponent` for the linking
+ * settings). After the link is established, the local user's
+ * `IAM_OWNER` membership applies — the admin can use the Console.
+ *
+ * ## Why a random initialPassword
+ *
+ * `@pulumiverse/zitadel.HumanUser` documents:
+ *
+ *   > Caution: Email can only be set verified if a password is set for
+ *   > the user, either with initialPassword or during runtime.
+ *
+ * We need `isEmailVerified = true` at creation so the OIDC sign-in
+ * flow does not block on an OTP step (the existing pattern documented
+ * in the identity-management capability for self-registration). The
+ * provider only allows that if `initialPassword` is also present.
+ *
+ * Setting a random, never-disclosed password satisfies the constraint.
+ * The password is unreachable in practice because the admin org's
+ * `LoginPolicy.userLogin = false` (see `AdminOrgConfigComponent`)
+ * disables the username + password sign-in form entirely. The Login V2
+ * UI for the admin org only ever presents the IdP buttons.
+ *
+ * `random.RandomPassword` persists the value in Pulumi state, but it
+ * never leaves Pulumi (no Output, no GSM write, no log). This is a
+ * deliberate trade-off: the password's existence is needed only to
+ * unlock `isEmailVerified`, not to be used.
+ */
+export class HumanAdminComponent extends pulumi.ComponentResource {
+	public readonly humanUser: zitadel.HumanUser
+	public readonly instanceMember: zitadel.InstanceMember
+
+	constructor(
+		name: string,
+		args: HumanAdminComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:HumanAdmin', name, {}, opts)
+
+		const { adminOrgId, email, firstName, lastName, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		// Random password to satisfy @pulumiverse/zitadel's constraint that
+		// isEmailVerified=true requires a password to be present. Never
+		// exposed beyond Pulumi state. Length 64, no special chars to keep
+		// it shell-safe in case state is ever inspected manually.
+		const password = new random.RandomPassword(
+			'admin-initial-password',
+			{
+				length: 64,
+				special: false,
+				upper: true,
+				lower: true,
+				numeric: true,
+			},
+			{ parent: this },
+		)
+
+		this.humanUser = new zitadel.HumanUser(
+			'pannpers',
+			{
+				orgId: adminOrgId,
+				// userName + email are the same so Login V2's username field
+				// accepts the email address directly. preferredLoginName ends
+				// up being the email after Zitadel applies the username rules.
+				userName: email,
+				email,
+				firstName,
+				lastName,
+				preferredLanguage: 'ja',
+				// Pre-verified email, paired with the random initialPassword
+				// above per the @pulumiverse/zitadel constraint.
+				isEmailVerified: true,
+				initialPassword: pulumi.secret(password.result),
+			},
+			resourceOptions,
+		)
+
+		// Grant IAM_OWNER at instance level so this admin can perform any
+		// Console / Management API operation across all orgs in the instance.
+		this.instanceMember = new zitadel.InstanceMember(
+			'pannpers-iam-owner',
+			{
+				userId: this.humanUser.id,
+				roles: ['IAM_OWNER'],
+			},
+			{ ...resourceOptions, dependsOn: [this.humanUser] },
+		)
+
+		this.registerOutputs({
+			humanUser: this.humanUser,
+			instanceMember: this.instanceMember,
+		})
+	}
+}

--- a/src/zitadel/constants.ts
+++ b/src/zitadel/constants.ts
@@ -57,16 +57,31 @@ export const BACKEND_WEBHOOK_BASE_URL =
 export const PRE_ACCESS_TOKEN_PATH = '/pre-access-token'
 
 /**
- * Default Organization ID assigned by Zitadel at first-instance bootstrap.
+ * Bootstrap-created `admin` Role Org ID for the dev environment.
  *
- * Discovered post-bootstrap via `GET /auth/v1/users/me` against the
- * machine user that bootstrap-uploader writes to GSM
- * (`zitadel-admin-sa-key`). The value is stable across pod restarts
- * but instance-specific — if the dev Zitadel database is wiped and
- * re-bootstrapped, this constant must be updated.
+ * Per OpenSpec change `add-zitadel-console-admin-via-google-idp`, the
+ * Zitadel instance is split into two orgs:
+ *   - `admin` role org — created by Zitadel at first-instance bootstrap
+ *     because the configmap sets `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.
+ *     Hosts the `pulumi-admin` machine user (used by Pulumi to authenticate),
+ *     the `login-client` machine user (Login V2 PAT host), and human admins.
+ *   - `liverty-music` product org — created by Pulumi via `zitadel.Org`.
+ *     Hosts the product Project, ApplicationOidc, end-user LoginPolicy,
+ *     `backend-app` machine user, and end-user accounts.
  *
- * Hardcoded for dev because cutover is dev-only (OpenSpec D10).
- * Staging / prod migrations must extend this with an env-keyed map or
- * a Dynamic Resource that discovers the orgId from the admin SA key.
+ * The id below is the dev environment's `admin` org id, discovered
+ * post-bootstrap via `POST /admin/v1/orgs/_search` against the machine
+ * user whose JSON key the bootstrap-uploader sidecar writes to GSM
+ * (`zitadel-admin-sa-key`). The value is stable across pod restarts but
+ * instance-specific — if the dev Zitadel database is wiped and
+ * re-bootstrapped, this constant MUST be updated to the new admin org id
+ * before running `pulumi up` against the re-bootstrapped instance.
+ *
+ * Captured 2026-05-03 after the dev DB wipe + re-bootstrap step in
+ * tasks.md Section 5: configmap.env now sets
+ * `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`, so this id refers to the org
+ * named `admin` (verified via `POST /admin/v1/orgs/_search`). Staging /
+ * prod adoption (separate change) extends this with an env-keyed map
+ * or a Dynamic Resource that discovers the orgId from the admin SA key.
  */
-export const ZITADEL_DEV_DEFAULT_ORG_ID = '369968599999251129'
+export const ZITADEL_DEV_ADMIN_ORG_ID = '371280364565496672'

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -3,19 +3,25 @@ import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../config.js'
 import { ActionsV2Component } from './components/actions-v2.js'
+import { AdminOrgConfigComponent } from './components/admin-org-config.js'
 import { FrontendComponent } from './components/frontend.js'
+import { GoogleAdminIdpComponent } from './components/google-admin-idp.js'
+import { HumanAdminComponent } from './components/human-admin.js'
 import { LoginClientComponent } from './components/login-client.js'
 import { MachineUserComponent } from './components/machine-user.js'
 import { SmtpComponent } from './components/smtp.js'
 import {
 	BACKEND_WEBHOOK_BASE_URL,
 	PRE_ACCESS_TOKEN_PATH,
-	ZITADEL_DEV_DEFAULT_ORG_ID,
+	ZITADEL_DEV_ADMIN_ORG_ID,
 	zitadelDomainMap,
 } from './constants.js'
 
 export * from './components/actions-v2.js'
+export * from './components/admin-org-config.js'
 export * from './components/frontend.js'
+export * from './components/google-admin-idp.js'
+export * from './components/human-admin.js'
 export * from './components/login-client.js'
 export * from './components/machine-user.js'
 export * from './components/secrets.js'
@@ -30,37 +36,67 @@ export interface ZitadelArgs {
 	gcpProjectId: pulumi.Input<string>
 	/** Postmark Server API Token — used as both SMTP username and password. */
 	postmarkServerApiToken: string
+	/** Google OAuth 2.0 Web Application client_id for the admin Google IdP.
+	 *  Sourced from Pulumi config `zitadel:googleAdminIdp.clientId` (ESC
+	 *  `pulumiConfig.zitadel.googleAdminIdp.clientId`). */
+	googleAdminIdpClientId: pulumi.Input<string>
+	/** Google OAuth 2.0 Web Application client_secret for the admin Google
+	 *  IdP. Sourced from Pulumi config
+	 *  `zitadel:googleAdminIdp.clientSecret` (ESC
+	 *  `pulumiConfig.zitadel.googleAdminIdp.clientSecret`, marked secret).
+	 *  MUST be passed wrapped in `pulumi.secret()` upstream. */
+	googleAdminIdpClientSecret: pulumi.Input<string>
 }
 
 /**
- * Zitadel orchestrates all Zitadel identity resources against the in-cluster
- * self-hosted Zitadel instance reachable at the env-specific issuer hostname
- * (e.g. `https://auth.dev.liverty-music.app` for dev).
+ * Zitadel orchestrates all Zitadel identity resources against the
+ * in-cluster self-hosted Zitadel instance reachable at the env-specific
+ * issuer hostname (e.g. `https://auth.dev.liverty-music.app` for dev).
  *
- * Cutover from Zitadel Cloud → self-hosted happened in cloud-provisioning's
- * `self-hosted-zitadel-cutover` PR. The provider's `domain` input now reads
- * from `constants.ts:zitadelDomainMap[env]`, and `jwtProfileJson` is sourced
- * from the GSM secret `zitadel-admin-sa-key` that the in-cluster Zitadel
- * pod's `bootstrap-uploader` sidecar wrote on first boot.
+ * ## Two-org topology
  *
- * The Cloud tenant's Zitadel resources are intentionally NOT torn down by
- * this class — per OpenSpec D10, the Cloud tenant is retained as a rollback
- * target for two weeks. Pulumi state for those resources must be removed
- * manually before merging the cutover PR (see runbook in proposal.md).
+ * Per OpenSpec change `add-zitadel-console-admin-via-google-idp`, the
+ * instance is split into two orgs by responsibility:
  *
- * Cutover scope is dev-only (D10). The `env` guard below makes a staging /
- * prod attempt fail loudly until those environments get their own
- * `ZITADEL_DEFAULT_ORG_ID` (and any other env-specific bootstrap state)
- * threaded through.
+ * - **`admin` role org** — created by Zitadel at first-instance bootstrap
+ *   because the configmap sets `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.
+ *   Hosts operator identities only: `pulumi-admin` (machine, IaC and
+ *   break-glass), `login-client` (machine, Login V2 PAT), and human
+ *   admins like `pannpers@pannpers.dev` (Google SSO via instance-level
+ *   IdP). Holds an explicit `LoginPolicy` that disables username +
+ *   password sign-in and exposes the Google IdP.
+ *
+ * - **`liverty-music` product org** — created by Pulumi as
+ *   `zitadel.Org('liverty-music', { isDefault: true })`. Hosts product
+ *   resources and end-user identities only: the `liverty-music` Project,
+ *   the frontend `ApplicationOidc`, the passkey-only end-user
+ *   `LoginPolicy`, the `backend-app` machine user (used by the backend
+ *   Go service to call Zitadel Management APIs), and future fan
+ *   accounts.
+ *
+ * Pulumi authenticates as `pulumi-admin` (admin org), reads the JWT
+ * profile JSON from GSM `zitadel-admin-sa-key`, and provisions
+ * everything else from there.
+ *
+ * Cutover scope is dev-only. Staging / prod adoption is a separate
+ * change; the `env` guard below makes a staging / prod attempt fail
+ * loudly until those environments get their own
+ * `ZITADEL_<ENV>_ADMIN_ORG_ID`, configmap with
+ * `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`, and Google OAuth client wired
+ * through Pulumi ESC.
  */
 export class Zitadel {
 	public readonly provider: zitadel.Provider
+	public readonly productOrg: zitadel.Org
 	public readonly project: zitadel.Project
 	public readonly frontend: FrontendComponent
 	public readonly smtp: SmtpComponent
 	public readonly actionsV2: ActionsV2Component
 	public readonly machineUser: MachineUserComponent
 	public readonly loginClient: LoginClientComponent
+	public readonly googleAdminIdp: GoogleAdminIdpComponent
+	public readonly adminOrgConfig: AdminOrgConfigComponent
+	public readonly humanAdmin: HumanAdminComponent
 
 	/** JWT profile JSON for the backend-app machine user. Store in Secret Manager. */
 	public readonly machineKeyDetails: pulumi.Output<string>
@@ -71,24 +107,32 @@ export class Zitadel {
 	public readonly loginClientToken: pulumi.Output<string>
 
 	constructor(name: string, args: ZitadelArgs) {
-		const { env, gcpProjectId, postmarkServerApiToken } = args
+		const {
+			env,
+			gcpProjectId,
+			postmarkServerApiToken,
+			googleAdminIdpClientId,
+			googleAdminIdpClientSecret,
+		} = args
 
 		if (env !== 'dev') {
-			// Self-hosted Zitadel cutover is dev-only per OpenSpec D10.
+			// Self-hosted Zitadel + two-org admin topology is dev-only.
 			// Extending to staging / prod requires:
-			//   - An env-keyed default-org-id source (constants.ts or
-			//     a Dynamic Resource that discovers it from the admin SA key).
+			//   - An env-keyed admin-org-id source (constants.ts or a Dynamic
+			//     Resource that discovers it from the admin SA key).
 			//   - A bootstrapped self-hosted instance with admin-sa-key in
-			//     that environment's GSM.
+			//     that environment's GSM, with
+			//     ZITADEL_FIRSTINSTANCE_ORG_NAME=admin in the configmap.
+			//   - Per-env Google OAuth client + ESC config.
 			//   - A separate cutover PR per environment.
 			throw new Error(
-				`Zitadel self-hosted cutover is dev-only; got env=${env}. ` +
-					'See OpenSpec change "self-hosted-zitadel" §13 (cutover scope) ' +
-					'and §15 (cooldown) for the staging/prod migration plan.',
+				`Zitadel self-hosted topology is dev-only; got env=${env}. ` +
+					'See OpenSpec change "add-zitadel-console-admin-via-google-idp" ' +
+					'for the staging/prod adoption plan.',
 			)
 		}
 
-		const orgId = ZITADEL_DEV_DEFAULT_ORG_ID
+		const adminOrgId = ZITADEL_DEV_ADMIN_ORG_ID
 		const domain = zitadelDomainMap[env]
 
 		// Pull the bootstrap-uploaded admin machine user JWT-profile JSON from
@@ -117,11 +161,25 @@ export class Zitadel {
 			jwtProfileJson,
 		})
 
+		// Product org — Pulumi-managed, marked Zitadel default org so that
+		// OIDC AuthN requests without an explicit org_id (e.g. the frontend
+		// SPA's auth flow) route to it. `isDefault: true` here flips the
+		// instance default away from the bootstrap admin org, which
+		// otherwise would carry the default flag.
+		this.productOrg = new zitadel.Org(
+			'liverty-music',
+			{
+				name: 'liverty-music',
+				isDefault: true,
+			},
+			{ provider: this.provider },
+		)
+
 		this.project = new zitadel.Project(
 			name,
 			{
 				name: name,
-				orgId,
+				orgId: this.productOrg.id,
 				// Minimal role settings for initial setup
 				projectRoleAssertion: false,
 				projectRoleCheck: false,
@@ -129,12 +187,12 @@ export class Zitadel {
 				// Use default private labeling to avoid potential policy conflicts with instance SMTP
 				privateLabelingSetting: 'PRIVATE_LABELING_SETTING_UNSPECIFIED',
 			},
-			{ provider: this.provider },
+			{ provider: this.provider, dependsOn: [this.productOrg] },
 		)
 
 		this.frontend = new FrontendComponent(name, {
 			env,
-			orgId,
+			orgId: this.productOrg.id,
 			projectId: this.project.id,
 			provider: this.provider,
 		})
@@ -154,18 +212,54 @@ export class Zitadel {
 			provider: this.provider,
 		})
 
+		// Product service machine user — backend-app calls Zitadel Management
+		// APIs from the backend Go service. Lives in the product org per the
+		// "Place Machine Users by Responsibility" requirement.
 		this.machineUser = new MachineUserComponent(name, {
-			orgId,
+			orgId: this.productOrg.id,
 			provider: this.provider,
 		})
 
 		this.machineKeyDetails = this.machineUser.keyDetails
 
+		// Operator machine user — login-client hosts the Login V2 PAT. Lives
+		// in the admin role org per the "Place Machine Users by
+		// Responsibility" requirement.
 		this.loginClient = new LoginClientComponent(name, {
-			orgId,
+			orgId: adminOrgId,
 			provider: this.provider,
 		})
 
 		this.loginClientToken = this.loginClient.token
+
+		// Instance-level Google IdP for human admin sign-in. The admin org's
+		// LoginPolicy below references this IdP id; the product org's policy
+		// does not, keeping end-user passkey-only sign-in unaffected.
+		this.googleAdminIdp = new GoogleAdminIdpComponent(name, {
+			clientId: googleAdminIdpClientId,
+			clientSecret: googleAdminIdpClientSecret,
+			provider: this.provider,
+		})
+
+		// Login policies on admin org + instance default. Both reference the
+		// Google IdP so Console login surfaces the Google button regardless
+		// of which routing path Login V2 takes.
+		this.adminOrgConfig = new AdminOrgConfigComponent(name, {
+			adminOrgId,
+			googleIdpId: this.googleAdminIdp.idp.id,
+			provider: this.provider,
+		})
+
+		// Human admin user (pannpers@pannpers.dev) in the admin org, with
+		// IAM_OWNER granted at instance level. First Google sign-in auto-
+		// links the IdP identity to this user via the Google IdP's
+		// `isLinkingAllowed` setting.
+		this.humanAdmin = new HumanAdminComponent(name, {
+			adminOrgId,
+			email: 'pannpers@pannpers.dev',
+			firstName: 'Kyosuke',
+			lastName: 'Hamada',
+			provider: this.provider,
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Implements the Pulumi side of OpenSpec change
`add-zitadel-console-admin-via-google-idp`. Pairs with merged PR #224
(configmap-only) that landed `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`.

After this PR is merged, Pulumi Cloud Deployments runs `pulumi up` against
the (already-rebootstrapped) dev Zitadel and provisions:

- `liverty-music` product org (`zitadel.Org` with `isDefault: true`)
- All product resources moved into it: Project, ApplicationOidc,
  end-user LoginPolicy, `backend-app` MachineUser
- Instance-level Google IdP for human admin sign-in
- Admin-org LoginPolicy + DefaultLoginPolicy that expose the Google IdP
  and disable username + password sign-in (admin-only)
- HumanUser `pannpers@pannpers.dev` in admin org with random throwaway
  password (unreachable; satisfies @pulumiverse/zitadel's
  `isEmailVerified` constraint)
- `InstanceMember(IAM_OWNER)` binding for pannpers
- `login-client` MachineUser stays in admin org per the "Operator
  Machine Users" requirement

End-user passkey-only login policy on `liverty-music` org is preserved
unchanged. The frontend SPA's OIDC `client_id` rotates as a side effect
of moving `ApplicationOidc` to the new product org — frontend Pulumi
stack reads the new value via ESC, so a frontend `pulumi up` after this
will pick it up automatically.

## Pre-merge state (verified before push)

- PR #224 merged + ArgoCD synced ConfigMap (`ZITADEL_FIRSTINSTANCE_ORG_NAME: admin` confirmed in cluster)
- Dev DB wiped + re-bootstrapped → new `admin` org id `371280364565496672`
- GSM `zitadel-admin-sa-key` v2 uploaded by bootstrap-uploader; v1 retained for audit
- Google OAuth 2.0 Web client created in `liverty-music-dev` GCP project; `client_id` + `client_secret` written to ESC `liverty-music/cloud-provisioning/dev` (`pulumiConfig.zitadel.googleAdminIdp.{clientId,clientSecret}`)
- ArgoCD selfHeal restored to `true`; zitadel app `Synced/Healthy`
- `make lint-ts` passes (only pre-existing biome warning in `network.ts:245` remains)

## Post-merge expected flow

1. Pulumi Cloud Deployments triggers `pulumi up` for dev stack.
2. New resources provisioned in admin org + new `liverty-music` product org.
3. Manual smoke test: open <https://auth.dev.liverty-music.app/ui/console>,
   sign in via Google as `pannpers@pannpers.dev`, confirm
   `IAM_OWNER` access to instance.
4. Frontend Pulumi stack: trigger `pulumi up` (or merge a frontend PR)
   to refresh OIDC `client_id` from ESC.

## Test plan

- [ ] CI green (Lint, claude-review, CI Success)
- [ ] After merge, watch Pulumi Cloud Deployments run finish without errors
- [ ] Smoke test admin Console sign-in via Google
- [ ] End-user login UX unchanged (passkey-only on `liverty-music` org login URL)
- [ ] `pulumi-admin` machine user + `zitadel-admin-sa-key` GSM v2 unchanged after `pulumi up` (break-glass invariant)

## Related

- PR #224 (configmap, merged)
- OpenSpec change `add-zitadel-console-admin-via-google-idp` (specification PR follows)
