### PR TITLE
fix(zitadel): give admin RandomPassword the symbols Zitadel requires

### DIFF
--- a/src/zitadel/components/human-admin.ts
+++ b/src/zitadel/components/human-admin.ts
@@ -64,16 +64,24 @@ export class HumanAdminComponent extends pulumi.ComponentResource {
 
 		// Random password to satisfy @pulumiverse/zitadel's constraint that
 		// isEmailVerified=true requires a password to be present. Never
-		// exposed beyond Pulumi state. Length 64, no special chars to keep
-		// it shell-safe in case state is ever inspected manually.
+		// exposed beyond Pulumi state. Length 64; `special: true` and
+		// `minSpecial: 4` are required because Zitadel's default password
+		// complexity policy rejects passwords without symbols (`Password
+		// must contain symbol (COMMA-ZDLwA)`). The password is never used
+		// (admin org `LoginPolicy.userLogin = false`), so shell-safety
+		// concerns from inspecting state manually do not apply.
 		const password = new random.RandomPassword(
 			'admin-initial-password',
 			{
 				length: 64,
-				special: false,
+				special: true,
+				minSpecial: 4,
 				upper: true,
 				lower: true,
 				numeric: true,
+				minUpper: 4,
+				minLower: 4,
+				minNumeric: 4,
 			},
 			{ parent: this },
 		)


### PR DESCRIPTION
## Summary

Hotfix on top of #225. The post-merge `pulumi up` for #225 ([deployment 277](https://app.pulumi.com/pannpers/liverty-music/dev/deployments/277/d5eb732c-8466-482f-87c2-15348483f78a)) failed in two ways:

1. **HumanUser `pannpers` create failed** — `Password must contain symbol (COMMA-ZDLwA)`. The `RandomPassword` for the admin user was generated with `special: false` (originally chosen for shell-safety). Zitadel's default password complexity policy rejects passwords without symbols. **Fix in this PR**: switch to `special: true` and add `min*: 4` for headroom. The shell-safety concern was unfounded because the admin org's `LoginPolicy.userLogin = false` makes the password unreachable for sign-in regardless.

2. **Several stale state entries blocked further apply** — e.g. `failed to delete PAT: rpc error: PermissionDenied: Organisation doesn't exist (AUTH-Bs7Ds)`. Those state entries pointed to Zitadel resource IDs from before the Section-5 dev DB wipe. The bootstrap regenerated everything with new IDs, so Pulumi's "delete the old before re-creating in the new product org" plan failed at the delete step.

   **Fix done out-of-band** (state surgery, not in this PR's diff): `pulumi stack export | jq | pulumi stack import --force` removed seven stale state entries:
   - `Smtp$SmtpConfig::postmark`
   - `LoginClient$MachineUser::login-client`
   - `LoginClient$InstanceMember::login-client-member`
   - `LoginClient$PersonalAccessToken::login-client-pat`
   - `MachineUser$MachineUser::backend-app`
   - `MachineUser$MachineKey::backend-app-key`
   - `ActionsV2$dynamic:Resource::pre-access-token-webhook`

   The new `Org liverty-music` (product org, id `371348346264093539`) and `IdpGoogle admin-google` (id `371348346196984675`) created in run 277 stay in state — they are valid.

After this PR merges and Pulumi Cloud Deployments runs `pulumi up`, the seven removed entries get recreated cleanly in the new admin / liverty-music product orgs, and the HumanUser create succeeds.

## Test plan

- [ ] CI green (lint, claude-review, dev preview, prod preview)
- [ ] Post-merge: `pulumi up` for dev completes without errors
- [ ] Verify in Console / API: `HumanUser pannpers@pannpers.dev` exists in admin org with `IAM_OWNER`
- [ ] Verify `pulumi-admin` machine user + `zitadel-admin-sa-key` GSM v2 unchanged (break-glass invariant)
- [ ] Smoke test: pannpers signs in to `https://auth.dev.liverty-music.app/ui/console` via Google

## Related

- #225 (merged) — the original two-org topology PR
- OpenSpec change `add-zitadel-console-admin-via-google-idp`
