### PR TITLE
feat(zitadel): pre-link admin Google identity via UserIdpLink Dynamic Resource

### DIFF
--- a/docs/runbooks/add-zitadel-admin-user.md
+++ b/docs/runbooks/add-zitadel-admin-user.md
@@ -1,0 +1,235 @@
+# Runbook: add a new Zitadel admin user (Google SSO, IAM_OWNER)
+
+> **Background:** OpenSpec change `add-zitadel-console-admin-via-google-idp`
+> set up the `admin` role org with `LoginPolicy.userLogin = false` and
+> `IdpGoogle.isCreationAllowed = false`. That combination intentionally
+> blocks any "sign in once and Zitadel will figure it out" path, so a
+> new admin's Google identity has to be **pre-linked** to a
+> Pulumi-declared local user via `ZitadelUserIdpLink` before they can
+> sign in. This runbook walks the full operation.
+
+## When to use this runbook
+
+Use this whenever a new human operator needs `IAM_OWNER` on the
+self-hosted Zitadel instance (e.g. they need to access
+`https://auth.dev.liverty-music.app/ui/console`). Anyone with
+`IAM_OWNER` can manage every org in the instance, so apply the same
+gating you would for a GCP project Owner — assume each grant is
+high-trust.
+
+This runbook is **not** for end users (people signing into the
+product). End-user sign-up flows live in the `liverty-music` product
+org and use the standard register-via-passkey path; nothing in this
+file applies to them.
+
+## Prerequisites
+
+The new admin must:
+
+- Have a Google account on a domain wired into the Zitadel admin org's
+  IdP (today: `pannpers.dev` Workspace).
+- Have working `gcloud` access OR be able to use the
+  [OAuth Playground](https://developers.google.com/oauthplayground/)
+  in a browser (for the sub-claim lookup in step 1).
+
+You (the operator running this runbook) must have:
+
+- Push access to `liverty-music/cloud-provisioning`.
+- `esc` CLI authenticated against the `liverty-music` org.
+- `gh` CLI authenticated for opening the PR.
+
+## Step 1 — get the new admin's Google `sub` claim
+
+Zitadel keys IdP links by the external user's stable subject identifier
+(`sub`), not their email. We need that 21-digit number before any
+Pulumi code can declare the link.
+
+The new admin runs **one** of these (whichever is easier for them):
+
+### Option A — OAuth Playground (browser only, ~3 min)
+
+1. Open <https://developers.google.com/oauthplayground/>.
+2. In the left "Step 1" panel, scroll to **Google OAuth2 API v2** and
+   tick `https://www.googleapis.com/auth/userinfo.profile`.
+3. Click **Authorize APIs**, sign in as the new admin's Google
+   account, accept the consent screen.
+4. **Exchange authorization code for tokens** (Step 2 panel).
+5. In Step 3 (right panel), call
+   `GET https://www.googleapis.com/oauth2/v2/userinfo`.
+6. The response JSON's `id` field is the `sub`. Copy it.
+
+### Option B — `gcloud` + userinfo (CLI, ~1 min)
+
+```bash
+# Make sure gcloud is signed in as the new admin's account.
+gcloud config get-value account
+# If wrong: gcloud auth login <new-admin-email>
+
+TOKEN=$(gcloud auth print-access-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://www.googleapis.com/oauth2/v2/userinfo
+```
+
+Look for `"id": "117…"` in the response. That's the `sub`.
+
+> `gcloud auth print-identity-token --audiences=...` is the more
+> obvious path but rejects user accounts ("Invalid account type for
+> `--audiences`. Requires valid service account."). Don't bother with
+> it.
+
+The `sub` is **not** secret on its own — it's just an opaque ID Google
+issues per account — but treat it as low-sensitivity config (we still
+store it under ESC `--secret` to keep the Pulumi config surface
+uniform).
+
+## Step 2 — store the `sub` in ESC
+
+```bash
+esc env set liverty-music/dev pulumiConfig.zitadel.adminGoogleSubs.<userName> <sub> --secret
+```
+
+Where:
+
+- `<userName>` is the Pulumi-side identifier you'll use in code
+  (kebab-case, e.g. `pannpers`, `alice`). Keep it short and stable —
+  changing it later forces a Pulumi resource rename.
+- `<sub>` is the value from step 1.
+
+Verify:
+
+```bash
+esc env get liverty-music/dev pulumiConfig.zitadel.adminGoogleSubs.<userName>
+# Expect: "[secret]" with a Definition ciphertext line
+```
+
+> Repeat for `liverty-music/staging` and `liverty-music/prod` as those
+> environments adopt the self-hosted topology. Today only `dev` has
+> the Zitadel stack; staging / prod sets are tracked by the OpenSpec
+> change `add-zitadel-console-admin-via-google-idp` D10.
+
+## Step 3 — declare the admin in Pulumi
+
+In `src/zitadel/index.ts`, the `Zitadel` class today instantiates a
+single `HumanAdminComponent` for `pannpers`. Two extension paths:
+
+### 3a — Adding the second / third admin (small fan-out)
+
+Duplicate the existing block, plumbing in a new `pannpersGoogleSub`-
+style ESC field via `ZitadelArgs`:
+
+```ts
+this.aliceAdmin = new HumanAdminComponent(`${name}-alice`, {
+  adminOrgId: this.adminOrg.id,
+  email: 'alice@pannpers.dev',
+  firstName: 'Alice',
+  lastName: 'Example',
+  googleIdpId: this.googleAdminIdp.idp.id,
+  googleSub: aliceGoogleSub,        // new ZitadelArgs field
+  domain,
+  jwtProfileJson,
+  provider: this.provider,
+})
+```
+
+And in `src/index.ts` extend the typed ESC schema:
+
+```ts
+const zitadelConfig = config.requireSecretObject<{
+  googleAdminIdp: { clientId: string; clientSecret: string }
+  adminGoogleSubs: { pannpers: string; alice: string }   // ← add new key
+}>('zitadel')
+```
+
+Then thread the new key through `ZitadelArgs` the same way
+`pannpersGoogleSub` is plumbed today.
+
+### 3b — Beyond ~5 admins (refactor recommended)
+
+Refactor `HumanAdminComponent` to accept a `HumanAdminSpec[]` array
+and iterate. The current per-admin component is fine for the small
+fan-out we have today; refactor the moment a third admin lands so
+the duplication doesn't ossify.
+
+## Step 4 — run pre-commit checks locally
+
+```bash
+make check
+```
+
+This runs `biome check`, `tsc --noEmit`, and the vitest suite. Fix
+anything red before pushing.
+
+## Step 5 — open the PR and let the auto-deploy take over
+
+```bash
+git checkout -b add-admin-<userName>
+git add -A
+git commit -m "feat(zitadel): add <userName>@pannpers.dev as admin"
+git push -u origin HEAD
+gh pr create --assignee pannpers --reviewer pannpers
+```
+
+Merging to `main` triggers Pulumi Cloud Deployments to run
+`pulumi up` against `dev` automatically. Watch:
+
+- <https://app.pulumi.com/pannpers/liverty-music/dev/deployments>
+- `gh run list --repo liverty-music/cloud-provisioning --branch main --limit 3`
+
+The new resources you should see in the diff:
+
+- `zitadel.HumanUser` (the local user)
+- `zitadel.InstanceMember` (`IAM_OWNER`)
+- `ZitadelUserIdpLink` (the pre-link)
+
+## Step 6 — verify Console sign-in end-to-end
+
+In a private window (so old sessions don't mask cookie/policy issues):
+
+1. Open <https://auth.dev.liverty-music.app/ui/console>.
+2. Click **Google (admin)**.
+3. Sign in with the new admin's Google account.
+4. **Expected:** Console loads with full instance access. The new
+   admin should be able to read every org in the instance.
+
+If the sign-in dead-ends on `/ui/v2/login/idp/google/account-not-found`,
+the link did not register correctly. Most common causes:
+
+- ESC `sub` value typo (extra whitespace, wrong digits) — re-run
+  step 1, compare byte-for-byte.
+- The Google account used for sign-in differs from the one whose
+  `sub` you captured (e.g. they signed in to OAuth Playground as a
+  personal account but to Console as the Workspace account). Both
+  must be the same Google identity.
+- Stale Login V2 in-memory policy cache:
+  `kubectl -n zitadel rollout restart deployment/zitadel-login`.
+- IdP intent landed but the user's `IAM_OWNER` membership missing —
+  check via the Zitadel admin API:
+  ```bash
+  curl -s -H "Authorization: Bearer $(./tmp/get-zitadel-jwt.sh)" \
+    "https://auth.dev.liverty-music.app/admin/v1/members/_search" \
+    | jq '.result[] | select(.userId=="<userId>")'
+  ```
+
+## Removing an admin
+
+Follow the inverse:
+
+1. Delete the `HumanAdminComponent` block from `src/zitadel/index.ts`.
+2. Remove the `adminGoogleSubs.<userName>` ESC entry:
+   ```bash
+   esc env rm liverty-music/dev pulumiConfig.zitadel.adminGoogleSubs.<userName>
+   ```
+3. PR + merge. Pulumi will:
+   - DELETE the IdP link via `/v2/users/{userId}/links/{idpId}/{externalUserId}`
+   - Remove the `IAM_OWNER` instance membership
+   - Delete the local `HumanUser`
+
+The user's Workspace Google account is unaffected (we only manage
+Zitadel-side state).
+
+## Reference
+
+- OpenSpec change: `add-zitadel-console-admin-via-google-idp`
+- Component: [`src/zitadel/components/human-admin.ts`](../../src/zitadel/components/human-admin.ts)
+- Dynamic resource: [`src/zitadel/dynamic/user-idp-link.ts`](../../src/zitadel/dynamic/user-idp-link.ts)
+- Initial implementation PR: liverty-music/cloud-provisioning#229

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ const postmarkConfig = config.requireObject(
 // look in the unrelated `zitadel:` provider namespace and fail.
 const zitadelConfig = config.requireSecretObject<{
 	googleAdminIdp: { clientId: string; clientSecret: string }
+	adminGoogleSubs: { pannpers: string }
 }>('zitadel')
 
 const env = pulumi.getStack() as Environment
@@ -82,6 +83,9 @@ if (env === 'dev') {
 		),
 		googleAdminIdpClientSecret: zitadelConfig.apply(
 			(z) => z.googleAdminIdp.clientSecret,
+		),
+		pannpersGoogleSub: zitadelConfig.apply(
+			(z) => z.adminGoogleSubs.pannpers,
 		),
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails

--- a/src/zitadel/components/human-admin.ts
+++ b/src/zitadel/components/human-admin.ts
@@ -1,6 +1,7 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as random from '@pulumi/random'
 import * as zitadel from '@pulumiverse/zitadel'
+import { ZitadelUserIdpLink } from '../dynamic/user-idp-link.js'
 
 export interface HumanAdminComponentArgs {
 	/** ID of the bootstrap-created `admin` role org. */
@@ -12,6 +13,19 @@ export interface HumanAdminComponentArgs {
 	firstName: pulumi.Input<string>
 	/** Admin's last name (Workspace profile). */
 	lastName: pulumi.Input<string>
+	/** Instance-level Google IdP id to pre-link to this human user. */
+	googleIdpId: pulumi.Input<string>
+	/**
+	 * Google `sub` claim for this admin's Google account. Must be the
+	 * stable numeric subject identifier returned by Google OIDC, not the
+	 * email — the email can change while the sub never does. Provisioned
+	 * via ESC `pulumiConfig.zitadel.adminGoogleSubs.<userName>`.
+	 */
+	googleSub: pulumi.Input<string>
+	/** Zitadel domain (for the Dynamic Resource API call). */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (for the Dynamic Resource API call). */
+	jwtProfileJson: pulumi.Input<string>
 	provider: zitadel.Provider
 }
 
@@ -19,11 +33,26 @@ export interface HumanAdminComponentArgs {
  * HumanAdminComponent provisions a single human admin user in the
  * `admin` role org and grants them `IAM_OWNER` at the instance level.
  *
- * Sign-in flow: the admin signs in via Google IdP. Zitadel matches the
- * verified Google email to the local user provisioned here and links
- * the IdP identity (see `GoogleAdminIdpComponent` for the linking
- * settings). After the link is established, the local user's
- * `IAM_OWNER` membership applies — the admin can use the Console.
+ * Sign-in flow: the admin signs in via Google IdP. The IdP identity is
+ * pre-linked at provisioning time by `ZitadelUserIdpLink` below using
+ * the admin's Google `sub` claim, so the very first sign-in resolves
+ * straight to the local user. The local user's `IAM_OWNER` membership
+ * then applies — the admin can use the Console.
+ *
+ * ## Why pre-link the Google identity in Pulumi
+ *
+ * The admin org's `LoginPolicy` disables username/password
+ * (`userLogin = false`) and the Google IdP forbids auto-creation
+ * (`isCreationAllowed = false`). With both off, Login V2 has no native
+ * way to bootstrap the first sign-in: there is no password to
+ * authenticate the autoLink prompt, and no permission to mint a fresh
+ * user from the OIDC profile. Without a pre-existing
+ * `(idpId, externalUserId)` record, the IdP callback dead-ends on the
+ * `account-not-found` page.
+ *
+ * `ZitadelUserIdpLink` declares that record up front, breaking the
+ * deadlock declaratively in IaC. See `dynamic/user-idp-link.ts` for the
+ * full rationale.
  *
  * ## Why a random initialPassword
  *
@@ -51,6 +80,7 @@ export interface HumanAdminComponentArgs {
 export class HumanAdminComponent extends pulumi.ComponentResource {
 	public readonly humanUser: zitadel.HumanUser
 	public readonly instanceMember: zitadel.InstanceMember
+	public readonly googleIdpLink: ZitadelUserIdpLink
 
 	constructor(
 		name: string,
@@ -59,7 +89,17 @@ export class HumanAdminComponent extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:HumanAdmin', name, {}, opts)
 
-		const { adminOrgId, email, firstName, lastName, provider } = args
+		const {
+			adminOrgId,
+			email,
+			firstName,
+			lastName,
+			googleIdpId,
+			googleSub,
+			domain,
+			jwtProfileJson,
+			provider,
+		} = args
 		const resourceOptions = { provider, parent: this }
 
 		// Random password to satisfy @pulumiverse/zitadel's constraint that
@@ -117,9 +157,28 @@ export class HumanAdminComponent extends pulumi.ComponentResource {
 			{ ...resourceOptions, dependsOn: [this.humanUser] },
 		)
 
+		// Pre-link the Google identity to this local user so the very first
+		// `/ui/console` Google sign-in lands directly on the local
+		// IAM_OWNER. Required because the admin org's userLogin/auto-create
+		// settings leave no native first-link path — see header comment and
+		// `dynamic/user-idp-link.ts`.
+		this.googleIdpLink = new ZitadelUserIdpLink(
+			'pannpers-google-link',
+			{
+				domain,
+				jwtProfileJson,
+				userId: this.humanUser.id,
+				idpId: googleIdpId,
+				externalUserId: googleSub,
+				displayName: email,
+			},
+			{ parent: this, dependsOn: [this.humanUser] },
+		)
+
 		this.registerOutputs({
 			humanUser: this.humanUser,
 			instanceMember: this.instanceMember,
+			googleIdpLink: this.googleIdpLink,
 		})
 	}
 }

--- a/src/zitadel/components/human-admin.ts
+++ b/src/zitadel/components/human-admin.ts
@@ -54,6 +54,15 @@ export interface HumanAdminComponentArgs {
  * deadlock declaratively in IaC. See `dynamic/user-idp-link.ts` for the
  * full rationale.
  *
+ * ## Adding a new admin
+ *
+ * The end-to-end procedure (Google `sub` lookup → ESC config → Pulumi
+ * code → verification) is captured in
+ * `docs/runbooks/add-zitadel-admin-user.md`. Follow it instead of
+ * copy-pasting this component blind — there are operational steps
+ * (ESC entry, sub-claim capture, post-deploy smoke test) that aren't
+ * visible from the code alone.
+ *
  * ## Why a random initialPassword
  *
  * `@pulumiverse/zitadel.HumanUser` documents:

--- a/src/zitadel/dynamic/__tests__/smtp-activation.test.ts
+++ b/src/zitadel/dynamic/__tests__/smtp-activation.test.ts
@@ -37,8 +37,22 @@ const baseOutputs = {
 	activatedAt: '2026-01-01T00:00:00.000Z',
 }
 
-function lastCallArgs() {
-	return mockedCall.mock.calls[0][0]
+function callArgsAt(index: number) {
+	return mockedCall.mock.calls[index][0]
+}
+
+/**
+ * Default `_search` response used by happy-path tests: returns one SMTP
+ * config with a discovered id distinct from `inputs.smtpConfigId`. This
+ * mirrors the v4 reality where `inputs.smtpConfigId` is the IAM org id
+ * (provider workaround in `smtp-activation.ts`) and the real activation
+ * id is the snowflake returned by `_search`.
+ */
+const searchOneConfigResponse = {
+	statusCode: 200,
+	body: JSON.stringify({
+		result: [{ id: 'real-cfg-snowflake', state: 'SMTP_CONFIG_INACTIVE' }],
+	}),
 }
 
 describe('smtpActivationProvider.create', () => {
@@ -46,37 +60,45 @@ describe('smtpActivationProvider.create', () => {
 		mockedCall.mockReset()
 	})
 
-	it('POSTs /admin/v1/smtp/{id}/_activate and returns an activatedAt timestamp', async () => {
-		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
+	it('discovers the real id via /admin/v1/smtp/_search, then POSTs /admin/v1/smtp/{realId}/_activate', async () => {
+		mockedCall.mockResolvedValueOnce(searchOneConfigResponse) // search
+		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' }) // activate
 
 		const result = await provider.create(baseInputs)
 
-		expect(mockedCall).toHaveBeenCalledOnce()
-		const args = lastCallArgs()
-		expect(args.method).toBe('POST')
-		expect(args.path).toBe('/admin/v1/smtp/smtp-cfg-1/_activate')
-		expect(args.domain).toBe('auth.example.test')
+		expect(mockedCall).toHaveBeenCalledTimes(2)
+		const search = callArgsAt(0)
+		expect(search.method).toBe('POST')
+		expect(search.path).toBe('/admin/v1/smtp/_search')
+		const activate = callArgsAt(1)
+		expect(activate.method).toBe('POST')
+		expect(activate.path).toBe(
+			'/admin/v1/smtp/real-cfg-snowflake/_activate',
+		)
+		expect(activate.domain).toBe('auth.example.test')
 		// Activation has no payload; body is intentionally undefined.
-		expect(args.body).toBeUndefined()
-		expect(result.id).toBe('smtp-activation:smtp-cfg-1')
+		expect(activate.body).toBeUndefined()
+		expect(result.id).toBe('smtp-activation:real-cfg-snowflake')
 		expect(result.outs?.smtpConfigId).toBe('smtp-cfg-1')
 		expect(result.outs?.activatedAt).toMatch(
 			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
 		)
 	})
 
-	it('treats an "already active" upstream response as success (idempotency on first apply against manually-activated SMTP)', async () => {
+	it('treats an "already active" upstream response on _activate as success (idempotency on first apply against manually-activated SMTP)', async () => {
+		mockedCall.mockResolvedValueOnce(searchOneConfigResponse)
 		mockedCall.mockResolvedValueOnce({
 			statusCode: 412,
 			body: '{"code":9,"message":"smtp config is already active"}',
 		})
 
 		await expect(provider.create(baseInputs)).resolves.toMatchObject({
-			id: 'smtp-activation:smtp-cfg-1',
+			id: 'smtp-activation:real-cfg-snowflake',
 		})
 	})
 
-	it('throws on a genuine non-2xx error (not the already-active case)', async () => {
+	it('throws on a genuine non-2xx error from _activate (not the already-active case)', async () => {
+		mockedCall.mockResolvedValueOnce(searchOneConfigResponse)
 		mockedCall.mockResolvedValueOnce({
 			statusCode: 500,
 			body: '{"code":13,"message":"internal"}',
@@ -84,6 +106,41 @@ describe('smtpActivationProvider.create', () => {
 
 		await expect(provider.create(baseInputs)).rejects.toThrow(
 			/Zitadel ActivateSmtpConfig failed \(500\)/,
+		)
+	})
+
+	it('throws on a non-2xx from _search so the upstream lookup failure surfaces clearly', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel SearchSmtpConfigs failed \(500\)/,
+		)
+	})
+
+	it('throws when _search returns zero configs (graph dependency should make this impossible — guards against silent skip)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 200,
+			body: JSON.stringify({ result: [] }),
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel SearchSmtpConfigs returned 0 configs/,
+		)
+	})
+
+	it('throws when _search returns more than one config (workaround assumes singleton)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 200,
+			body: JSON.stringify({
+				result: [{ id: 'cfg-a' }, { id: 'cfg-b' }],
+			}),
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel SearchSmtpConfigs returned 2 configs/,
 		)
 	})
 })

--- a/src/zitadel/dynamic/__tests__/user-idp-link.test.ts
+++ b/src/zitadel/dynamic/__tests__/user-idp-link.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../api-client.js', () => ({
+	zitadelApiCall: vi.fn(),
+}))
+
+const apiClient = await import('../api-client.js')
+const { userIdpLinkProvider } = await import('../user-idp-link.js')
+
+const mockedCall = vi.mocked(apiClient.zitadelApiCall)
+
+const provider = userIdpLinkProvider as Required<typeof userIdpLinkProvider>
+
+const baseProfile = {
+	type: 'serviceaccount' as const,
+	keyId: 'kid-1',
+	key: 'private-key-pem',
+	userId: 'machine-user-1',
+}
+
+const baseInputs = {
+	domain: 'auth.example.test',
+	jwtProfileJson: JSON.stringify(baseProfile),
+	userId: 'local-user-1',
+	idpId: 'idp-1',
+	externalUserId: 'google-sub-1',
+	displayName: 'Pannpers',
+}
+
+function lastCallArgs() {
+	return mockedCall.mock.calls[0][0]
+}
+
+describe('userIdpLinkProvider.create', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('POSTs /v2/users/{userId}/links with the idpLink body and returns a stable composite id', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 201, body: '{}' })
+
+		const result = await provider.create(baseInputs)
+
+		expect(mockedCall).toHaveBeenCalledOnce()
+		const args = lastCallArgs()
+		expect(args.method).toBe('POST')
+		expect(args.path).toBe('/v2/users/local-user-1/links')
+		expect(args.domain).toBe('auth.example.test')
+		expect(args.body).toEqual({
+			idpLink: {
+				idpId: 'idp-1',
+				userId: 'google-sub-1',
+				userName: 'Pannpers',
+			},
+		})
+		expect(result.id).toBe('user-idp-link:local-user-1:idp-1:google-sub-1')
+		expect(result.outs).toEqual(baseInputs)
+	})
+
+	it('falls back to externalUserId when displayName is omitted (audit label is best-effort)', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 201, body: '{}' })
+
+		const { displayName: _ignored, ...inputsNoDisplay } = baseInputs
+		await provider.create(inputsNoDisplay)
+
+		const args = lastCallArgs()
+		expect(args.body).toMatchObject({
+			idpLink: { userName: 'google-sub-1' },
+		})
+	})
+
+	it('treats a 409 already-exists upstream as success (idempotent re-apply)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 409,
+			body: '{"code":6,"message":"IDP link already exists (USER-AlreadyExists)"}',
+		})
+
+		await expect(provider.create(baseInputs)).resolves.toMatchObject({
+			id: 'user-idp-link:local-user-1:idp-1:google-sub-1',
+		})
+	})
+
+	it('throws on a genuine non-2xx error (not the already-exists case)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel AddIDPLink failed \(500\)/,
+		)
+	})
+
+	it('throws on a non-409 4xx (e.g. 404 unknown user) so configuration mistakes surface loudly', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 404,
+			body: '{"code":5,"message":"user not found"}',
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel AddIDPLink failed \(404\)/,
+		)
+	})
+})
+
+describe('userIdpLinkProvider.update', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests and echoes news (immutable identity tuple, no soft-field push endpoint)', async () => {
+		const news = { ...baseInputs, displayName: 'NewLabel' }
+		const result = await provider.update(
+			'user-idp-link:local-user-1:idp-1:google-sub-1',
+			baseInputs,
+			news,
+		)
+
+		expect(mockedCall).not.toHaveBeenCalled()
+		expect(result.outs).toEqual(news)
+	})
+})
+
+describe('userIdpLinkProvider.delete', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('DELETEs /v2/users/{userId}/links/{idpId}/{externalUserId}', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
+
+		await expect(
+			provider.delete(
+				'user-idp-link:local-user-1:idp-1:google-sub-1',
+				baseInputs,
+			),
+		).resolves.toBeUndefined()
+
+		const args = lastCallArgs()
+		expect(args.method).toBe('DELETE')
+		expect(args.path).toBe(
+			'/v2/users/local-user-1/links/idp-1/google-sub-1',
+		)
+		expect(args.body).toBeUndefined()
+	})
+
+	it('treats 404 as success (link already gone — idempotent removal)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 404,
+			body: '{"code":5,"message":"link not found"}',
+		})
+
+		await expect(
+			provider.delete(
+				'user-idp-link:local-user-1:idp-1:google-sub-1',
+				baseInputs,
+			),
+		).resolves.toBeUndefined()
+	})
+
+	it('throws on non-2xx, non-404 (e.g. 500 server error) so real failures are not swallowed', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(
+			provider.delete(
+				'user-idp-link:local-user-1:idp-1:google-sub-1',
+				baseInputs,
+			),
+		).rejects.toThrow(/Zitadel RemoveIDPLink failed \(500\)/)
+	})
+})
+
+describe('userIdpLinkProvider.read', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests and returns current outputs unchanged', async () => {
+		const result = await provider.read(
+			'user-idp-link:local-user-1:idp-1:google-sub-1',
+			baseInputs,
+		)
+
+		expect(mockedCall).not.toHaveBeenCalled()
+		expect(result.id).toBe('user-idp-link:local-user-1:idp-1:google-sub-1')
+		expect(result.props).toEqual(baseInputs)
+	})
+})

