### PR TITLE
fix(monitoring): correct cluster_name + location in log-based alert filters

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -303,8 +303,13 @@ export class Gcp {
 				googleChatSpaceIds: googleChatSpaces
 					? [googleChatSpaces.alertBackend]
 					: undefined,
-				clusterLocation: Regions.Osaka,
-				clusterName: `cluster-${RegionNames.Osaka}`,
+				// `resource.labels.location` on `k8s_container` log entries
+				// is the zone (`asia-northeast2-a`), not the region. The
+				// alert filter must use the zonal form to match real logs.
+				clusterLocation: `${Regions.Osaka}-a`,
+				// Cluster is created as `standard-cluster-${regionName}` in
+				// `kubernetes.ts`; the filter must reference the exact name.
+				clusterName: `standard-cluster-${RegionNames.Osaka}`,
 			})
 
 			// Zitadel observability: latency p99 alert + JWT error rate


### PR DESCRIPTION
## Summary

While verifying §2.4 of openspec change [`enable-gke-workload-logs`](https://github.com/liverty-music/specification/tree/enable-gke-workload-logs/openspec/changes/enable-gke-workload-logs), discovered that the legacy `MonitoringComponent` log-based alerts (`alert-error-log-server` + 4 others) **still do not fire** after #235 enabled workload log collection. Root cause: two filter clauses in the alert definitions reference values that do not match the actual GKE log entries.

This is a second-layer bug that was silent because the first-layer bug (workload logs not collected) prevented any log from ever reaching the filter for evaluation. #235 lifted the first layer; this PR lifts the second.

## Empirical evidence

§2.3 of `enable-gke-workload-logs` ran a synthetic ERROR pod in `backend` namespace with `app=server` label. The JWT alert (`alert-backend-jwt-zitadel-errors`, conditionThreshold) fired and delivered an OPEN + auto-close pair to Google Chat — verified by screenshot. But the same pod's log entries also satisfy `alert-error-log-server`'s filter (conditionMatchedLog), and that alert did **not** appear in the same channel.

Verified label mismatch directly:

```bash
$ gcloud logging read 'resource.type="k8s_container" AND resource.labels.namespace_name="backend"' \
    --project=liverty-music-dev --freshness=10m --limit=1 \
    --format='value(resource.labels.location,resource.labels.cluster_name)'

asia-northeast2-a    standard-cluster-osaka
```

vs. the filter (`monitoring.ts:117-119` via `index.ts:306-307`):

```
resource.labels.location="asia-northeast2"          # ← region, but real label is the zone
resource.labels.cluster_name="cluster-osaka"        # ← but real name is "standard-cluster-osaka"
```

Both clauses reject every real log entry → filter has matched zero entries since the alerts were first deployed.

## Fix

Two-line edit to [`src/gcp/index.ts:306-307`](src/gcp/index.ts#L306-L307):

```diff
- clusterLocation: Regions.Osaka,
- clusterName: `cluster-${RegionNames.Osaka}`,
+ clusterLocation: `${Regions.Osaka}-a`,                    // zone, not region
+ clusterName: `standard-cluster-${RegionNames.Osaka}`,    // matches Pulumi resource name in kubernetes.ts:407
```

Comments added to both lines so future readers see why these are zone-form and prefixed.

`MonitoringComponent` internals are unchanged — it already interpolates these values into the filter strings; only the caller-side inputs needed correction.

## Pulumi preview

```
~ gcp:liverty-music:MonitoringComponent monitoring                update [diff: ~clusterLocation,clusterName]
~ gcp:monitoring:AlertPolicy alert-atlas-migration-failure        update [diff: ~conditions]
~ gcp:monitoring:AlertPolicy alert-error-log-server               update [diff: ~conditions]
~ gcp:monitoring:AlertPolicy alert-error-log-consumer             update [diff: ~conditions]
~ gcp:monitoring:AlertPolicy alert-poison-queue-message           update [diff: ~conditions]
~ gcp:monitoring:AlertPolicy alert-error-log-concert-discovery    update [diff: ~conditions]
~ gcp:monitoring:Dashboard dashboard-zitadel-observability        update [diff: ~dashboardJson]   # unrelated pre-existing cosmetic drift

Resources: ~ 7 to update / 226 unchanged
```

## Test plan

- [x] `make lint-ts` (biome + tsc) — green.
- [x] `pulumi preview --stack dev` — clean 7-update diff, no destructive ops.
- [ ] CI green.
- [ ] Post-merge: re-run §2.4 smoke-test (a single synthetic ERROR log in `backend/server`). Expect `alert-error-log-server` to fire and deliver a Google Chat notification within ~1 min.

## Heads-up: more alert backlog

Same as the #235 note: now that **all** legacy log-based alerts can finally evaluate real workload logs (filter + ingestion both correct for the first time), expect any backlog of pre-existing real ERROR conditions to surface as initial pages once the change deploys.

## Related

- #235 (lifted the ingestion side)
- openspec change [`enable-gke-workload-logs`](https://github.com/liverty-music/specification/tree/enable-gke-workload-logs/openspec/changes/enable-gke-workload-logs) (this PR's parent change; §2.4 verification)
