### PR TITLE
fix(gke): enable WORKLOADS logging so log-based alerts can fire

### DIFF
--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -439,11 +439,7 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 					// `alert-atlas-migration-failure`, `alert-backend-jwt-zitadel-errors`)
 					// can actually fire — they read from Cloud Logging, which
 					// only ingests workload pod stdout when this component is
-					// enabled. The cluster was originally provisioned with
-					// `SYSTEM_COMPONENTS` only; this silently disabled every
-					// log-based alert until the gap was discovered while
-					// validating §1.13 of the archived `zitadel-observability`
-					// change. See openspec change `enable-gke-workload-logs`.
+					// enabled.
 					//
 					// Monitoring: stays system-only. We have no metric-based
 					// workload alerts today, so enabling GMP / workload

--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -434,10 +434,24 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 						channel: 'CHANNEL_STANDARD',
 					},
 
-					// Restrict logging/monitoring to system components; disable GMP (dev has
-					// no metric-based alerts — all alerts are log-based).
+					// Logging: include `WORKLOADS` so log-based AlertPolicies
+					// (e.g., `alert-error-log-server`, `alert-poison-queue-message`,
+					// `alert-atlas-migration-failure`, `alert-backend-jwt-zitadel-errors`)
+					// can actually fire — they read from Cloud Logging, which
+					// only ingests workload pod stdout when this component is
+					// enabled. The cluster was originally provisioned with
+					// `SYSTEM_COMPONENTS` only; this silently disabled every
+					// log-based alert until the gap was discovered while
+					// validating §1.13 of the archived `zitadel-observability`
+					// change. See openspec change `enable-gke-workload-logs`.
+					//
+					// Monitoring: stays system-only. We have no metric-based
+					// workload alerts today, so enabling GMP / workload
+					// monitoring would add Cloud Monitoring cost without a
+					// current consumer. Revisit if a metric-based alert is
+					// added to the project.
 					loggingConfig: {
-						enableComponents: ['SYSTEM_COMPONENTS'],
+						enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS'],
 					},
 					monitoringConfig: {
 						enableComponents: ['SYSTEM_COMPONENTS'],


### PR DESCRIPTION
## Summary

The dev GKE cluster (`standard-cluster-osaka`) has been silently dropping every workload pod's stdout for as long as it has existed. `loggingConfig.enableComponents` was set to `['SYSTEM_COMPONENTS']` only — `WORKLOADS` was never included. Cloud Logging therefore only sees `kube-system` entries; `backend`, `zitadel`, `otel-collector`, etc. produce stdout that `kubectl logs` can read live but that **never reaches Cloud Logging**.

**Every log-based AlertPolicy in the project has been silently non-functional**:

| AlertPolicy | Reads from |
|---|---|
| `alert-error-log-server` | backend/server ERROR logs |
| `alert-error-log-consumer` | backend/consumer ERROR logs |
| `alert-error-log-concert-discovery` | backend/concert-discovery ERROR logs |
| `alert-poison-queue-message` | backend/consumer poison-queue logs |
| `alert-atlas-migration-failure` | atlas-operator/manager logs |
| `alert-backend-jwt-zitadel-errors` | backend/server JWT validation ERROR logs (added in `zitadel-observability` PR-1b) |

Discovered while validating **§1.13** (smoke-test the latency alert) of the archived [`zitadel-observability`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-03-zitadel-observability) openspec change. A synthetic ERROR pod's stdout was visible via `kubectl logs` but never appeared in Cloud Logging, and `gcloud container clusters describe ... --format='value(loggingConfig.componentConfig.enableComponents)'` returned `SYSTEM_COMPONENTS` — confirming the gap is at the cluster's logging-collection scope, not a per-pod filter.

## Change

Single-line edit to [`src/gcp/components/kubernetes.ts`](src/gcp/components/kubernetes.ts#L439): add `'WORKLOADS'` to `loggingConfig.enableComponents`. Comment rewritten to explain *why* logging differs from monitoring (logging is the input to alerts; monitoring has no consumer in dev today).

```diff
- // Restrict logging/monitoring to system components; disable GMP (dev has
- // no metric-based alerts — all alerts are log-based).
+ // Logging: include `WORKLOADS` so log-based AlertPolicies
+ // ...
+ // can actually fire — they read from Cloud Logging, which
+ // only ingests workload pod stdout when this component is
+ // enabled. ...
+ //
+ // Monitoring: stays system-only. We have no metric-based
+ // workload alerts today, so enabling GMP / workload
+ // monitoring would add Cloud Monitoring cost without a
+ // current consumer. ...
  loggingConfig: {
-     enableComponents: ['SYSTEM_COMPONENTS'],
+     enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS'],
  },
  monitoringConfig: {
      enableComponents: ['SYSTEM_COMPONENTS'],
      managedPrometheus: { enabled: false },
  },
```

GKE applies the update **in-place** — no node-pool recreation, no workload pod restart, no service interruption. The managed logging agent is re-rolled by GCP, typically within 15 min of cluster config update.

## Pulumi preview

```
~ gcp:container/cluster:Cluster (update)
    ~ loggingConfig:
        ~ enableComponents: [
            + [1]: "WORKLOADS"
        ]
~ gcp:monitoring/dashboard:Dashboard (update)   # unrelated pre-existing cosmetic drift
    ~ dashboardJson: etag + GCP server-defaulted xPos/yPos defaults

Resources: ~ 2 to update / 231 unchanged
```

## Cost impact

Workload log ingestion is ~$0.50/GiB. Dev traffic is low — projected **< 1 GiB/month** in steady-state. The existing `gcp-cost-guardrails` billing budget (50/90/100% of ¥3,000/month for dev) will surface any unexpected spike.

## Heads-up: alert backlog

After this lands and the logging agent rolls out, **legacy log-based alerts will start firing on real workload ERROR conditions** that have been silently accumulating. Expect a small initial burst as the backlog clears. Each AlertPolicy has a `documentation.content` block with triage steps; review and act accordingly.

## Test plan

- [x] `make check` (biome + tsc + 40 vitest tests) — green.
- [x] `pulumi preview --stack dev` — clean diff: one cluster `loggingConfig` update, no destructive ops, no unrelated infra changes.
- [ ] CI green.
- [ ] Post-merge: Pulumi Cloud auto-applies. Confirm via:
  ```bash
  gcloud container clusters describe standard-cluster-osaka --zone=asia-northeast2-a \
    --project=liverty-music-dev \
    --format='value(loggingConfig.componentConfig.enableComponents)'
  # Expected: SYSTEM_COMPONENTS;WORKLOADS
  ```
- [ ] Within 15 min post-deploy: workload logs flowing —
  ```bash
  gcloud logging read 'resource.type="k8s_container" AND resource.labels.namespace_name="backend"' \
    --project=liverty-music-dev --freshness=15m --limit=5
  ```
- [ ] Re-run `zitadel-observability` §1.13 smoke-test (synthetic ERROR pod + lowered JWT alert threshold). Confirm Slack + Google Chat receive the notification. Revert threshold.

## Related

- openspec change [`enable-gke-workload-logs`](https://github.com/liverty-music/specification/tree/enable-gke-workload-logs/openspec/changes/enable-gke-workload-logs) (this PR's spec source)
- archived [`zitadel-observability`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-03-zitadel-observability) §1.13 — blocked on this change
- `gke-standard-infrastructure` capability — spec delta included in the openspec change
