### PR TITLE
fix(zitadel): discover real SMTP config id at activation time

### DIFF
--- a/src/zitadel/dynamic/smtp-activation.ts
+++ b/src/zitadel/dynamic/smtp-activation.ts
@@ -28,9 +28,30 @@ interface SmtpActivationOutputs extends SmtpActivationInputs {
  * verb to call on delete, and the only meaningful input
  * (`smtpConfigId`) is a hard identity tied to the `SmtpConfig` resource.
  *
- * - `create()` POSTs `/admin/v1/smtp/{id}/_activate`. Treats the upstream
- *   "already active" response as success (idempotency) so the first apply
- *   against a manually-activated SMTP does not stall the stack.
+ * ## Why we discover the activation id at runtime instead of using `inputs.smtpConfigId`
+ *
+ * `@pulumiverse/zitadel.SmtpConfig` (v0.2.0) returns the IAM org id as the
+ * Pulumi resource id (a holdover from Zitadel v3 when there was only ever
+ * one SMTP config per instance, so org id == "the SMTP id"). Zitadel v4
+ * introduced multi-config SMTP and assigns each config its own snowflake
+ * id; the activation endpoint requires that real id, not the IAM org id.
+ * Calling `/admin/v1/smtp/{org-id}/_activate` against a v4 instance returns
+ * 404 "SMTP configuration not found".
+ *
+ * Workaround: ignore `inputs.smtpConfigId` for the API call, instead
+ * `_search` for the SMTP config and activate the single result. The
+ * `smtpConfigId` input is retained as a Pulumi-graph dependency marker so
+ * activation only runs after the `SmtpConfig` resource has been created;
+ * its value is recorded in outputs for diff stability.
+ *
+ * Limitation: assumes exactly one SMTP config per instance, which matches
+ * the current `liverty-music` setup. If multi-config support is added
+ * later, this needs a sender-address or display-name filter.
+ *
+ * - `create()` discovers the real config id, then POSTs
+ *   `/admin/v1/smtp/{realId}/_activate`. Treats the upstream "already
+ *   active" response as success (idempotency) so the first apply against
+ *   a manually-activated SMTP does not stall the stack.
  * - `update()` is a no-op. Re-firing `_activate` would be a side effect
  *   without any state change, and there are no other inputs to update.
  * - `delete()` is a no-op. Removing the Pulumi resource record from state
@@ -43,11 +64,45 @@ export const smtpActivationProvider: pulumi.dynamic.ResourceProvider = {
 		inputs: SmtpActivationInputs,
 	): Promise<pulumi.dynamic.CreateResult<SmtpActivationOutputs>> {
 		const profile = JSON.parse(inputs.jwtProfileJson) as JwtProfile
+		// Step 1: discover the real SMTP config id (provider workaround).
+		const search = await zitadelApiCall({
+			domain: inputs.domain,
+			profile,
+			method: 'POST',
+			path: '/admin/v1/smtp/_search',
+			body: {},
+		})
+		if (search.statusCode < 200 || search.statusCode >= 300) {
+			throw new Error(
+				`Zitadel SearchSmtpConfigs failed (${search.statusCode}): ${search.body}`,
+			)
+		}
+		const searchResult = JSON.parse(search.body) as {
+			result?: Array<{ id: string; state?: string }>
+		}
+		const configs = searchResult.result ?? []
+		if (configs.length === 0) {
+			throw new Error(
+				'Zitadel SearchSmtpConfigs returned 0 configs; cannot activate ' +
+					'(`SmtpConfig` resource may not have settled yet — Pulumi ' +
+					'graph dependency on `smtpConfigId` should make this race ' +
+					'impossible, please report)',
+			)
+		}
+		if (configs.length > 1) {
+			throw new Error(
+				`Zitadel SearchSmtpConfigs returned ${configs.length} configs; ` +
+					'this provider workaround assumes exactly one SMTP config ' +
+					'per instance. Add a sender-address filter to disambiguate.',
+			)
+		}
+		const realId = configs[0].id
+		// Step 2: activate using the real id.
 		const res = await zitadelApiCall({
 			domain: inputs.domain,
 			profile,
 			method: 'POST',
-			path: `/admin/v1/smtp/${inputs.smtpConfigId}/_activate`,
+			path: `/admin/v1/smtp/${realId}/_activate`,
 		})
 		// 2xx covers the happy path. Zitadel returns the same shape for
 		// "newly activated" and "already active" cases on this endpoint
@@ -63,7 +118,7 @@ export const smtpActivationProvider: pulumi.dynamic.ResourceProvider = {
 			)
 		}
 		return {
-			id: `smtp-activation:${inputs.smtpConfigId}`,
+			id: `smtp-activation:${realId}`,
 			outs: {
 				...inputs,
 				activatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Hotfix on top of #226. The post-merge `pulumi up` for #226 ([deployment 280](https://app.pulumi.com/pannpers/liverty-music/dev/deployments/280)) succeeded for **10 of 11 attempted creations** (Project, ApplicationOidc, both LoginPolicies, DefaultLoginPolicy, both MachineUsers, SmtpConfig, HumanUser pannpers, pre-access-token-webhook) but the `smtp-activation` Dynamic Resource hit:

```
Zitadel ActivateSmtpConfig failed (404):
SMTP configuration not found (COMMAND-E9K20hxOS9)
```

That error blocked the remaining ~17 resources from being created (PAT, MachineKey, OrgMember, InstanceMember pannpers→IAM_OWNER, Zitadel monitoring dashboard + 2 alerts, GSM secret versions).

## Root cause

`@pulumiverse/zitadel.SmtpConfig` (v0.2.0) returns the IAM org id as the Pulumi resource id (a holdover from Zitadel v3 when each instance had at most one SMTP config). Zitadel v4 introduced multi-config SMTP and assigns each config its own snowflake id; the activation endpoint requires that real id, not the IAM org id.

Live API check confirms:

```
POST /admin/v1/smtp/_search →
  result[0].id            = "371355406351467363"   (real, what `_activate` needs)
  result[0].resourceOwner = "371280364565431136"   (IAM org id, what Pulumi returns)
  result[0].state         = "SMTP_CONFIG_INACTIVE"
```

This was latent before the Section-5 dev wipe — earlier deployments must have happened against an older Zitadel version where `_activate/{org-id}` was accepted (or the same id was returned for both fields by coincidence).

## Fix

In the `smtp-activation` Dynamic Resource's `create()`, ignore the input `smtpConfigId` for the API call. Instead `_search` the SMTP configs and activate the single result. The `smtpConfigId` input is retained as a Pulumi-graph dependency marker so activation only runs after the `SmtpConfig` resource has been created.

Limitation: assumes exactly one SMTP config per instance, which matches the current `liverty-music` setup. Multi-config support would require a sender-address or display-name filter — left as a future knob.

## Test plan

- [ ] CI green
- [ ] Post-merge `pulumi up`: smtp-activation succeeds, remaining ~17 resources get created, dev stack returns to fully-applied
- [ ] Verify in Zitadel API: `POST /admin/v1/smtp/_search → result[0].state == "SMTP_CONFIG_ACTIVE"`
- [ ] Smoke test: pannpers signs in to https://auth.dev.liverty-music.app/ui/console via Google

## Related

- #225 / #226 (merged) — the original two-org topology + password fix PRs
