### PR TITLE
fix(zitadel): switch CronJob to bitnamilegacy/kubectl (image was pulled)

### DIFF
--- a/k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml
@@ -103,12 +103,17 @@ spec:
             cloud.google.com/gke-spot: "true"
           containers:
           - name: kubectl
-            # bitnami/kubectl ships a minimal image with kubectl on
-            # the PATH. The :1.32 tag is pinned to match the cluster
-            # control-plane minor (1.35 minor diff is within the
-            # supported skew). Updates are a one-line bump in this
-            # file when the cluster bumps.
-            image: bitnami/kubectl:1.32
+            # `bitnamilegacy/kubectl` is Bitnami's legacy-free path on
+            # Docker Hub — `bitnami/kubectl:*` was withdrawn from the
+            # free public catalog in 2025, breaking the original
+            # `bitnami/kubectl:1.32` tag. The image is a drop-in
+            # replacement (same Bitnami build, just a different repo).
+            # The first scheduled fire (2026-05-10 03:00 UTC) failed
+            # 3 times with `ImagePullBackOff: docker.io/bitnami/kubectl:1.32
+            # not found` before this fix.
+            # The :1.32 tag matches the cluster control-plane minor.
+            # Updates are a one-line bump in this file when the cluster bumps.
+            image: bitnamilegacy/kubectl:1.32
             command:
             - kubectl
             args:


### PR DESCRIPTION
## Summary

The §18.6 weekly-restart CronJob in dev (`zitadel-restart` in `zitadel` namespace) fired for the first time on **2026-05-10 03:00 UTC** and **failed** with `ImagePullBackOff` × 3:

```
Failed to pull image "bitnami/kubectl:1.32": rpc error: code = NotFound
desc = failed to resolve reference "docker.io/bitnami/kubectl:1.32": not found
```

`bitnami/kubectl:*` tags were withdrawn from Bitnami's free public Docker Hub catalog in 2025. The image moved to `bitnamilegacy/*` — same Bitnami build, just a different repo. Drop-in replacement.

This means the band-aid for `self-hosted-zitadel §18.6` (weekly forced restart) was **NOT functioning** between 2026-05-04 (CronJob deploy via #221) and now.

## Fix

Single-line image bump in [`k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml`](https://github.com/liverty-music/cloud-provisioning/blob/main/k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml):

```diff
- image: bitnami/kubectl:1.32
+ image: bitnamilegacy/kubectl:1.32
```

Comment updated to explain the historical context (so the next person who reads it understands why we're on `bitnamilegacy`).

## How this was found

Running the deferred §2.9 verification task from the archived `zitadel-observability` openspec change ([`openspec/changes/archive/2026-05-03-zitadel-observability/`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-03-zitadel-observability)). The very reason §2.9 was held back as a follow-up rather than marked done at archive time — to verify the CronJob actually fires.

## Verification

- [x] `kubectl kustomize --enable-helm k8s/namespaces/zitadel/overlays/dev` renders cleanly with `image: bitnamilegacy/kubectl:1.32` and no other diffs.
- [x] `bitnamilegacy/kubectl:1.32` resolves on Docker Hub (latest is 1.33.4; `1.32`/`1.32.0`-`1.32.4` all present).
- [ ] CI green.
- [ ] Post-merge: ArgoCD reconciles the CronJob.
- [ ] Manual one-off verification: `kubectl create job --from=cronjob/zitadel-restart manual-test-1 -n zitadel` succeeds + rolls the Zitadel deploy without downtime.
- [ ] Next Sunday 03:00 UTC scheduled fire confirmed successful.

## Related

- liverty-music/specification#437 (archive of `zitadel-observability`, merged) §2.9
- #221 (PR-2: original CronJob deploy)
- `self-hosted-zitadel §18.6` (in-flight openspec change tracking the band-aid life cycle)