--- a/src/zitadel/dynamic/index.ts
+++ b/src/zitadel/dynamic/index.ts
@@ -1,3 +1,4 @@
 export * from './execution.js'
 export * from './smtp-activation.js'
 export * from './target.js'
+export * from './user-idp-link.js'

--- a/src/zitadel/dynamic/user-idp-link.ts
+++ b/src/zitadel/dynamic/user-idp-link.ts
@@ -1,0 +1,198 @@
+import * as pulumi from '@pulumi/pulumi'
+import { type JwtProfile, zitadelApiCall } from './api-client.js'
+
+export interface ZitadelUserIdpLinkArgs {
+	/** Zitadel domain, e.g. `auth.dev.liverty-music.app`. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (stringified) for Management API auth. */
+	jwtProfileJson: pulumi.Input<string>
+	/** Zitadel-side local user id to attach the external identity to. */
+	userId: pulumi.Input<string>
+	/** Zitadel IdP id (instance- or org-level) the link references. */
+	idpId: pulumi.Input<string>
+	/**
+	 * External identity provider's stable user id. For Google OIDC this is
+	 * the `sub` claim — a numeric string immutable for the lifetime of the
+	 * Google account. Stored in Pulumi state and ESC; not a secret but
+	 * still the join key, so changes here trigger a `replace`.
+	 */
+	externalUserId: pulumi.Input<string>
+	/**
+	 * Optional display label for the IdP entry in Zitadel's user profile.
+	 * Pure presentation, never used for matching. Defaults to
+	 * `externalUserId` when omitted.
+	 */
+	displayName?: pulumi.Input<string>
+}
+
+interface UserIdpLinkInputs {
+	domain: string
+	jwtProfileJson: string
+	userId: string
+	idpId: string
+	externalUserId: string
+	displayName?: string
+}
+
+/**
+ * Provider for `ZitadelUserIdpLink`. Pre-creates the binding between a
+ * Pulumi-managed local Zitadel user and the external identity that user
+ * will sign in with — so the very first IdP login lands directly on the
+ * existing local user instead of hitting the Login V2
+ * `account-not-found` page.
+ *
+ * ## Why this resource exists
+ *
+ * Without a pre-created link, Login V2's first-sign-in flow needs *one
+ * of* the following to succeed:
+ *   1. `LoginPolicy.userLogin = true` so the user can authenticate with
+ *      a local password and confirm "yes, this Google account is mine"
+ *      via Zitadel's autoLink prompt.
+ *   2. `IdpGoogle.isAutoCreation = true` so a brand-new local user is
+ *      created from the Google profile.
+ *
+ * The `admin` role org explicitly forbids both: it disables
+ * username/password (`LoginPolicy.userLogin = false`) to enforce
+ * IdP-only Console access, and forbids auto-creation
+ * (`IdpGoogle.isCreationAllowed = false`) to prevent anyone with a
+ * matching email domain from implicitly becoming an instance-level
+ * admin. That combination leaves no native path to bootstrap the first
+ * sign-in — Login V2 has nothing to match against and gives up.
+ *
+ * Pre-creating the link via the v2 user service breaks the deadlock:
+ * the `(idpId, externalUserId)` tuple is already in Zitadel by the time
+ * the admin clicks "Sign in with Google", so the IdP callback resolves
+ * straight to the local `IAM_OWNER` and the Console loads.
+ *
+ * ## Why the Zitadel v2 user service (`/v2/users/{userId}/links`)
+ *
+ * - Stable, GA, documented for first-class IdP-link management.
+ * - Single endpoint covers add (POST) and remove (DELETE), keeping
+ *   create/delete symmetric.
+ * - Same JWT-bearer auth as the rest of the dynamic resources here, so
+ *   no new auth scaffolding is needed.
+ *
+ * The legacy v1 management API
+ * (`/management/v1/users/{userId}/idps`) would also work but is a
+ * separate code path Zitadel may eventually deprecate; v2 is preferred.
+ *
+ * ## CRUD shape
+ *
+ * - `create()` POSTs the link. A 409/AlreadyExists from Zitadel is
+ *   treated as success so the resource is idempotent across re-applies
+ *   and partial-failure recoveries (matches the same pattern used in
+ *   `smtp-activation.ts`).
+ * - `update()` is a no-op by design. The `(userId, idpId,
+ *   externalUserId)` tuple IS the resource identity — changes there
+ *   produce a Pulumi `replace`, not an `update`. The only soft field
+ *   (`displayName`) has no Zitadel "update existing link" endpoint, so
+ *   there is nothing to push.
+ * - `delete()` DELETEs the link. 404 is treated as success (the link
+ *   is already gone — idempotent removal). Other non-2xx errors throw
+ *   so a real Zitadel-side failure surfaces in the deployment log
+ *   instead of silently leaving stale Pulumi state.
+ * - `read()` is a no-op returning current outputs. A live `GET` is not
+ *   exposed by Zitadel's v2 user service for individual links, and
+ *   list+filter would add cost without helping the typical
+ *   import/refresh flow that this resource is part of.
+ */
+export const userIdpLinkProvider: pulumi.dynamic.ResourceProvider = {
+	async create(
+		inputs: UserIdpLinkInputs,
+	): Promise<pulumi.dynamic.CreateResult<UserIdpLinkInputs>> {
+		const profile = JSON.parse(inputs.jwtProfileJson) as JwtProfile
+		const res = await zitadelApiCall({
+			domain: inputs.domain,
+			profile,
+			method: 'POST',
+			path: `/v2/users/${inputs.userId}/links`,
+			body: {
+				idpLink: {
+					idpId: inputs.idpId,
+					userId: inputs.externalUserId,
+					userName: inputs.displayName ?? inputs.externalUserId,
+				},
+			},
+		})
+		if (
+			(res.statusCode < 200 || res.statusCode >= 300) &&
+			!isAlreadyExists(res.statusCode, res.body)
+		) {
+			throw new Error(
+				`Zitadel AddIDPLink failed (${res.statusCode}): ${res.body}`,
+			)
+		}
+		return {
+			id: `user-idp-link:${inputs.userId}:${inputs.idpId}:${inputs.externalUserId}`,
+			outs: inputs,
+		}
+	},
+
+	async update(
+		_id: string,
+		_olds: UserIdpLinkInputs,
+		news: UserIdpLinkInputs,
+	): Promise<pulumi.dynamic.UpdateResult<UserIdpLinkInputs>> {
+		// No-op by design — see provider doc comment above. The identity
+		// tuple is immutable from Pulumi's perspective (changes trigger
+		// `replace`), and Zitadel exposes no "update existing link"
+		// endpoint for the soft `displayName` field.
+		return { outs: news }
+	},
+
+	async delete(_id: string, state: UserIdpLinkInputs): Promise<void> {
+		const profile = JSON.parse(state.jwtProfileJson) as JwtProfile
+		const res = await zitadelApiCall({
+			domain: state.domain,
+			profile,
+			method: 'DELETE',
+			path: `/v2/users/${state.userId}/links/${state.idpId}/${state.externalUserId}`,
+		})
+		// 2xx = removed, 404 = already gone. Both are success on delete.
+		if (res.statusCode === 404) return
+		if (res.statusCode >= 200 && res.statusCode < 300) return
+		throw new Error(
+			`Zitadel RemoveIDPLink failed (${res.statusCode}): ${res.body}`,
+		)
+	},
+
+	async read(
+		id: string,
+		state: UserIdpLinkInputs,
+	): Promise<pulumi.dynamic.ReadResult<UserIdpLinkInputs>> {
+		// No-op: see provider doc comment above for why a live GET is not
+		// performed against Zitadel's v2 user service for this resource.
+		return { id, props: state }
+	},
+}
+
+function isAlreadyExists(statusCode: number, body: string): boolean {
+	// Zitadel surfaces "already exists" as a 409 with a recognizable
+	// code/message envelope. Match conservatively to avoid swallowing
+	// unrelated 409s (none observed today, but cheap insurance).
+	if (statusCode !== 409) return false
+	return /already.?exists/i.test(body) || /AlreadyExists/i.test(body)
+}
+
+/**
+ * `ZitadelUserIdpLink` declares a binding between a Pulumi-managed
+ * local Zitadel user and the external identity that user signs in
+ * with. Required for the `admin` role org because that org's
+ * `LoginPolicy` and `IdpGoogle` config disable both
+ * username/password fallback and IdP auto-creation, leaving no
+ * native first-sign-in path. Pre-creating the link makes the very
+ * first Google sign-in resolve straight to the local `IAM_OWNER`.
+ *
+ * For end-user (product) sign-in flows that allow either userLogin
+ * or auto-creation, this resource is unnecessary — Zitadel handles
+ * the first-link prompt natively there.
+ */
+export class ZitadelUserIdpLink extends pulumi.dynamic.Resource {
+	constructor(
+		name: string,
+		args: ZitadelUserIdpLinkArgs,
+		opts?: pulumi.CustomResourceOptions,
+	) {
+		super(userIdpLinkProvider, name, args, opts)
+	}
+}

