### PR TITLE
fix(monitoring): drop GCP-rejected fields from Zitadel alerts + dashboard

### DIFF
--- a/src/gcp/components/zitadel-monitoring.ts
+++ b/src/gcp/components/zitadel-monitoring.ts
@@ -128,9 +128,10 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
 					},
 				],
 				alertStrategy: {
-					notificationRateLimit: {
-						period: '300s', // 5 minutes
-					},
+					// `notificationRateLimit` is not allowed on metric-threshold
+					// alerts (only on log-match alerts) per the GCP Monitoring
+					// API. Debouncing is provided by the 60 s alignmentPeriod
+					// + 60 s `duration` above — a transient blip cannot fire.
 					autoClose: '3600s', // 1 hour
 				},
 				notificationChannels,
@@ -223,9 +224,10 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
 					},
 				],
 				alertStrategy: {
-					notificationRateLimit: {
-						period: '300s',
-					},
+					// Same rule as the latency alert above — the GCP API
+					// rejects `notificationRateLimit` on `conditionThreshold`
+					// alerts, even when the metric is log-derived. Debouncing
+					// here is the 60 s alignment + 300 s `duration`.
 					autoClose: '3600s',
 				},
 				notificationChannels,
@@ -308,7 +310,7 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
               }
             ],
             "thresholds": [
-              { "value": 20, "color": "YELLOW", "direction": "ABOVE", "label": "80% of max_connections (dev tier db-f1-micro → 25)" }
+              { "value": 20, "direction": "ABOVE", "label": "80% of max_connections (dev tier db-f1-micro → 25)" }
             ],
             "yAxis": {
               "label": "active backends",
@@ -391,7 +393,7 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
               }
             ],
             "thresholds": [
-              { "value": 10000, "color": "RED", "direction": "ABOVE", "label": "alert threshold (10 s)" }
+              { "value": 10000, "direction": "ABOVE", "label": "alert threshold (10 s)" }
             ],
             "yAxis": { "label": "ms", "scale": "LOG10" }
           }


### PR DESCRIPTION
## Summary

Pulumi Cloud Deployment **update 265** (PR-1b auto-deploy, #223) failed to create the `ZitadelMonitoringComponent` resources. Two distinct GCP API rejections — both silent at preview time because Pulumi only validates field shape, not API business rules.

PR #437 (specification archive of `zitadel-observability`) is held pending this fix.

## Errors observed (from Pulumi UI)

```
gcp:monitoring:AlertPolicy (alert-zitadel-oidc-latency-p99)
  Error 400: Field alertStrategy.notificationRateLimit had an invalid value of
  "period { seconds: 300 }": only log-based alert policies may specify a
  notification rate limit

gcp:monitoring:Dashboard (dashboard-zitadel-observability)
  Error 400: Field mosaicLayout.tiles[0].widget.xyChart.threshold[0].color is
  not allowed: color cannot be specified within a XyChart Threshold.
```

Same errors recur across updates 266 / 275 / 276 / 278 / 279 — all dev auto-deploys since #223 merged have failed at this step.

## Fix

### 1. Remove `alertStrategy.notificationRateLimit` from both AlertPolicies

GCP only allows `notificationRateLimit` on alerts that use `conditionMatchedLog`. Both Zitadel alerts here use `conditionThreshold`:

- **Latency alert**: reads `workload.googleapis.com/rpc.server.duration` (a regular GCP metric).
- **JWT error alert**: reads `logging.googleapis.com/user/backend_jwt_validation_zitadel_errors` (log-derived metric, but the alert queries it via `conditionThreshold`, so the GCP API classifies it as metric-based).

Debouncing is preserved by the existing aggregation settings: `alignmentPeriod: 60s` + `duration` (60s for latency, 300s for JWT). A transient blip cannot fire.

### 2. Remove `color` from `XyChart.thresholds`

The `color` field exists only on `Scorecard.thresholds`, not on `XyChart.thresholds`. The XyChart variant accepts only `value` / `direction` / `label`. Threshold lines now render in GCP's default color (red for `direction: ABOVE`).

Affected panels:
- Cloud SQL `num_backends` panel: dropped `"color": "YELLOW"` from the 80%-of-`max_connections` line.
- OIDCService p99 panel: dropped `"color": "RED"` from the 10s alert-threshold line.

## Pulumi preview

```
+ 3 to create
    + gcp:monitoring:Dashboard      dashboard-zitadel-observability
    + gcp:monitoring:AlertPolicy    alert-zitadel-oidc-latency-p99
    + gcp:monitoring:AlertPolicy    alert-backend-jwt-zitadel-errors
~ 1 to update                       (KubernetesComponent — minor drift)
+-2 to replace                      (zitadel-machine-key-version, zitadel-login-pat-version — unrelated drift from #225 bootstrap)
227 unchanged
```

The 2 SecretVersion replaces are pre-existing drift from PR #225's admin-org bootstrap and out of scope for this fix.

## Test plan

- [x] `make check` (biome + tsc + 40 vitest tests) — green.
- [x] `pulumi preview --stack dev` — clean diff with the 3 expected creates.
- [ ] CI green on this branch.
- [ ] Post-merge: Pulumi Cloud auto-deploy creates the 3 monitoring resources successfully.
- [ ] `gcloud alpha monitoring policies list --project=liverty-music-dev --filter='displayName~"Zitadel"'` returns 2 policies.
- [ ] `gcloud monitoring dashboards list --project=liverty-music-dev` returns the `Zitadel Observability` dashboard.

## Coordination

After this lands and dev verification passes:
- liverty-music/specification#437 (archive of `zitadel-observability`) can finally merge — the §1.12 deferred verification will be satisfied.
