### PR TITLE
docs(zitadel): add break-glass + oauth-client-recreate runbooks

### DIFF
--- a/docs/runbooks/zitadel-break-glass.md
+++ b/docs/runbooks/zitadel-break-glass.md
@@ -161,24 +161,49 @@ The break-glass path **fails** if any of the following are broken:
   through the Console or ran `DELETE /management/v1/users/<id>`).
 - The `eventstore` schema in Cloud SQL is corrupt.
 
-### A. SA key missing in GSM but pulumi-admin still in Zitadel
+### A. SA key missing or corrupt in GSM but pulumi-admin still in Zitadel
 
-The bootstrap-uploader sidecar in the `zitadel-*` pod re-uploads the
-key on every pod start (idempotent — see
-[`k8s/namespaces/zitadel/base/deployment-api.yaml`](../../k8s/namespaces/zitadel/base/deployment-api.yaml)).
-Trigger a pod restart:
+**The bootstrap-uploader sidecar does NOT help here.** It only fires
+during the *first* boot of an empty Zitadel database — Zitadel writes
+the admin SA key to the `emptyDir` bootstrap volume only when
+`FIRSTINSTANCE_*` runs. On any restart against a populated DB the
+volume is wiped, the file is never recreated, and the sidecar's
+`while [ ! -f "$KEY_FILE" ]; do sleep 2; done` loop blocks forever.
+See [`k8s/namespaces/zitadel/base/deployment-api.yaml#L122-L148`](../../k8s/namespaces/zitadel/base/deployment-api.yaml#L122-L148)
+for the sidecar source.
+
+**Recovery option — restore from a prior GSM secret version.**
+GSM keeps every uploaded version unless explicitly destroyed. List
+versions and look for a known-good one (created on or before the
+last successful Pulumi run):
 
 ```bash
-kubectl -n zitadel rollout restart deployment/zitadel
-kubectl -n zitadel rollout status  deployment/zitadel --timeout=120s
-kubectl -n zitadel logs -l app=zitadel -c bootstrap-uploader --tail=20
-# expected: "bootstrap-uploader: upload complete" or
-#           "bootstrap-uploader: stored version already matches, skipping upload"
+gcloud secrets versions list zitadel-admin-sa-key \
+  --project=liverty-music-dev \
+  --format='table(name,state,createTime)'
 ```
 
-The sidecar reads the bootstrap volume `/var/zitadel/bootstrap/admin-sa.json`
-written by Zitadel's `start-from-init` and pushes it to GSM. After
-the upload, retry [Step 2](#step-2--confirm-the-sa-key-authenticates-against-zitadel).
+If a prior `STATE=ENABLED` version exists, fetch and verify it:
+
+```bash
+PRIOR=<version-number>
+gcloud secrets versions access "$PRIOR" --secret=zitadel-admin-sa-key \
+  --project=liverty-music-dev > /tmp/zitadel-admin-sa-key.json
+# Run the sanity script from Step 2; if it succeeds, mark this version as
+# the new "latest" by adding a new version that is a copy of the prior:
+gcloud secrets versions access "$PRIOR" --secret=zitadel-admin-sa-key \
+  --project=liverty-music-dev \
+  | gcloud secrets versions add zitadel-admin-sa-key \
+    --project=liverty-music-dev --data-file=-
+```
+
+Then retry [Step 2](#step-2--confirm-the-sa-key-authenticates-against-zitadel).
+
+**No prior version available.** Scenario A collapses into Scenario B
+— without any working SA key for the existing `pulumi-admin` user,
+there is no path to recover that user's identity short of
+re-bootstrapping the whole instance with a fresh `pulumi-admin` (and
+fresh SA key).
 
 ### B. `pulumi-admin` user deleted from Zitadel (no SA key valid)
 
@@ -193,29 +218,68 @@ its key:
    `POST /v2/users/_search` filtered by `type=HUMAN` should return only
    the locked-out admins. Self-hosted dev should have zero end users
    (they live in `liverty-music` product org and only post-launch).
-3. **DROP and recreate the `zitadel` database in Cloud SQL** — same
-   procedure as the original change `add-zitadel-console-admin-via-google-idp`
-   Phase 5 (DB wipe). Use the Cloud SQL Auth Proxy + IAM as
-   `zitadel@liverty-music-dev.iam`:
-   ```sql
+3. **DROP and recreate the `zitadel` database in Cloud SQL.** The IAM
+   user `zitadel@liverty-music-dev.iam` cannot do this — it has the
+   `cloudsqliamuser` role only and (a) defaults to connecting to the
+   `zitadel` database (so PostgreSQL refuses `DROP DATABASE zitadel`
+   with "cannot drop the currently open database"), and (b) lacks
+   `CREATEDB` and ownership of the existing DB. Authenticate as the
+   built-in `postgres` superuser instead — same approach as
+   [`k8s/namespaces/zitadel/base/job-grant-db.yaml`](../../k8s/namespaces/zitadel/base/job-grant-db.yaml).
+
+   Start a Cloud SQL Auth Proxy *without* `--auto-iam-authn` and a
+   psql client pod, both pointed at the `postgres` database (not
+   `zitadel`):
+
+   ```bash
+   # Fetch the postgres admin password from GSM. The secret name
+   # matches the ESC-managed `gcp.postgresAdminPassword` value.
+   PG_ADMIN_PASSWORD=$(gcloud secrets versions access latest \
+     --project=liverty-music-dev --secret=postgres-admin-password)
+
+   # In one terminal: port-forward Cloud SQL Auth Proxy to localhost.
+   kubectl -n zitadel run sql-proxy-rescue \
+     --rm -i --restart=Never --image=gcr.io/cloud-sql-connectors/cloud-sql-proxy:2 \
+     --command -- \
+     --psc --port=5432 --address=0.0.0.0 \
+     liverty-music-dev:asia-northeast2:postgres-osaka &
+
+   kubectl -n zitadel port-forward pod/sql-proxy-rescue 5432:5432 &
+
+   # In another terminal: connect to the `postgres` DB (not zitadel).
+   PGPASSWORD="$PG_ADMIN_PASSWORD" psql \
+     -h 127.0.0.1 -p 5432 -U postgres -d postgres \
+     -v ON_ERROR_STOP=1 <<'SQL'
    DROP DATABASE zitadel;
-   CREATE DATABASE zitadel OWNER "zitadel@liverty-music-dev.iam";
+   CREATE DATABASE zitadel;
+   SQL
    ```
+
+   The new database is owned by `cloudsqlsuperuser`. ArgoCD's
+   `zitadel-db-grant` Job (also in `k8s/namespaces/zitadel/base/`)
+   will re-grant ownership to `zitadel@liverty-music-dev.iam` on its
+   next sync — no manual GRANT step needed here.
+
 4. **Restart the Zitadel deployment** so `start-from-init` runs against
    the empty DB:
    ```bash
    kubectl -n zitadel rollout restart deployment/zitadel
    ```
 5. **Wait for `bootstrap-uploader: upload complete`** in the new pod's
-   logs. The new admin SA key lands in GSM. The new admin org is named
-   `admin` because `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` is in the
-   ConfigMap.
+   logs. This *is* a true first-instance boot now, so the sidecar
+   fires correctly and the new admin SA key lands in GSM. The new
+   admin org is named `admin` because
+   `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` is in the ConfigMap.
 6. **Update `constants.ts.ZITADEL_DEV_ADMIN_ORG_ID`** with the new org
    id (search via `POST /admin/v1/orgs/_search`).
 7. **`pulumi up`** to re-provision `liverty-music` product org, IdPs,
-   human admin, link, etc.
+   human admin, link, etc. (Per the project CLAUDE.md, dev `pulumi
+   up` runs via Pulumi Cloud Deployments on PR merge — open a PR with
+   the constants update and let the auto-deploy run.)
 8. Follow [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md) to
-   re-link the human admin's Google identity.
+   re-link each human admin's Google identity (the user IDs change
+   with the new instance, so existing ESC sub records still apply but
+   need new `userId` lookups).
 
 This is a destructive procedure (loses any Pulumi-managed
 `MachineKey` rotations, custom Action revisions, etc.). Reach for it

--- a/docs/runbooks/zitadel-break-glass.md
+++ b/docs/runbooks/zitadel-break-glass.md
@@ -1,0 +1,252 @@
+# Runbook: Zitadel Console break-glass recovery
+
+> **When to use:** the human admin (Google SSO) cannot reach
+> `https://auth.dev.liverty-music.app/ui/console` for any reason — IdP
+> outage, accidentally-deleted Google OAuth client, broken admin
+> `LoginPolicy`, deleted human-admin `HumanUser`, broken `IdpGoogle`
+> resource, mangled `ZitadelUserIdpLink`. This runbook walks the
+> machine-user (`pulumi-admin`) recovery path so the operator can
+> repair Zitadel state via Pulumi without going through the human
+> sign-in flow.
+
+## Background — why two independent identities exist
+
+The dev Zitadel instance has **two paths** to authenticate
+infrastructure changes:
+
+1. **Human admin** (`pannpers@pannpers.dev`, `IAM_OWNER`) — Google SSO
+   → Console UI. The everyday path. Depends on Google IdP, the OAuth
+   client, the admin org's `LoginPolicy`, the `IdpGoogle` Pulumi
+   resource, and the `ZitadelUserIdpLink` pre-link. Many moving parts.
+2. **Machine admin** (`pulumi-admin`, `IAM_OWNER`) — JSON service
+   account key in GSM secret `zitadel-admin-sa-key` → JWT-bearer
+   exchange → Zitadel admin REST API. The `@pulumiverse/zitadel`
+   Pulumi provider is the typical consumer. Depends on **only** the
+   GSM secret + Cloud SQL eventstore being intact.
+
+Path 2 is the break-glass identity. It survives any failure of path 1
+because Pulumi's `liverty-music-provider` reads the SA key directly
+from GSM and talks to Zitadel without going through Login V2 or any
+IdP. See OpenSpec change `add-zitadel-console-admin-via-google-idp`
+spec requirement *"Retain Break-glass Machine User"*.
+
+## Pre-conditions for break-glass to work
+
+Verify these before relying on the runbook (if any are broken, the
+break-glass path itself is compromised — see [Recovering the
+break-glass identity itself](#recovering-the-break-glass-identity-itself)):
+
+```bash
+# 1. The pulumi-admin user still exists in the admin org.
+PROJECT=liverty-music-dev
+gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
+  --project="$PROJECT" > /tmp/zitadel-admin-sa-key.json
+jq -r '.userId' /tmp/zitadel-admin-sa-key.json
+# expected: a Zitadel user-id snowflake (numeric string)
+
+# 2. The Cloud SQL eventstore is reachable.
+kubectl -n zitadel get pods -l app=zitadel
+# expected: zitadel-* pod Running 3/3 (zitadel + cloud-sql-proxy + bootstrap-uploader)
+```
+
+## Break-glass procedure
+
+### Step 1 — fetch the SA key locally
+
+```bash
+gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
+  --project=liverty-music-dev > /tmp/zitadel-admin-sa-key.json
+```
+
+The file contains the `pulumi-admin` machine user's RSA private key.
+Treat it like a root credential — delete from `/tmp` after use, do not
+commit, do not paste anywhere.
+
+### Step 2 — confirm the SA key authenticates against Zitadel
+
+A short Python script using only the standard library plus
+`cryptography` to mint a JWT-bearer assertion, exchange it for a
+Zitadel access token, and call a sanity endpoint:
+
+```python
+#!/usr/bin/env python3
+import json, time, urllib.request
+from base64 import urlsafe_b64encode
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+ZITADEL = "https://auth.dev.liverty-music.app"
+
+def b64url(d): return urlsafe_b64encode(d).rstrip(b"=").decode()
+with open("/tmp/zitadel-admin-sa-key.json") as f: key = json.load(f)
+now = int(time.time())
+header = {"alg":"RS256","typ":"JWT","kid":key["keyId"]}
+payload = {"iss":key["userId"],"sub":key["userId"],"aud":ZITADEL,"iat":now,"exp":now+300}
+h = b64url(json.dumps(header,separators=(",",":")).encode())
+p = b64url(json.dumps(payload,separators=(",",":")).encode())
+sig = serialization.load_pem_private_key(key["key"].encode(), password=None).sign(
+    f"{h}.{p}".encode(), padding.PKCS1v15(), hashes.SHA256())
+body = (
+    "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer"
+    f"&assertion={h}.{p}.{b64url(sig)}"
+    "&scope=openid urn:zitadel:iam:org:project:id:zitadel:aud"
+)
+req = urllib.request.Request(f"{ZITADEL}/oauth/v2/token", data=body.encode(),
+    headers={"Content-Type":"application/x-www-form-urlencoded"}, method="POST")
+token = json.loads(urllib.request.urlopen(req).read())["access_token"]
+
+# Sanity: list orgs (IAM_OWNER required).
+req = urllib.request.Request(f"{ZITADEL}/admin/v1/orgs/_search",
+    headers={"Authorization": f"Bearer {token}", "Content-Type":"application/json"},
+    data=b"{}", method="POST")
+print(json.loads(urllib.request.urlopen(req).read()))
+```
+
+Save as `/tmp/zitadel-break-glass-smoke.py`, then `python3
+/tmp/zitadel-break-glass-smoke.py`.
+
+**Expected output:** a JSON envelope listing `admin` and
+`liverty-music` orgs. If the call returns 401/403, the SA key is
+invalid — see [Recovering the break-glass identity
+itself](#recovering-the-break-glass-identity-itself).
+
+### Step 3 — let Pulumi take over
+
+The `@pulumiverse/zitadel` provider reads `zitadel-admin-sa-key` from
+GSM directly via `gcp.secretmanager.getSecretVersionOutput` (see
+[`src/zitadel/index.ts`](../../src/zitadel/index.ts) — the
+`jwtProfileJson` wiring). No additional config is needed; running
+Pulumi commands against the `dev` stack uses this same path.
+
+```bash
+cd ~/dev/src/github.com/liverty-music/cloud-provisioning
+
+# Confirm Pulumi can talk to Zitadel — empty diff proves the key works.
+pulumi preview -s dev
+# expected: "no changes" or only resources unrelated to identity
+```
+
+If `preview` succeeds, **everyday Pulumi flow is back online**. From
+this point you can:
+
+- Re-create a deleted `HumanUser` / `InstanceMember` /
+  `ZitadelUserIdpLink` by reverting the offending PR or `pulumi up`.
+- Re-create a deleted `IdpGoogle` by `pulumi up` (ESC carries
+  `clientId` / `clientSecret`; the IdP is fully declarative).
+- Re-create a deleted `LoginPolicy` on the admin org by `pulumi up`
+  (`AdminOrgConfigComponent`).
+
+### Step 4 — restore Console access
+
+After Pulumi reconciles the broken resources:
+
+1. Wait for `pulumi up` to complete (or the Pulumi Cloud auto-deploy
+   on PR merge if you are routing through CI).
+2. Test `https://auth.dev.liverty-music.app/ui/console` in a private
+   window. The Google SSO path should resolve to the human admin and
+   load Console with `IAM_OWNER`.
+3. If the smoke test still fails, check the IdP link via the API:
+   ```bash
+   python3 /tmp/list-pannpers-idp-links.py   # see add-zitadel-admin-user.md
+   ```
+   `result[]` must contain a link with `idpId` matching the Google IdP
+   id and `userId` matching the ESC-stored Google `sub`.
+
+## Recovering the break-glass identity itself
+
+The break-glass path **fails** if any of the following are broken:
+
+- The `zitadel-admin-sa-key` GSM secret is missing or corrupt.
+- The `pulumi-admin` user is gone from Zitadel (someone deleted it
+  through the Console or ran `DELETE /management/v1/users/<id>`).
+- The `eventstore` schema in Cloud SQL is corrupt.
+
+### A. SA key missing in GSM but pulumi-admin still in Zitadel
+
+The bootstrap-uploader sidecar in the `zitadel-*` pod re-uploads the
+key on every pod start (idempotent — see
+[`k8s/namespaces/zitadel/base/deployment-api.yaml`](../../k8s/namespaces/zitadel/base/deployment-api.yaml)).
+Trigger a pod restart:
+
+```bash
+kubectl -n zitadel rollout restart deployment/zitadel
+kubectl -n zitadel rollout status  deployment/zitadel --timeout=120s
+kubectl -n zitadel logs -l app=zitadel -c bootstrap-uploader --tail=20
+# expected: "bootstrap-uploader: upload complete" or
+#           "bootstrap-uploader: stored version already matches, skipping upload"
+```
+
+The sidecar reads the bootstrap volume `/var/zitadel/bootstrap/admin-sa.json`
+written by Zitadel's `start-from-init` and pushes it to GSM. After
+the upload, retry [Step 2](#step-2--confirm-the-sa-key-authenticates-against-zitadel).
+
+### B. `pulumi-admin` user deleted from Zitadel (no SA key valid)
+
+This is a **total lockout** state — there is no IAM_OWNER identity
+that can authenticate. Recovery requires re-bootstrapping Zitadel
+with a fresh first-instance run, which regenerates `pulumi-admin` and
+its key:
+
+1. **Verify the lockout** — confirm both human and machine paths fail
+   (Console returns 401 / Pulumi preview returns "permission denied").
+2. **Verify there are no human end users to lose** —
+   `POST /v2/users/_search` filtered by `type=HUMAN` should return only
+   the locked-out admins. Self-hosted dev should have zero end users
+   (they live in `liverty-music` product org and only post-launch).
+3. **DROP and recreate the `zitadel` database in Cloud SQL** — same
+   procedure as the original change `add-zitadel-console-admin-via-google-idp`
+   Phase 5 (DB wipe). Use the Cloud SQL Auth Proxy + IAM as
+   `zitadel@liverty-music-dev.iam`:
+   ```sql
+   DROP DATABASE zitadel;
+   CREATE DATABASE zitadel OWNER "zitadel@liverty-music-dev.iam";
+   ```
+4. **Restart the Zitadel deployment** so `start-from-init` runs against
+   the empty DB:
+   ```bash
+   kubectl -n zitadel rollout restart deployment/zitadel
+   ```
+5. **Wait for `bootstrap-uploader: upload complete`** in the new pod's
+   logs. The new admin SA key lands in GSM. The new admin org is named
+   `admin` because `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin` is in the
+   ConfigMap.
+6. **Update `constants.ts.ZITADEL_DEV_ADMIN_ORG_ID`** with the new org
+   id (search via `POST /admin/v1/orgs/_search`).
+7. **`pulumi up`** to re-provision `liverty-music` product org, IdPs,
+   human admin, link, etc.
+8. Follow [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md) to
+   re-link the human admin's Google identity.
+
+This is a destructive procedure (loses any Pulumi-managed
+`MachineKey` rotations, custom Action revisions, etc.). Reach for it
+only after confirming option A is genuinely impossible.
+
+### C. Cloud SQL eventstore corrupt
+
+Out of scope for this runbook — recovery is via Cloud SQL PITR
+(Point-In-Time-Recovery) to a known-good timestamp before the
+corruption, then re-running the steps above against the restored DB.
+See the Cloud SQL operational runbook (separate doc).
+
+## After recovery — drift sweep
+
+A break-glass intervention often leaves Pulumi state out of sync with
+reality (the admin-side fix is usually a hand-API-call, not a
+declarative change). Reconcile:
+
+```bash
+cd ~/dev/src/github.com/liverty-music/cloud-provisioning
+pulumi -s dev refresh --yes
+pulumi -s dev preview
+# expected: empty diff. Anything non-empty is drift introduced by the
+# manual fix and should be either codified into the next PR or reverted.
+```
+
+## Reference
+
+- OpenSpec change: `add-zitadel-console-admin-via-google-idp`
+- Spec requirement: *"Retain Break-glass Machine User"*
+- Pulumi provider wiring: [`src/zitadel/index.ts`](../../src/zitadel/index.ts) (`jwtProfileJson`)
+- Bootstrap-uploader sidecar: [`k8s/namespaces/zitadel/base/deployment-api.yaml`](../../k8s/namespaces/zitadel/base/deployment-api.yaml)
+- Admin user lifecycle (everyday path): [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md)
+- Zitadel hang incident: [`zitadel-hang.md`](zitadel-hang.md)

--- a/docs/runbooks/zitadel-oauth-client-recreate.md
+++ b/docs/runbooks/zitadel-oauth-client-recreate.md
@@ -82,14 +82,16 @@ esc env set liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientSecret \
 > being able to read it back from `esc env get` without the project's
 > decrypt key simplifies debugging.
 
-Verify:
+Verify (use `--value string` so `esc` prints just the value, not the
+markdown envelope it would otherwise render — matches the established
+pattern in [`docs/TICKET_SYSTEM_SETUP.md`](../TICKET_SYSTEM_SETUP.md)):
 
 ```bash
-esc env get liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientId
+esc env get liverty-music/dev --value string pulumiConfig.zitadel.googleAdminIdp.clientId
 # expected: a printable client_id
 
-esc env get liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientSecret
-# expected: "[secret]" with a Definition ciphertext line
+esc env get liverty-music/dev --value string pulumiConfig.zitadel.googleAdminIdp.clientSecret
+# expected: "[secret]" (value is masked; add --show-secrets to reveal)
 ```
 
 ## Step 4 — let Pulumi reconcile
@@ -97,9 +99,10 @@ esc env get liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientSecret
 Merging any change to `cloud-provisioning/main` triggers Pulumi Cloud
 Deployments to run `pulumi up` against `dev`. If you don't have a
 pending change, push an empty-diff commit (e.g. a comment-only edit
-to a docs file) to wake the auto-deploy. Or run `pulumi up` locally
-against the `dev` stack — but prefer the auto-deploy path so the
-change goes through CI review.
+to a docs file) to wake the auto-deploy. **Do NOT** run `pulumi up`
+locally against the `dev` stack — per the project CLAUDE.md, local
+`pulumi up` conflicts with the automated job and is expressly
+forbidden in this repo.
 
 The `IdpGoogle` Pulumi resource will detect the changed `clientId` /
 `clientSecret` and submit an update to Zitadel without recreating

--- a/docs/runbooks/zitadel-oauth-client-recreate.md
+++ b/docs/runbooks/zitadel-oauth-client-recreate.md
@@ -1,0 +1,149 @@
+# Runbook: Recreate the Zitadel admin Google OAuth client
+
+> **When to use:** the Google OAuth 2.0 Web Application client behind
+> Zitadel's admin Google IdP has been deleted, disabled, or its
+> redirect URI mangled — and as a result `https://auth.dev.liverty-music.app/ui/console`
+> Google sign-in returns `redirect_uri_mismatch`, `unauthorized_client`,
+> or `disabled_client`. This runbook walks the manual recreation path.
+
+## Why this is manual (not Pulumi)
+
+Google does **not** expose a public API for creating general-purpose
+OAuth 2.0 Web Application clients. The only declarative-tool option
+in `@pulumi/gcp` is `gcp.iap.Client`, which (a) was deprecated
+2025-01-22 and shut down 2026-03-19, and (b) is scoped to
+Identity-Aware Proxy, not generic OIDC sign-in. So the OAuth client
+is created **once per environment** through the Google Cloud Console
+UI; from then on, all rotation happens via `esc env set` + `pulumi up`.
+
+See OpenSpec change `add-zitadel-console-admin-via-google-idp` design
+D6 for the full rationale.
+
+## Pre-conditions
+
+- You have **Owner** or **OAuth Config Admin** on the `liverty-music-dev`
+  GCP project.
+- You can sign in to Google as a member of the `pannpers.dev`
+  Workspace (the Internal consent screen audience).
+- You have `esc` CLI authenticated against `liverty-music`
+  (`esc env ls` lists the org's environments).
+
+## Step 1 — re-establish the consent screen if it was reset
+
+The OAuth client is gated by the project's "Auth Platform" (Google's
+new combined OAuth-consent + client UI replacing the old separate
+"OAuth consent screen" + "Credentials" pages). If only the client
+was deleted, the consent screen survives — skip this step.
+
+If the consent screen is also gone:
+
+1. Open <https://console.cloud.google.com/auth/overview?project=liverty-music-dev>.
+2. Choose **User type: Internal** (limited to `pannpers.dev`
+   Workspace — no Google review or external verification).
+3. **App name:** `Liverty Music Admin Console (dev)`.
+4. **Support email:** `pannpers@pannpers.dev`.
+5. **Developer contact email:** `pannpers@pannpers.dev`.
+6. **Authorised domain:** add `liverty-music.app` (so that the
+   Zitadel callback URL `auth.dev.liverty-music.app` is accepted at
+   client-creation time).
+7. **App logo / homepage:** leave empty for dev. Save.
+
+## Step 2 — create the Web Application client
+
+1. Open <https://console.cloud.google.com/auth/clients?project=liverty-music-dev>
+   → **Create Client**.
+2. **Application type:** `Web application`.
+3. **Name:** `Zitadel Admin IdP (dev)`.
+4. **Authorised JavaScript origins:** *(none — leave empty)*.
+5. **Authorised redirect URIs:** add exactly this single entry:
+   ```
+   https://auth.dev.liverty-music.app/idps/callback
+   ```
+   This is the Zitadel v4 Login V2 fixed callback path. No IdP id
+   suffix — Zitadel uses the same path for every external IdP and
+   resolves which one by the `state` parameter. See OpenSpec
+   pre-flight task 1.4.
+6. **Create.** Copy the `Client ID` and `Client secret` from the
+   modal that appears (the secret is only shown once).
+
+## Step 3 — push the new credentials to Pulumi ESC
+
+```bash
+# Replace the placeholders with the values from Step 2.
+esc env set liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientId \
+  '<NEW_CLIENT_ID>.apps.googleusercontent.com'
+esc env set liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientSecret \
+  '<NEW_CLIENT_SECRET>' --secret
+```
+
+> **Important:** the existing OpenSpec change wrote `clientId` as
+> plaintext (no `--secret`) and `clientSecret` as encrypted
+> (`--secret`). Match that pattern — `clientId` is not sensitive and
+> being able to read it back from `esc env get` without the project's
+> decrypt key simplifies debugging.
+
+Verify:
+
+```bash
+esc env get liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientId
+# expected: a printable client_id
+
+esc env get liverty-music/dev pulumiConfig.zitadel.googleAdminIdp.clientSecret
+# expected: "[secret]" with a Definition ciphertext line
+```
+
+## Step 4 — let Pulumi reconcile
+
+Merging any change to `cloud-provisioning/main` triggers Pulumi Cloud
+Deployments to run `pulumi up` against `dev`. If you don't have a
+pending change, push an empty-diff commit (e.g. a comment-only edit
+to a docs file) to wake the auto-deploy. Or run `pulumi up` locally
+against the `dev` stack — but prefer the auto-deploy path so the
+change goes through CI review.
+
+The `IdpGoogle` Pulumi resource will detect the changed `clientId` /
+`clientSecret` and submit an update to Zitadel without recreating
+the IdP. Existing `ZitadelUserIdpLink` records survive — the
+`(idpId, externalUserId)` tuple does not change.
+
+## Step 5 — smoke test the admin sign-in flow
+
+1. Open `https://auth.dev.liverty-music.app/ui/console` in a private
+   window (so old session cookies don't mask the broken state).
+2. Click **Google (admin)**.
+3. Sign in as `pannpers@pannpers.dev` (or any other admin pre-linked
+   per [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md)).
+4. **Expected:** Console loads with `IAM_OWNER` privileges. No
+   `redirect_uri_mismatch` from Google, no `account-not-found` from
+   Zitadel.
+
+If sign-in still fails:
+
+- `redirect_uri_mismatch` from Google → the redirect URI in Step 2.5
+  is wrong. Confirm exact match (no trailing slash, http vs https,
+  hostname spelling).
+- `unauthorized_client` from Google → the Web Application client is
+  paused or in the wrong project. Confirm it's in
+  `liverty-music-dev` and Active.
+- `account-not-found` from Zitadel → the OAuth client is fine but
+  the IdP-link record for the human admin is missing. Follow
+  [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md) Step 6
+  troubleshooting.
+
+## Why we don't rotate the secret on a fixed schedule
+
+The Google OAuth client secret has no expiry. Rotation here is
+event-driven — you rotate when there is reason to believe the secret
+is compromised (laptop loss, leaked CI logs, etc.), not on a calendar.
+The rotation procedure is the same as Step 3 above (write the new
+secret to ESC, let Pulumi reconcile). Existing admin sessions remain
+valid until they expire naturally; new sign-in attempts use the new
+secret.
+
+## Reference
+
+- OpenSpec change: `add-zitadel-console-admin-via-google-idp`
+- Spec requirement: *"Maintain Google OAuth Client in Dev Infrastructure"*
+- Design decision: D6
+- Admin user lifecycle: [`add-zitadel-admin-user.md`](add-zitadel-admin-user.md)
+- Total lockout recovery: [`zitadel-break-glass.md`](zitadel-break-glass.md)


### PR DESCRIPTION
## Summary

Closes the two operational-doc gaps surfaced by `/opsx:verify` against the
`add-zitadel-console-admin-via-google-idp` OpenSpec change.

| New runbook | Closes OpenSpec task | Why |
|---|---|---|
| [`docs/runbooks/zitadel-break-glass.md`](docs/runbooks/zitadel-break-glass.md) | 10.4 | Operator path back to Console when Google SSO is down — fetch `pulumi-admin` SA key from GSM, mint JWT-bearer assertion, exchange for token, reconcile via `pulumi preview`. Plus a "recover the break-glass identity itself" section for the catastrophic case (DB wipe + re-bootstrap). |
| [`docs/runbooks/zitadel-oauth-client-recreate.md`](docs/runbooks/zitadel-oauth-client-recreate.md) | 4.7 (capability spec scenario *"Client recreation runbook"*) | Manual Google OAuth 2.0 Web Application client recreation in `liverty-music-dev` — consent screen, Web Application client, redirect URI, ESC `googleAdminIdp.{clientId,clientSecret}`, then `pulumi up`. |

## Why these are docs-only

Neither runbook adds code or changes infrastructure. Both document procedures that are intentionally out-of-band from Pulumi:

- **Break-glass** depends on the `pulumi-admin` machine user that already exists per OpenSpec spec *"Retain Break-glass Machine User"*. The runbook just shows how to use it.
- **OAuth client recreation** is manual because Google does not expose a public API for general-purpose OAuth 2.0 Web Application clients (the only `@pulumi/gcp` option, `gcp.iap.Client`, is deprecated and IAP-scoped — see OpenSpec design D6).

## Cross-references

Both runbooks back-reference the OpenSpec change for traceability and link to [`add-zitadel-admin-user.md`](docs/runbooks/add-zitadel-admin-user.md) (the everyday admin lifecycle path added in PR #229) so an operator hitting one runbook can navigate to the others.

## Test plan

- [x] Files render correctly on GitHub (markdown links, code blocks)
- [x] No code changes → CI lint/test should pass identically to main

Refs: #229