--- a/src/zitadel/dynamic/user-idp-link.ts
+++ b/src/zitadel/dynamic/user-idp-link.ts
@@ -133,10 +133,13 @@ export const userIdpLinkProvider: pulumi.dynamic.ResourceProvider = {
 		_olds: UserIdpLinkInputs,
 		news: UserIdpLinkInputs,
 	): Promise<pulumi.dynamic.UpdateResult<UserIdpLinkInputs>> {
-		// No-op by design — see provider doc comment above. The identity
-		// tuple is immutable from Pulumi's perspective (changes trigger
-		// `replace`), and Zitadel exposes no "update existing link"
-		// endpoint for the soft `displayName` field.
+		// No-op by design. The `ZitadelUserIdpLink` class wires
+		// `replaceOnChanges: ['userId', 'idpId', 'externalUserId']` so any
+		// identity-tuple change goes through delete+create, never here.
+		// Anything that does reach `update()` is a change to a non-tuple
+		// input (e.g. `displayName`, `domain`, `jwtProfileJson`) — none of
+		// which Zitadel exposes a "modify in place" endpoint for, so there
+		// is nothing to push.
 		return { outs: news }
 	},
 
@@ -186,6 +189,21 @@ function isAlreadyExists(statusCode: number, body: string): boolean {
  * For end-user (product) sign-in flows that allow either userLogin
  * or auto-creation, this resource is unnecessary — Zitadel handles
  * the first-link prompt natively there.
+ *
+ * ## Why `replaceOnChanges` on the identity tuple
+ *
+ * Zitadel keys IdP links by the `(userId, idpId, externalUserId)`
+ * tuple — a change to any one means "different link," not "edit this
+ * link." The v2 user service has no "update existing link" endpoint,
+ * and the provider's `update()` is intentionally a no-op. Without
+ * `replaceOnChanges`, Pulumi's default diff would route any change
+ * through `update()`, leaving Pulumi state showing the new tuple
+ * while Zitadel still holds the old link — silently re-introducing
+ * the first-login deadlock this resource exists to fix.
+ *
+ * Declaring `replaceOnChanges` makes Pulumi delete the old link and
+ * create the new one when any identity-tuple field changes, which is
+ * what the upstream API actually supports.
  */
 export class ZitadelUserIdpLink extends pulumi.dynamic.Resource {
 	constructor(
@@ -193,6 +211,14 @@ export class ZitadelUserIdpLink extends pulumi.dynamic.Resource {
 		args: ZitadelUserIdpLinkArgs,
 		opts?: pulumi.CustomResourceOptions,
 	) {
-		super(userIdpLinkProvider, name, args, opts)
+		super(userIdpLinkProvider, name, args, {
+			...opts,
+			replaceOnChanges: [
+				...(opts?.replaceOnChanges ?? []),
+				'userId',
+				'idpId',
+				'externalUserId',
+			],
+		})
 	}
 }

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -45,6 +45,15 @@ export interface ZitadelArgs {
 	 *  `pulumiConfig.zitadel.googleAdminIdp.clientSecret`, marked secret).
 	 *  MUST be passed wrapped in `pulumi.secret()` upstream. */
 	googleAdminIdpClientSecret: pulumi.Input<string>
+	/**
+	 * Google OIDC `sub` claim for the human admin (`pannpers@pannpers.dev`).
+	 * Sourced from ESC `pulumiConfig.zitadel.adminGoogleSubs.pannpers`.
+	 * Stable numeric string per Google account; consumed by
+	 * `ZitadelUserIdpLink` to pre-link the Google identity to the local
+	 * `pannpers` HumanUser so first-sign-in on `/ui/console` works without
+	 * userLogin or auto-creation.
+	 */
+	pannpersGoogleSub: pulumi.Input<string>
 }
 
 /**
@@ -113,6 +122,7 @@ export class Zitadel {
 			postmarkServerApiToken,
 			googleAdminIdpClientId,
 			googleAdminIdpClientSecret,
+			pannpersGoogleSub,
 		} = args
 
 		if (env !== 'dev') {
@@ -280,14 +290,21 @@ export class Zitadel {
 		})
 
 		// Human admin user (pannpers@pannpers.dev) in the admin org, with
-		// IAM_OWNER granted at instance level. First Google sign-in auto-
-		// links the IdP identity to this user via the Google IdP's
-		// `isLinkingAllowed` setting.
+		// IAM_OWNER granted at instance level. The Google identity is
+		// pre-linked via `ZitadelUserIdpLink` (inside the component) so the
+		// very first `/ui/console` sign-in resolves directly to this user
+		// — required because the admin org's userLogin/auto-create policy
+		// leaves no native first-link path. See
+		// `dynamic/user-idp-link.ts` for the rationale.
 		this.humanAdmin = new HumanAdminComponent(name, {
 			adminOrgId: this.adminOrg.id,
 			email: 'pannpers@pannpers.dev',
 			firstName: 'Kyosuke',
 			lastName: 'Hamada',
+			googleIdpId: this.googleAdminIdp.idp.id,
+			googleSub: pannpersGoogleSub,
+			domain,
+			jwtProfileJson,
 			provider: this.provider,
 		})
 	}


### PR DESCRIPTION
## Summary

Pre-links the human admin's Google identity to the local `pannpers` HumanUser at provisioning time so the very first `/ui/console` Google sign-in resolves directly to `IAM_OWNER` instead of dead-ending on Login V2's `account-not-found` page.

- **New `ZitadelUserIdpLink` Dynamic Resource** (`src/zitadel/dynamic/user-idp-link.ts`) that calls Zitadel's v2 user service (`POST /v2/users/{userId}/links`). CRUD shape mirrors `smtp-activation`: idempotent create (409 = success), no-op update, idempotent delete (404 = success), no-op read.
- **`HumanAdminComponent`** now owns the link alongside the existing HumanUser + InstanceMember(IAM_OWNER), so the abstraction still represents "admin sign-in works end-to-end".
- **`pannpersGoogleSub`** sourced from ESC `pulumiConfig.zitadel.adminGoogleSubs.pannpers` (already set in dev) and threaded through `ZitadelArgs` into the component.
- **Stale smtp-activation tests fixed** (PR #227 follow-up): three tests on `main` were silently broken because they were not updated when `_search`-then-`_activate` was added. Rewrote them and added 2 new cases for `_search` failure modes.

## Why a Dynamic Resource

`@pulumiverse/zitadel` v0.2.0 exposes neither a `UserIdpLink` resource nor the `auto_linking: AUTO_LINKING_OPTION_EMAIL` field on the IdP config that the official Zitadel Terraform provider has. A Dynamic Resource (already used in this repo for `smtp-activation` / `actions-v2`) is strictly less work than an upstream provider bump and easier to swap when the upstream catches up.

## Why not `auto_linking: EMAIL`

Even with `auto_linking` enabled, Zitadel's autoLink flow still **prompts the user to confirm by signing in with the existing local account's username + password**. The admin org explicitly disables that fallback (`userLogin = false`), so the prompt has nothing to authenticate against. Pre-linking at IaC time bypasses the prompt entirely.

## Trigger that surfaced this

PR #228 made the admin org the Zitadel default, so Console now correctly serves the admin org's LoginPolicy (Google-only sign-in surface). But the very first Google sign-in still failed because no `(idpId, externalUserId)` record existed in Zitadel yet. This PR closes that last gap.

## Test plan

- [x] `make check` passes (40 tests, lint, tsc)
- [ ] CI green on this PR
- [ ] After merge: Pulumi Cloud Deployments runs `pulumi up` against dev → `ZitadelUserIdpLink` is created
- [ ] After deploy: `/ui/console` Google sign-in lands directly on the admin Console (no `account-not-found`)
- [ ] Subsequent sign-ins also work (idempotent)

## Operational note: adding a future admin

Per the Option C runbook discussed in design:
1. New admin obtains their Google `sub` via OAuth Playground or `gcloud auth print-access-token` + `userinfo` endpoint
2. `esc env set liverty-music/dev pulumiConfig.zitadel.adminGoogleSubs.<userName> <sub> --secret`
3. Extend `HumanAdminComponent` (or refactor to an `admins[]` array) to instantiate one HumanUser + InstanceMember + UserIdpLink per admin

Refs: #225 #226 #227 #228
