### PR TITLE
test(monitoring): lower Zitadel latency alert threshold for smoke-test [REVERT IMMEDIATELY]

### DIFF
--- a/src/gcp/components/zitadel-monitoring.ts
+++ b/src/gcp/components/zitadel-monitoring.ts
@@ -128,10 +128,19 @@ export class ZitadelMonitoringComponent extends pulumi.ComponentResource {
 								},
 							],
 							comparison: 'COMPARISON_GT',
-							// `unit:"ms"` per the OTEL histogram descriptor →
-							// 10 s = 10000 ms. Healthy steady state is ~200 ms,
-							// so 10 s is 50× the high-water mark (design D3).
-							thresholdValue: 10000,
+							// SMOKE TEST: threshold temporarily lowered to
+							// 100 ms (from 10000 ms = 10 s) to exercise the
+							// full notification path end-to-end. Healthy
+							// steady-state p99 is ~200 ms, so this fires
+							// within ~60 s of deploy and the Slack /
+							// Google Chat notification path is verified.
+							// **Revert in a follow-up PR immediately after
+							// notification is confirmed received.**
+							// Tracked-in: openspec change
+							// `zitadel-observability` §1.13 (deferred
+							// smoke-test, post-archive 2026-05-03).
+							// `unit:"ms"` per the OTEL histogram descriptor.
+							thresholdValue: 100, // SMOKE TEST — revert to 10000
 							duration: '60s',
 							trigger: { count: 1 },
 						},


### PR DESCRIPTION
## ⚠️ Smoke-test PR — temporary, revert immediately after

This PR lowers the `alert-zitadel-oidc-latency-p99` threshold from **10000 ms** (10 s, prod-shaped) to **100 ms** so the alert fires on steady-state traffic (Zitadel OIDCService p99 is ~200 ms in dev). The goal is to end-to-end exercise the notification path through Slack + Google Chat.

## Sequence

1. **Merge this PR** (during business hours; on-call should be aware that one false-positive alert will fire).
2. Pulumi Cloud auto-deploys the AlertPolicy update.
3. Within ~60 s of deploy (one alignment window), the alert transitions `OK → OPEN` and a notification fires to the `alertBackend` channels (Slack + Google Chat).
4. Confirm receipt in both channels — screenshot or message ID is enough.
5. **Open immediate follow-up PR** reverting `thresholdValue: 100` → `10000`.
6. Confirm the alert auto-closes after the threshold is restored (within another ~60 s alignment window).

## Pulumi preview

```
~ gcp:monitoring:AlertPolicy alert-zitadel-oidc-latency-p99   thresholdValue: 10000 => 100
~ gcp:monitoring:Dashboard   dashboard-zitadel-observability  (pre-existing dashboardJson drift, unrelated)

Resources:
    ~ 2 to update
    231 unchanged
```

## Why now

This satisfies **§1.13** of the archived [`zitadel-observability`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-03-zitadel-observability) openspec change. §1.13 was kept on the deferred list at archive time precisely because it requires firing a real notification, which is best done with deliberate operator attention. Same session as §2.9 verification (PR #233) and §3.1 upstream-issue search.

## Test plan

- [x] `make lint-ts` green.
- [x] `pulumi preview --stack dev` — clean diff: `~ thresholdValue: 10000 => 100`, no other AlertPolicy fields touched.
- [ ] CI green.
- [ ] Post-merge: alert fires in Slack + Google Chat within ~60 s.
- [ ] Follow-up revert PR restores `thresholdValue: 10000`.
- [ ] Alert auto-closes after revert.

## DO NOT merge if

- An actual incident is in flight on the dev Zitadel — the smoke-test alert will mask real signal.
- On-call is unaware — coordinate first.
