### PR TITLE
fix(monitoring): correct aggregation + drop XyChart threshold direction

### DIFF
--- a/src/gcp/components/zitadel-monitoring.ts
+++ b/src/gcp/components/zitadel-monitoring.ts
@@ -107,13 +107,23 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
 								'AND metric.labels.rpc_service=monitoring.regex.full_match(".*OIDCService.*")',
 							aggregations: [
 								{
-									// 60 s alignment matches `OTEL_METRIC_EXPORT_INTERVAL`
-									// in the Zitadel pod env, so each evaluation cycle
-									// sees ~1 fresh data point with a full 60 s of
-									// in-process histogram aggregation already baked in.
+									// `rpc.server.duration` is a CUMULATIVE
+									// DISTRIBUTION metric (OTEL histogram, translated
+									// by the `googlecloud` exporter). The percentile
+									// aligner cannot be applied directly to cumulative
+									// distributions (GCP API rejects with "ALIGN_PERCENTILE_99
+									// cannot be applied to metrics with kind CUMULATIVE
+									// and value type DISTRIBUTION"). Two-stage pattern:
+									//   1. `ALIGN_DELTA` over 60 s converts cumulative
+									//      → delta DISTRIBUTION (matches OTEL_METRIC_EXPORT_INTERVAL
+									//      so each cycle sees ~1 fresh point with a full
+									//      60 s of in-process histogram aggregation).
+									//   2. `REDUCE_PERCENTILE_99` across series grouped
+									//      by `rpc_method` produces one p99 line per
+									//      method — fires when ANY method's p99 > 10 s.
 									alignmentPeriod: '60s',
-									perSeriesAligner: 'ALIGN_PERCENTILE_99',
-									crossSeriesReducer: 'REDUCE_MAX',
+									perSeriesAligner: 'ALIGN_DELTA',
+									crossSeriesReducer: 'REDUCE_PERCENTILE_99',
 									groupByFields: ['metric.labels.rpc_method'],
 								},
 							],
@@ -310,7 +320,7 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
               }
             ],
             "thresholds": [
-              { "value": 20, "direction": "ABOVE", "label": "80% of max_connections (dev tier db-f1-micro → 25)" }
+              { "value": 20, "label": "80% of max_connections (dev tier db-f1-micro → 25)" }
             ],
             "yAxis": {
               "label": "active backends",
@@ -380,8 +390,8 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
                     "filter": "metric.type=\\"workload.googleapis.com/rpc.server.duration\\" AND metric.labels.service_name=\\"zitadel\\" AND metric.labels.rpc_service=monitoring.regex.full_match(\\".*OIDCService.*\\")",
                     "aggregation": {
                       "alignmentPeriod": "60s",
-                      "perSeriesAligner": "ALIGN_PERCENTILE_99",
-                      "crossSeriesReducer": "REDUCE_MAX",
+                      "perSeriesAligner": "ALIGN_DELTA",
+                      "crossSeriesReducer": "REDUCE_PERCENTILE_99",
                       "groupByFields": ["metric.labels.rpc_method"]
                     }
                   },
@@ -393,7 +403,7 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
               }
             ],
             "thresholds": [
-              { "value": 10000, "direction": "ABOVE", "label": "alert threshold (10 s)" }
+              { "value": 10000, "label": "alert threshold (10 s)" }
             ],
             "yAxis": { "label": "ms", "scale": "LOG10" }
           }


### PR DESCRIPTION
## Summary

PR #230 fixed two GCP API rejections, but the next deploy (update 280) hit **two more**, both same class — silent at preview, fail at apply. Pulumi only validates against provider schema; not against API business rules.

This PR fixes both. Preview is clean (`+ 3 to create`).

PR #437 (specification archive) remains held until this lands and the dev resources are confirmed in Cloud Monitoring.

## Errors observed (Pulumi UI, update 280)

```
gcp:monitoring:AlertPolicy (alert-zitadel-oidc-latency-p99)
  Error 400: Field aggregation.perSeriesAligner had an invalid value of
  "ALIGN_PERCENTILE_99": The aligner cannot be applied to metrics with
  kind CUMULATIVE and value type DISTRIBUTION.

gcp:monitoring:Dashboard (dashboard-zitadel-observability)
  Error 400: Field mosaicLayout.tiles[0].widget.xyChart.threshold[0].direction
  is not allowed: direction cannot be specified within a XyChart Threshold.
```

## Fix

### 1. AlertPolicy aggregation: two-stage pattern for CUMULATIVE DISTRIBUTION

`workload.googleapis.com/rpc.server.duration` is a CUMULATIVE DISTRIBUTION metric (OTEL histogram, translated by the `googlecloud` exporter). The percentile aligner cannot be applied directly to cumulative distributions.

```diff
  alignmentPeriod: '60s',
- perSeriesAligner: 'ALIGN_PERCENTILE_99',
- crossSeriesReducer: 'REDUCE_MAX',
+ perSeriesAligner: 'ALIGN_DELTA',          // cumulative → delta DISTRIBUTION
+ crossSeriesReducer: 'REDUCE_PERCENTILE_99', // then 99-percentile across grouped series
  groupByFields: ['metric.labels.rpc_method'],
```

The semantic intent is preserved: 60 s alignment matches `OTEL_METRIC_EXPORT_INTERVAL`, and the reducer produces one p99 line per `rpc_method` — fires when ANY method's p99 > 10 s.

Same fix applied to the dashboard's OIDCService p99 panel (same metric, same aligner constraint).

### 2. XyChart.thresholds: `direction` is also rejected

PR #230 dropped `color` based on the first error message. The next deploy revealed `direction` is also rejected. `XyChart.thresholds[]` accepts only `value` and `label` — even though the proto schema lists the full `Threshold` object (the `color`/`direction` fields belong to `Scorecard.thresholds` only).

Both threshold lines updated:
- Cloud SQL `num_backends` panel (80% of `max_connections` line at value=20)
- OIDCService p99 panel (alert threshold line at value=10000)

## Pulumi preview

```
+ 3 to create
    + gcp:monitoring:Dashboard      dashboard-zitadel-observability
    + gcp:monitoring:AlertPolicy    alert-zitadel-oidc-latency-p99
    + gcp:monitoring:AlertPolicy    alert-backend-jwt-zitadel-errors
+-2 to replace                      (zitadel-machine-key-version, zitadel-login-pat-version — pre-existing drift, unrelated)
228 unchanged
```

## Test plan

- [x] `make check` (biome + tsc + 40 vitest tests) — green.
- [x] `pulumi preview --stack dev` — clean diff.
- [ ] CI green on this branch.
- [ ] Post-merge: Pulumi Cloud auto-deploy reaches the create step and the 3 monitoring resources land successfully.
- [ ] `gcloud alpha monitoring policies list --project=liverty-music-dev --filter='displayName~Zitadel'` returns 2 policies.
- [ ] `gcloud monitoring dashboards list --project=liverty-music-dev` returns the Zitadel Observability dashboard.

## Why this slipped past PR #230

The original PR-1b (#223) had four GCP API field-level bugs. They surface one at a time on apply because Pulumi reports the first error and aborts. Every redeploy reveals the next layer. This PR addresses errors 3 + 4. Hopefully the last layer.
