### PR TITLE
feat(infra): provision prod GCP resources (cluster, KMS, DNS)

### DIFF
--- a/docs/DEV_VS_PROD_DIFFERENCES.md
+++ b/docs/DEV_VS_PROD_DIFFERENCES.md
@@ -1,0 +1,79 @@
+# Dev vs Prod Differences
+
+Developer-facing reference comparing every meaningful configuration
+difference between the `liverty-music-dev` and `liverty-music-prod`
+environments. Use this when reasoning about behavior gaps between
+the two stacks.
+
+Rationale and reversibility classification for each difference live in
+[PROD_BOOTSTRAP_DECISIONS.md](./PROD_BOOTSTRAP_DECISIONS.md). The
+"Irreversible vs reversible cluster settings" reference table is in
+[GKE_CLUSTER_MODE_DECISION.md](./GKE_CLUSTER_MODE_DECISION.md).
+
+Last updated: 2026-05-11.
+
+## Comparison table
+
+| Setting | dev | prod | Trigger to flip | Reversible? |
+|---|---|---|---|---|
+| **GKE cluster mode** | Standard | Standard | A new OpenSpec change | ❌ Requires new cluster + workload migration |
+| **GKE topology** | Zonal (`asia-northeast2-a`) | Regional (`asia-northeast2`) | n/a | ❌ Irreversible |
+| **Dataplane** | LEGACY_DATAPATH (kube-proxy / iptables) | ADVANCED_DATAPATH (Dataplane V2 / eBPF) | n/a | ❌ Irreversible (must set at creation) |
+| **etcd Application-layer Secrets Encryption (CMEK)** | Off (Google default at-rest only) | On — Cloud KMS key `gke-etcd-encryption` | SOC2 / audit gate | ❌ Irreversible at cluster creation |
+| **GKE deletion protection** | Off (`deletionProtection: false`) | On (`deletionProtection: true`) | Manual override only | ✅ Mutable (Pulumi config) |
+| **Spot node pool min/max** | 1 / 3 nodes | 1 / 3 nodes | Workload count growth | ✅ Mutable (Pulumi config) |
+| **Spot node machine type** | `e2-medium` | `e2-medium` | Workload sizing pressure | ✅ Replaceable (new node pool) |
+| **Boot disk** | 30 GB `pd-standard` | 30 GB `pd-standard` | Image cache pressure / latency | ✅ Replaceable (new node pool) |
+| **Boot disk CMEK** | Default Google encryption | Default Google encryption | Compliance gate | ✅ Replaceable (new node pool with CMEK) |
+| **Node privacy** | `enablePrivateNodes: false` (public IPs) | `enablePrivateNodes: false` (public IPs) | First real users on prod | ✅ Mutable post-creation |
+| **Cloud NAT** | Not provisioned | Not provisioned | When prod flips to private nodes | ✅ Add VPC-level resource |
+| **Confidential GKE Nodes** | Off | Off | Blockchain mainnet GA → add dedicated signing node pool | ✅ Per-pool addition; cluster-level enable is ❌ irreversible |
+| **Google Managed Prometheus (GMP)** | Disabled | Disabled | First real users on prod | ✅ Mutable |
+| **Logging components** | `SYSTEM_COMPONENTS` + `WORKLOADS` | `SYSTEM_COMPONENTS` + `WORKLOADS` | n/a | ✅ Mutable |
+| **Monitoring components** | `SYSTEM_COMPONENTS` only | `SYSTEM_COMPONENTS` only | Metric-based alerts need GMP first | ✅ Mutable |
+| **kube-dns autoscaler override** | `preventSinglePointFailure: false` (replicas 1) | GKE default (replicas 2) | n/a | ✅ Mutable (k8s ConfigMap) |
+| **Cloud SQL instance tier** | `db-f1-micro` | `db-f1-micro` | First real traffic on prod | ✅ Mutable (in-place tier upgrade with brief downtime) |
+| **Cloud SQL availability** | ZONAL | REGIONAL | n/a | ❌ Set at instance creation (different prod instance) |
+| **Cloud SQL deletionProtection** | Off | On | n/a | ✅ Mutable |
+| **Cloud SQL databases** | `liverty_music` + `zitadel` (when Zitadel SA provided) | `liverty_music` only (Zitadel deferred to follow-up change) | Zitadel-for-prod change | ✅ Add database resource |
+| **Self-hosted Zitadel** | Provisioned via Pulumi (`src/index.ts:73` gate) | Not provisioned (env guard) | Future `self-hosted-zitadel-prod` follow-up change | ⚠️ Code gate, requires Pulumi change |
+| **Domain authority for `liverty-music.app` apex** | Cloudflare manages `liverty-music.app`; `dev.liverty-music.app` delegated to Cloud DNS via NS | Cloudflare retains apex authoritative; `api.` + `auth.` subdomains delegated to Cloud DNS via per-subdomain NS records | n/a | ✅ Mutable (Cloudflare API) |
+| **Cloud DNS zone count** | 1 zone (`dev.liverty-music.app`) | 2 zones (`api.liverty-music.app`, `auth.liverty-music.app`) | n/a | ❌ Zone names fixed at creation; new zone needs new NS delegation |
+| **Certificate Manager hostnames** | `dev.liverty-music.app`, `api.dev.liverty-music.app`, `auth.dev.liverty-music.app` | `api.liverty-music.app`, `auth.liverty-music.app` (no apex cert — Cloudflare serves apex) | n/a | ❌ Certificate `domains` field is immutable; replace requires new cert |
+| **API Gateway static IP** | One shared global IP for all dev hostnames | One shared global IP for all prod hostnames | n/a | ✅ Mutable, but Gateway listener pins to it |
+| **ArgoCD Applications set** | Full set (argocd / core / external-secrets / reloader / atlas-operator / nats / keda / otel-collector / image-updater / backend / backend-migrations / frontend / gateway / zitadel) | Same full set (parity per resolved Q4 in proposal) | n/a | ✅ Mutable (add or remove yaml files in `argocd-apps/prod/`) |
+| **Pulumi deploy trigger** | Auto-deploy on merge to `main` (Pulumi Cloud) | Manual trigger only via Pulumi Cloud console | Per `deployment-infrastructure` spec | ⚠️ Stack-level policy, deliberate |
+| **GCP cost guardrails** | Billing budget alert, Places API per-day quota override, Vertex AI per-minute quota override (all dev-only per `gcp-cost-guardrails` spec) | None (avoids over-throttling real prod traffic) | n/a | ✅ Mutable (Pulumi resources) |
+| **Places API enablement** | `places.googleapis.com` enabled (used by venue enrichment with the dev quota override gate) | API NOT enabled (env-gated in `kubernetes.ts`) | If prod ever needs venue enrichment | ✅ Mutable (add to API enable list) |
+| **Vertex AI / aiplatform.googleapis.com** | Enabled (per `project.ts:112`, unconditional) — used by concert-discovery CronJob with a dev-only per-minute quota override | Enabled (same unconditional API enablement) — no quota override, so workloads in prod are throttled only by the default GCP per-region quotas | n/a — API stays enabled both sides; behavior difference is the quota override only | ✅ Mutable |
+| **GitHub Organization-level config** | Skipped (`if (env === 'prod')` gate in `src/index.ts:52`) | Provisioned (org-level GitHub Actions secrets, Buf token, etc.) | n/a | ⚠️ Code gate, deliberate |
+| **Cloudflare branch protection (GitHub repos)** | Not applied | Applied (`if (environment === 'prod')` in `src/github/components/repository.ts`) | n/a | ⚠️ Code gate, deliberate |
+
+## Per-namespace Kustomize overlay status
+
+The following table records which Kubernetes namespaces under
+`k8s/namespaces/<ns>/overlays/` have a dedicated `prod/` overlay.
+Where the base manifest is sufficient for prod, no overlay is needed.
+
+| Namespace | dev overlay | prod overlay | Notes |
+|---|---|---|---|
+| `argocd` | ✅ | ✅ (pre-existing) | Used by ArgoCD self-management |
+| `external-secrets` | ✅ | (audit pending) | Helm-chart based; check helm values per env |
+| `reloader` | ✅ | (audit pending) | Single-file overlay; likely env-trivial |
+| `atlas-operator` | ✅ | (audit pending) | Helm-based |
+| `nats` | ✅ | (audit pending) | StatefulSet; replica counts may differ |
+| `keda` | ✅ | (audit pending) | Helm-based |
+| `otel-collector` | ✅ | (audit pending) | OTLP exporter endpoint may differ |
+| `backend` | ✅ | (audit pending) | Hostnames + ConfigMap values change for prod |
+| `frontend` | ✅ | (audit pending) | Hostname changes |
+| `zitadel` | ✅ | (deferred) | Awaits Zitadel-for-prod follow-up change |
+| `gateway` | ✅ | (audit pending) | HTTPRoute hostnames change |
+
+This table is updated by the `provision-prod-gcp-resources` OpenSpec
+change as overlays are authored.
+
+## See also
+
+- [PROD_BOOTSTRAP_DECISIONS.md](./PROD_BOOTSTRAP_DECISIONS.md) — why each decision was made, with future-revisit triggers
+- [GKE_CLUSTER_MODE_DECISION.md](./GKE_CLUSTER_MODE_DECISION.md) — Standard vs Autopilot analysis and irreversibility reference
+- OpenSpec change `provision-prod-gcp-resources` in `liverty-music/specification` — the change that established this layout

--- a/docs/DEV_VS_PROD_DIFFERENCES.md
+++ b/docs/DEV_VS_PROD_DIFFERENCES.md
@@ -35,8 +35,9 @@ Last updated: 2026-05-11.
 | **Cloud SQL instance tier** | `db-f1-micro` | `db-f1-micro` | First real traffic on prod | ✅ Mutable (in-place tier upgrade with brief downtime) |
 | **Cloud SQL availability** | ZONAL | REGIONAL | n/a | ❌ Set at instance creation (different prod instance) |
 | **Cloud SQL deletionProtection** | Off | On | n/a | ✅ Mutable |
-| **Cloud SQL databases** | `liverty_music` + `zitadel` (when Zitadel SA provided) | `liverty_music` only (Zitadel deferred to follow-up change) | Zitadel-for-prod change | ✅ Add database resource |
-| **Self-hosted Zitadel** | Provisioned via Pulumi (`src/index.ts:73` gate) | Not provisioned (env guard) | Future `self-hosted-zitadel-prod` follow-up change | ⚠️ Code gate, requires Pulumi change |
+| **Cloud SQL databases** | `liverty_music` + `zitadel` | `liverty_music` + `zitadel` (infra provisioned, workload deferred) | n/a | ✅ Add database resource |
+| **Zitadel infrastructure** (GCP SA, DB, IAM, cert, DNS for `auth.<host>`) | Provisioned via Pulumi | Provisioned via Pulumi (same as dev) — idle until the workload is deployed | n/a | n/a — already provisioned |
+| **Self-hosted Zitadel workload** (Pulumi-managed Zitadel application + machine key + login PAT) | Provisioned via Pulumi (`src/index.ts:73` gate; depends on `zitadelMachineKey` / `zitadelLoginPat` ESC values) | Not deployed — ESC values are not set for prod, so the gate evaluates false | Future `self-hosted-zitadel-prod` follow-up change provides the ESC values and removes the implicit gate | ⚠️ Requires ESC config + Pulumi change |
 | **Domain authority for `liverty-music.app` apex** | Cloudflare manages `liverty-music.app`; `dev.liverty-music.app` delegated to Cloud DNS via NS | Cloudflare retains apex authoritative; `api.` + `auth.` subdomains delegated to Cloud DNS via per-subdomain NS records | n/a | ✅ Mutable (Cloudflare API) |
 | **Cloud DNS zone count** | 1 zone (`dev.liverty-music.app`) | 2 zones (`api.liverty-music.app`, `auth.liverty-music.app`) | n/a | ❌ Zone names fixed at creation; new zone needs new NS delegation |
 | **Certificate Manager hostnames** | `dev.liverty-music.app`, `api.dev.liverty-music.app`, `auth.dev.liverty-music.app` | `api.liverty-music.app`, `auth.liverty-music.app` (no apex cert — Cloudflare serves apex) | n/a | ❌ Certificate `domains` field is immutable; replace requires new cert |

--- a/docs/GKE_CLUSTER_MODE_DECISION.md
+++ b/docs/GKE_CLUSTER_MODE_DECISION.md
@@ -1,0 +1,143 @@
+# GKE Cluster Mode Decision (Autopilot vs Standard)
+
+Reference document for choosing between GKE Autopilot and Standard for each
+environment in Liverty Music. Captures the reasoning so future contributors
+don't need to re-derive it.
+
+Last verified against GCP docs: 2026-05-11.
+
+## TL;DR
+
+| Environment | Mode | Topology | Nodes | NAT |
+|---|---|---|---|---|
+| `dev` | Standard | Zonal (`asia-northeast2-a`) | Public, Spot e2-medium | None |
+| `staging` | Autopilot | Regional | Private | Cloud NAT |
+| `prod` | **Autopilot** | Regional | Private | Cloud NAT |
+
+`dev` is deliberately the outlier: it trades availability and security for cost.
+
+## Pricing facts (verified May 2026)
+
+Source: <https://cloud.google.com/kubernetes-engine/pricing>
+
+1. **Cluster management fee = $0.10/hour for every cluster**, irrespective of
+   mode (Autopilot or Standard), topology (zonal or regional), or size. Quote:
+   > "A flat cluster management fee of $0.10 per cluster per hour ... applies
+   > to all GKE clusters irrespective of the mode of operation, cluster size,
+   > or topology."
+
+2. **GKE free tier = $74.40 monthly credit per billing account**, applied to
+   "zonal Standard or Autopilot clusters". Regional Standard clusters are
+   **not** covered.
+
+3. **Compute billing differs by mode**:
+   - **Autopilot**: pay only for Pod resource requests (CPU / memory / Spot /
+     accelerator class).
+   - **Standard**: pay for node VMs, regardless of how full the Pods pack
+     them.
+
+4. **Cost claim by Google** (blog, May 2026): Autopilot can save up to 85%
+   TCO vs traditional managed Kubernetes; benchmarks of ~12% and ~42%
+   savings on real workloads. Per-unit price is higher than VM pricing, but
+   you stop paying for unused node headroom and the OS overhead.
+
+## Why dev uses Standard
+
+Standard mode is a **deliberate exception** for dev only, justified by:
+
+- Spot e2-medium nodes (~70% cheaper than on-demand). Autopilot supports Spot
+  but with less node-pool granularity.
+- 30 GB `pd-standard` boot disks (default is 100 GB `pd-balanced`).
+- kube-dns autoscaler override (drop replicas 2 → 1) to free CPU for the
+  cluster autoscaler to retire the 3rd node.
+- GMP disabled (dev has no metric-based alerts).
+- Public nodes (no Cloud NAT, saves ~¥5,292/month).
+- Zonal (free-tier credit applies to either Autopilot or zonal Standard, so
+  this part is **mode-neutral**; the choice was driven by Compute Engine
+  control, not the management fee).
+
+**Tradeoff**: dev is single-zone and has public node IPs. Both are
+unacceptable for prod.
+
+## Why staging and prod use Autopilot
+
+Google's explicit guidance, from
+<https://cloud.google.com/kubernetes-engine/docs/concepts/choose-cluster-mode>:
+
+> "Use Autopilot for most workloads, unless your application requires
+> privileges or configuration options that don't meet the Autopilot
+> constraints."
+>
+> "Autopilot ... Ideal for most production workloads."
+
+Specific reasons for Liverty Music prod:
+
+1. **Workload fit**: Zitadel, backend API, frontend, ArgoCD, ESO, Reloader
+   are all general-purpose HPA-driven services. No DaemonSets requiring host
+   privileges, no GPU/accelerator demand, no CPU pinning needs.
+2. **Operational savings**: small team. Node pool sizing, autoscaler tuning,
+   GKE version upgrades, disk type/size decisions are non-revenue work.
+3. **No management-fee arbitrage**: prod is regional → does not qualify for
+   the free tier in either mode. Both modes pay $74.40/month on the
+   management fee.
+4. **Bin-packing**: prod needs HA headroom on Standard nodes (~30-50% idle
+   capacity reserve). Autopilot's per-Pod billing eliminates that waste.
+5. **Hybrid escape hatch**: as of Sept 2025, per-workload Autopilot ComputeClasses
+   work inside Standard clusters and vice versa, so the decision is not
+   one-way. See
+   <https://cloud.google.com/blog/products/containers-kubernetes/gke-gets-new-pricing-and-capabilities-on-10th-birthday>.
+
+## When to revisit (prod)
+
+Switch prod from Autopilot → Standard if **and only if** one of these is
+true:
+
+1. Need Spot in prod (cost-driven HA trade — not typical for prod).
+2. Need DaemonSets requiring host privileges (e.g., custom CNI, node-local
+   cache).
+3. Need bare-metal performance tuning (CPU pinning, hugepages, NUMA).
+4. Locked into a specific feature Autopilot doesn't support — see
+   <https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison>.
+
+## Irreversible vs reversible cluster settings
+
+This shapes the prod provisioning order. Verified against
+<https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters>
+and the network-isolation concepts page.
+
+### Immutable after creation — must be right on day 1
+
+- Cluster availability type (zonal vs regional)
+- Region location
+- Network and subnet assignment
+- Network routing mode (VPC-native vs routes-based)
+- Pod and Service secondary IP ranges
+- Node service account
+
+### Mutable after creation — can be deferred or changed later
+
+- `enablePrivateNodes` (public ↔ private node toggle). Per GKE
+  network-isolation docs: *"You can change these settings at any time."*
+- `enablePrivateEndpoint` (private vs public control plane endpoint)
+- Master authorized networks
+- Cloud NAT (this is a VPC-level resource, not a cluster setting; add or
+  remove any time)
+- Release channel
+- Logging / monitoring components
+- Add-on toggles
+- Node pool size, machine type, disk size (create new pool, drain old)
+- HPA settings, Pod resource requests
+
+### Implication for prod provisioning order
+
+Pick zonal-vs-regional, region, VPC/subnet, secondary ranges, routing
+mode, and node SA **first** — these are forever. Layer security (private
+nodes, NAT, authorized networks) and right-sizing on top — those can be
+tuned over time.
+
+## See also
+
+- <https://cloud.google.com/kubernetes-engine/pricing>
+- <https://cloud.google.com/kubernetes-engine/docs/concepts/choose-cluster-mode>
+- <https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison>
+- <https://cloud.google.com/blog/products/containers-kubernetes/how-gke-autopilot-saves-on-kubernetes-costs>

--- a/docs/PROD_BOOTSTRAP_DECISIONS.md
+++ b/docs/PROD_BOOTSTRAP_DECISIONS.md
@@ -1,0 +1,251 @@
+# prod Cluster Bootstrap Decisions
+
+Records the decisions made when designing the `liverty-music-prod` GKE cluster
+and surrounding infrastructure. Captured so future contributors and security
+auditors can trace the rationale.
+
+Last updated: 2026-05-11.
+
+Companion documents:
+- [GKE_CLUSTER_MODE_DECISION.md](./GKE_CLUSTER_MODE_DECISION.md) — mode choice details, irreversible-vs-reversible reference table.
+- [DEV_VS_PROD_DIFFERENCES.md](./DEV_VS_PROD_DIFFERENCES.md) — operator-facing comparison table of every config difference between dev and prod.
+- [runbooks/prod-cluster-credentials.md](./runbooks/prod-cluster-credentials.md) — how to fetch kubectl credentials for the prod cluster.
+
+## Context
+
+- prod has **no users yet** (not yet in service). No SLO obligation in this
+  phase.
+- Cost is the dominant axis. Availability and security baseline can grow over
+  time, but choices that are *irreversible* must be made now.
+- Environments are separated at the **GCP project level**
+  (`liverty-music-prod` vs `liverty-music-dev`), so VPC / subnet / CIDR can be
+  identical without conflict.
+- Workload composition matches dev: backend, frontend, Zitadel, ArgoCD, ESO,
+  Reloader, Atlas Operator, OTel Collector, NATS, KEDA, Image Updater.
+- Blockchain ticket-purchase functionality is planned. Its phase determines
+  when external security audit becomes mandatory (see Audit Timing below).
+
+## Decision Summary
+
+| Decision | Value | Reversibility |
+|---|---|---|
+| Cluster mode | Standard | Irreversible (re-create + migrate workloads) |
+| Cluster topology | Regional (`asia-northeast2`) | Irreversible |
+| Network mode | VPC-native (default) | Irreversible |
+| Dataplane V2 | ✅ Enabled (`datapathProvider: 'ADVANCED_DATAPATH'`) | Irreversible |
+| etcd / Application-layer Secrets CMEK | ✅ Enabled | Irreversible at cluster level |
+| `enablePrivateNodes` | `false` (public nodes, no Cloud NAT) | Mutable — flip later |
+| Cloud NAT | Not provisioned | Mutable — add later |
+| Node pool: machine type | e2-medium Spot (same as dev) | Replaceable (new pool) |
+| Node pool: max nodes | 3 (same as dev initially) | Mutable — config value |
+| Boot disk | 30 GB pd-standard | Replaceable (new pool) |
+| Boot disk CMEK | ❌ Default Google encryption | Per-pool replaceable |
+| Cluster-level Confidential GKE Nodes | ❌ Skip | Irreversible (set if "yes") |
+| Node-pool Confidential Nodes | ❌ Skip initially, add for blockchain signing pool | Pool-level — add later OK |
+| HSM-protected KMS keys | ❌ Defer to blockchain mainnet phase | Add per-key later |
+| GMP / managedPrometheus | Disabled (same as dev) | Mutable |
+| Logging components | `SYSTEM_COMPONENTS` + `WORKLOADS` | Mutable |
+| Service IP secondary range | `10.30.0.0/20` (4,096 services, same as dev) | **Irreversible — cannot expand** |
+| Pod IP secondary range | `10.20.0.0/16` (256 nodes max) | Expandable (add more ranges) but not shrinkable |
+| Primary subnet range | `10.10.0.0/20` | Expandable, not shrinkable |
+| Master IPv4 CIDR | `172.16.0.0/28` | Irreversible |
+| Node service account | `gke-node` (per project) | Irreversible |
+
+## Decisions in Detail
+
+### 1. Cluster mode: Standard (not Autopilot)
+
+**Why**: User-chosen for consistency with dev. Standard offers fine-grained
+node-pool control (Spot, machine type, disk type) that we exercised in dev to
+hit ~50% cost reduction. Same mental model across envs.
+
+**Trade-off**: Google's official recommendation is "Autopilot for most
+production workloads". Once prod has users and operational toil becomes
+expensive, revisit.
+
+**Reversibility**: NOT in-place mutable. Switching modes = create new cluster
++ workload migration. Per [Prepare to migrate to Autopilot from Standard](https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-migrate-cluster-mode):
+> "Neither direction supports in-place conversion."
+
+### 2. Topology: Regional (asia-northeast2)
+
+**Why**: Even without SLO, single-AZ failure recovery should not require
+manual intervention. Free-tier credit eligibility is identical for regional
+Standard vs zonal (in fact, regional Standard does **not** qualify for free
+tier; only zonal Standard and Autopilot do). Net additional cost:
+$0.10/hr × 24 × 30 = $72/month management fee (uncovered by free tier).
+
+**Trade-off**: ~¥10,800/month extra vs zonal. Accepted because the
+zonal → regional migration is irreversible.
+
+**Reversibility**: ❌ Cannot be changed after creation.
+
+### 3. Dataplane V2: Enabled
+
+**Why**: GCP announcement (received 2026-05): Dataplane V2 becomes default on
+2027-03-30. Enable now to align with future default and gain:
+- NetworkPolicy enforcement always-on
+- eBPF-based perf
+- Built-in network policy logging
+- New GKE features delivered Dataplane-V2-first
+
+**Cost**: None (no premium).
+
+**Reversibility**: ❌ Cannot be enabled or disabled after cluster creation.
+> "GKE Dataplane V2 can only be enabled when creating a new cluster.
+> Existing clusters cannot be upgraded to use GKE Dataplane V2."
+> — [GKE Dataplane V2 docs](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2)
+
+### 4. etcd / Application-layer Secrets CMEK: Enabled
+
+**Why**: Future SOC2 / blockchain security audit will almost certainly
+require encryption-at-rest with customer-controlled keys for Kubernetes
+Secret resources. Enabling later requires cluster-wide operation; cost is
+negligible ($0.06/month for one software key + ops within free tier).
+
+**What it encrypts**: Kubernetes Secret resources written to etcd (not
+control-plane disks themselves — those cannot be CMEK-protected).
+
+**What it does NOT encrypt**: Boot disks (separate setting), Persistent
+Volumes (StorageClass setting), in-memory secrets (Confidential Nodes
+needed).
+
+**Cost**:
+- Software key: $0.06 / key version / month
+- Symmetric encrypt/decrypt: $0.03 / 10k operations
+- 20,000 operations / month free tier per project
+- Estimated total: ~$0.20/month (¥30/month)
+
+**Reversibility**: Set at cluster creation. Can rotate to a new key, but
+enabling it on an existing cluster requires a cluster-wide re-encryption
+operation.
+
+**Implementation note**: Will need a new Cloud KMS keyring + key under the
+prod project. Configure via Pulumi `databaseEncryption` field on
+`gcp.container.Cluster`.
+
+### 5. enablePrivateNodes: false (public nodes), no Cloud NAT
+
+**Why**: Cost-first phase, no users. Mirrors dev — saves ~¥5,292/month on
+Cloud NAT fixed cost. Acceptable because **this setting is mutable**:
+> "You can change these settings at any time."
+> — [Network isolation docs](https://cloud.google.com/kubernetes-engine/docs/concepts/network-isolation)
+
+**Future revisit trigger**: First real users / external traffic.
+Flip `enablePrivateNodes` → `true` and add Cloud NAT in the same Pulumi
+update. Workloads continue running.
+
+### 6. Confidential GKE Nodes (cluster level): Skip
+
+**Why**:
+- Cluster-level enablement is **irreversible**.
+- Forces machine family from e2 → N2D / C3, raising node cost ~4-5x at the
+  smallest size before the Confidential premium itself.
+- Does NOT solve the blockchain-key-protection problem (a compromised
+  container can still read its own memory). KMS-based signing is the right
+  abstraction for that.
+- Node-pool-level Confidential Nodes can be added later as a dedicated
+  blockchain-signing node pool (taint-isolated).
+
+**Future revisit trigger**: Blockchain mainnet GA, or auditor explicitly
+requires it.
+
+### 7. CIDR ranges: same as dev
+
+**Why**: GCP project separation means VPCs are independent — no IP conflict.
+Mental model overhead minimized by sharing one `NetworkConfig.Osaka` constant
+([src/gcp/index.ts:39-50](../src/gcp/index.ts#L39-L50)).
+
+Current sizing supports up to 256 nodes (Pod range `/16`) and 4,096 services
+(`/20`). Well beyond expected prod scale for the foreseeable future.
+
+**Irreversibility focus**: The Service secondary range
+(`servicesCidr: 10.30.0.0/20`) **cannot be expanded or changed** after
+cluster creation. `/20` = 4,096 services is generous and accepted.
+
+The Pod range can be expanded by adding additional Pod IP ranges
+(discontiguous CIDR) if scale ever exceeds 256 nodes.
+
+### 8. Workload set: same as dev (GMP, Spot, etc.)
+
+**Why**: No users → no alerting need → GMP off, logging minimal.
+Spot VMs acceptable because preemption only affects internal dogfooding,
+not external SLO. Same `cloud.google.com/gke-spot: "true"` nodeSelector
+in workload manifests works unchanged.
+
+**Future revisit trigger**: Going live with users. At that point, expect to:
+- Enable GMP (`managedPrometheus.enabled: true`)
+- Add `WORKLOADS` log streaming (already on after [e72720f](https://github.com/liverty-music/cloud-provisioning/commit/e72720f))
+- Add a non-Spot node pool for latency-sensitive workloads, retain Spot for
+  background / batch.
+
+## Future Revisit Triggers
+
+| Trigger | Decisions to revisit |
+|---|---|
+| First real users on prod | `enablePrivateNodes`, Cloud NAT, GMP, non-Spot pool for critical workloads, replicas + HPA |
+| Blockchain testnet → mainnet beta | KMS-based key signing (move blockchain keys from Secret Manager → Cloud KMS sign API), SA split (deployer vs signer), audit logging review |
+| Blockchain mainnet GA | External infra security audit, smart contract audit (CertiK / OpenZeppelin / Halborn), Confidential Nodes on dedicated signing node pool, Cloud HSM keys |
+| SOC2 Type II consideration | Boot disk CMEK on new pools, formal key rotation policy, audit-trail completeness review |
+| Multi-region DR requirement | Second cluster (different region), Multi-Cluster Ingress / Global LB |
+
+## Audit Timing Guidance for Blockchain Feature
+
+| Blockchain phase | Audit posture |
+|---|---|
+| Internal testnet | None — no funds at risk |
+| Mainnet beta (limited users, transaction caps) | Internal security review. Move signing keys to Cloud KMS. SA split. Audit logging in place. |
+| Mainnet GA (open, no caps) | External infra audit + smart contract audit mandatory |
+| Enterprise customers / B2B | SOC2 Type II initiation |
+
+## Key Security Principle: Private Key Storage
+
+**Blockchain private keys (deployer, signer, treasury) must NOT live in
+container memory as plain environment variables.** Current state has them
+in GCP Secret Manager → flowed via ESO → Kubernetes Secret → env var, which
+exposes them in container memory and is the first thing an auditor will
+flag.
+
+The target pattern is:
+- Key material stored in Cloud KMS (asymmetric signing keys).
+- Application calls KMS `AsymmetricSign` API with the key resource name and
+  message digest.
+- Signature is returned; the private key never leaves KMS.
+- Workload Identity binds the signing K8s ServiceAccount to a dedicated GCP
+  SA with `roles/cloudkms.signer` on only that key.
+
+This eliminates entire classes of attack (memory dump, core dump, log
+leakage) that Confidential Nodes can only partially mitigate.
+
+## Implementation Sketch (not yet coded)
+
+The following Pulumi changes are NOT yet implemented. They are the planned
+shape of the prod cluster definition derived from the decisions above.
+
+```typescript
+// In kubernetes.ts, replace the `if (environment === 'prod') return;` block
+// with a Standard-mode cluster definition mirroring dev but with:
+//   • location: `${region}`           (regional, not `${region}-a`)
+//   • datapathProvider: 'ADVANCED_DATAPATH'   (Dataplane V2)
+//   • databaseEncryption: { state: 'ENCRYPTED', keyName: <prod KMS key> }
+//   • enablePrivateNodes: false      (mutable, defer until users arrive)
+//   • node pool: identical to dev (e2-medium Spot, 30 GB pd-standard)
+//
+// New Cloud KMS resources needed in prod project:
+//   • KeyRing 'gke-cluster'
+//   • CryptoKey 'gke-etcd-encryption' (PURPOSE_ENCRYPT_DECRYPT, software)
+//   • IAM binding: GKE service agent → roles/cloudkms.cryptoKeyEncrypterDecrypter
+```
+
+## Sources
+
+- [Prepare to migrate to Autopilot from Standard (mode is not in-place mutable)](https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-migrate-cluster-mode)
+- [GKE Dataplane V2 (creation-time only)](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2)
+- [GKE Network Isolation (private nodes are mutable)](https://cloud.google.com/kubernetes-engine/docs/concepts/network-isolation)
+- [GKE types of clusters (immutable fields)](https://cloud.google.com/kubernetes-engine/docs/concepts/types-of-clusters)
+- [Alias IPs and ipAllocationPolicy sizing](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips)
+- [Confidential GKE Nodes (cluster-level setting is irreversible)](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes)
+- [Confidential VM pricing](https://cloud.google.com/confidential-computing/confidential-vm/pricing)
+- [Cloud KMS pricing](https://cloud.google.com/kms/pricing)
+- [GKE pricing (cluster management fee, free tier)](https://cloud.google.com/kubernetes-engine/pricing)
+- [GKE 10th birthday pricing announcement (Sept 2025 single paid tier)](https://cloud.google.com/blog/products/containers-kubernetes/gke-gets-new-pricing-and-capabilities-on-10th-birthday)

--- a/docs/runbooks/prod-cluster-credentials.md
+++ b/docs/runbooks/prod-cluster-credentials.md
@@ -1,0 +1,153 @@
+# Runbook: fetch `kubectl` credentials for the prod GKE cluster
+
+> **Background:** The prod GKE cluster (`standard-cluster-osaka` in
+> `liverty-music-prod`) is a regional Standard cluster created by the
+> OpenSpec change `provision-prod-gcp-resources`. It uses
+> Workload Identity for in-cluster auth and `gke-gcloud-auth-plugin`
+> for human `kubectl` access. There is no kubeconfig committed to
+> the repo — every operator generates one on demand from gcloud.
+
+## When to use this runbook
+
+Use this when you need to run `kubectl` or `helm` commands against
+the prod cluster — typically for:
+
+- Smoke-testing after the first `pulumi up --stack prod`.
+- Investigating an alert that requires direct pod / log inspection
+  beyond what Cloud Logging shows.
+- Manually applying an emergency patch (rare; ArgoCD is authoritative
+  for application manifests).
+
+Routine deployments do NOT need this runbook — ArgoCD reconciles
+`k8s/argocd-apps/prod/*` automatically.
+
+## Prerequisites
+
+You must have:
+
+- `gcloud` CLI installed and authenticated (`gcloud auth login` for
+  human SSO; `gcloud auth application-default login` if using ADC).
+- The `gke-gcloud-auth-plugin` component installed:
+  ```bash
+  gcloud components install gke-gcloud-auth-plugin
+  ```
+- IAM membership granting at least `roles/container.clusterViewer`
+  on `liverty-music-prod`. Read-only operators: `clusterViewer`.
+  Write access: `roles/container.developer` or higher (request via
+  your usual GCP IAM channel).
+
+## Steps
+
+### 1. Authenticate gcloud against the prod project
+
+```bash
+gcloud config set project liverty-music-prod
+gcloud auth login
+```
+
+If using application-default credentials (ADC) for tooling that
+expects them (e.g. some Helm plugins), also run:
+
+```bash
+gcloud auth application-default login
+```
+
+### 2. Fetch the cluster credentials
+
+```bash
+gcloud container clusters get-credentials standard-cluster-osaka \
+  --region asia-northeast2 \
+  --project liverty-music-prod
+```
+
+This writes a context entry into `~/.kube/config` named
+`gke_liverty-music-prod_asia-northeast2_standard-cluster-osaka`
+and sets it as the current context.
+
+### 3. Verify the connection
+
+```bash
+kubectl config current-context
+kubectl get nodes
+kubectl get ns
+```
+
+Expected:
+
+- The current context shows the prod cluster.
+- `kubectl get nodes` returns at least one Spot node from the
+  `spot-pool-osaka` node pool.
+- `kubectl get ns` includes the standard namespaces
+  (`argocd`, `external-secrets`, `backend`, `frontend`, etc.) once
+  ArgoCD has bootstrapped them.
+
+### 4. Switch back to dev when finished
+
+To avoid accidentally running prod-impacting commands later:
+
+```bash
+kubectl config use-context gke_liverty-music-dev_asia-northeast2-a_standard-cluster-osaka
+```
+
+Or use `kubectx prod` / `kubectx dev` if you have
+[`kubectx`](https://github.com/ahmetb/kubectx) installed.
+
+## Verifying the irreversible-decision state
+
+After the first `pulumi up --stack prod`, confirm the three
+irreversible cluster settings from `docs/PROD_BOOTSTRAP_DECISIONS.md`
+are actually in effect on the live cluster:
+
+```bash
+# Topology + Dataplane V2 + etcd CMEK in one describe
+gcloud container clusters describe standard-cluster-osaka \
+  --region asia-northeast2 \
+  --project liverty-music-prod \
+  --format='value(location,networkConfig.datapathProvider,databaseEncryption.state,databaseEncryption.keyName)'
+```
+
+Expected output:
+
+```
+asia-northeast2     ADVANCED_DATAPATH     ENCRYPTED     projects/liverty-music-prod/locations/asia-northeast2/keyRings/gke-cluster/cryptoKeys/gke-etcd-encryption
+```
+
+If any of these three values differs from the expected — the
+cluster was not created per spec. Do **not** attempt to "fix" it
+with `gcloud container clusters update`; per GKE docs none of these
+three settings are mutable post-creation. Destroy the cluster
+(`pulumi destroy --target ...`), correct the Pulumi config, and
+re-create.
+
+## Troubleshooting
+
+### "gke-gcloud-auth-plugin not found"
+
+```bash
+gcloud components install gke-gcloud-auth-plugin
+```
+
+Then retry the `get-credentials` command. The Kubernetes client
+fork no longer ships in-tree GCP auth as of `client-go` 0.26;
+GKE requires the external plugin.
+
+### "Required 'container.clusters.get' permission"
+
+You don't have IAM access. Confirm your `gcloud auth list` shows
+the expected identity and that the GCP IAM admin granted at least
+`roles/container.clusterViewer` on `liverty-music-prod`.
+
+### `kubectl get nodes` shows no nodes
+
+The cluster autoscaler may have scaled the Spot pool to zero or
+Spot capacity is unavailable in `asia-northeast2`. Check the
+cluster autoscaler logs in Cloud Logging
+(`resource.type="k8s_cluster" jsonPayload.noScaleUp`) for the
+reason. If a long-running outage prevents Spot reclaim, switch
+the prod pool to on-demand temporarily.
+
+## See also
+
+- [PROD_BOOTSTRAP_DECISIONS.md](../PROD_BOOTSTRAP_DECISIONS.md)
+- [GKE_CLUSTER_MODE_DECISION.md](../GKE_CLUSTER_MODE_DECISION.md)
+- [DEV_VS_PROD_DIFFERENCES.md](../DEV_VS_PROD_DIFFERENCES.md)

--- a/src/gcp/components/kms.ts
+++ b/src/gcp/components/kms.ts
@@ -1,0 +1,96 @@
+import * as gcp from '@pulumi/gcp'
+import * as pulumi from '@pulumi/pulumi'
+import { ApiService } from '../services/api.js'
+
+export interface KmsComponentArgs {
+	project: gcp.organizations.Project
+	region: pulumi.Input<string>
+}
+
+/**
+ * KmsComponent provisions a Cloud KMS keyring and CryptoKey used as the
+ * customer-managed encryption key (CMEK) for the GKE cluster's etcd
+ * Application-layer Secrets Encryption.
+ *
+ * The key encrypts Kubernetes Secret resources stored in etcd. It does NOT
+ * cover GKE node boot disks (separate per-pool CMEK), Cloud SQL data, or
+ * Persistent Volumes — those use independent CMEK configurations.
+ *
+ * Rotation: 90 days, handled transparently by Cloud KMS. Older key versions
+ * remain available for decryption of already-encrypted data, so rotation
+ * does not break the cluster.
+ *
+ * Lifecycle warning: cluster-creation-time etcd CMEK is irreversible per GKE
+ * documentation. Destroying this key would render the cluster's stored
+ * Secrets unreadable. The CryptoKey resource is marked `protect: true` so
+ * Pulumi refuses to destroy it without an explicit override.
+ */
+export class KmsComponent extends pulumi.ComponentResource {
+	public readonly keyRing: gcp.kms.KeyRing
+	public readonly cryptoKey: gcp.kms.CryptoKey
+	/** Full resource name of the CryptoKey, suitable for cluster `databaseEncryption.keyName`. */
+	public readonly keyName: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: KmsComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('gcp:liverty-music:KmsComponent', name, args, opts)
+
+		const { project, region } = args
+
+		const apiService = new ApiService(project)
+		const enabledApis = apiService.enableApis(
+			['cloudkms.googleapis.com'],
+			this,
+		)
+
+		this.keyRing = new gcp.kms.KeyRing(
+			'gke-cluster',
+			{
+				name: 'gke-cluster',
+				project: project.projectId,
+				location: region,
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		this.cryptoKey = new gcp.kms.CryptoKey(
+			'gke-etcd-encryption',
+			{
+				name: 'gke-etcd-encryption',
+				keyRing: this.keyRing.id,
+				purpose: 'ENCRYPT_DECRYPT',
+				rotationPeriod: '7776000s', // 90 days
+				versionTemplate: {
+					algorithm: 'GOOGLE_SYMMETRIC_ENCRYPTION',
+					protectionLevel: 'SOFTWARE',
+				},
+			},
+			{ parent: this, protect: true },
+		)
+
+		// Grant the GKE service agent permission to encrypt/decrypt with this
+		// key. The agent (`service-<project-number>@container-engine-robot.
+		// iam.gserviceaccount.com`) is automatically provisioned by GCP once
+		// the Container API is enabled; the IAM binding works against its
+		// well-known identity.
+		new gcp.kms.CryptoKeyIAMMember(
+			'gke-etcd-encryption-binding',
+			{
+				cryptoKeyId: this.cryptoKey.id,
+				role: 'roles/cloudkms.cryptoKeyEncrypterDecrypter',
+				member: pulumi.interpolate`serviceAccount:service-${project.number}@container-engine-robot.iam.gserviceaccount.com`,
+			},
+			{ parent: this },
+		)
+
+		this.keyName = this.cryptoKey.id
+
+		this.registerOutputs({
+			keyRingId: this.keyRing.id,
+			cryptoKeyId: this.cryptoKey.id,
+		})
+	}
+}

--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -1,7 +1,7 @@
 import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import type { Region, RegionName } from '../region.js'
-import { ApiService } from '../services/api.js'
+import { ApiService, type GoogleApis } from '../services/api.js'
 import { IamService, Roles } from '../services/iam.js'
 
 export interface SecretConfig {
@@ -29,6 +29,15 @@ export interface KubernetesComponentArgs {
 	podsCidr: pulumi.Input<string>
 	servicesCidr: pulumi.Input<string>
 	masterCidr: string
+
+	/**
+	 * Cloud KMS CryptoKey resource name used for the GKE cluster's etcd
+	 * Application-layer Secrets Encryption. When provided, the cluster is
+	 * created with `databaseEncryption.state = ENCRYPTED`. Currently passed
+	 * for prod only; dev does not enable etcd CMEK. Irreversible at cluster
+	 * creation per GKE docs.
+	 */
+	etcdCmekKeyName?: pulumi.Input<string>
 
 	/**
 	 * The Artifact Registry repositories to grant pull access to.
@@ -74,16 +83,21 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 			podsCidr,
 			servicesCidr,
 			masterCidr,
+			etcdCmekKeyName,
 			artifactRegistries,
 			secrets = [],
 			esoOnlySecrets = [],
 		} = args
 
 		const apiService = new ApiService(project)
-		const enabledApis = apiService.enableApis(
-			['container.googleapis.com', 'places.googleapis.com'],
-			this,
-		)
+		// `places.googleapis.com` is dev-only (gated by gcp-cost-guardrails:
+		// dev has a per-day quota override for venue enrichment; prod does
+		// not use the Places API directly).
+		const apisToEnable: GoogleApis[] = ['container.googleapis.com']
+		if (environment === 'dev') {
+			apisToEnable.push('places.googleapis.com')
+		}
+		const enabledApis = apiService.enableApis(apisToEnable, this)
 		const allSecrets = [...secrets, ...esoOnlySecrets]
 		const enabledSecretManagerApi =
 			allSecrets.length > 0
@@ -382,19 +396,182 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 		)
 
 		if (environment === 'prod') {
-			return
-		}
-
-		if (environment === 'dev') {
-			// 6. GKE Standard Cluster (zonal, Spot node pool) — dev only
-			// Uses Standard mode instead of Autopilot to eliminate the $0.10/hr cluster
-			// management fee (¥10,800/month). Nodes are public (enablePrivateNodes: false)
-			// to remove the Cloud NAT dependency (¥5,292/month fixed cost).
+			// 6. GKE Standard Cluster (regional, Spot node pool) — prod.
+			//
+			// Three irreversible decisions baked in at creation per
+			// docs/PROD_BOOTSTRAP_DECISIONS.md:
+			//   • Regional location (asia-northeast2) — zonal → regional is not
+			//     in-place mutable.
+			//   • Dataplane V2 (datapathProvider: ADVANCED_DATAPATH) — cannot
+			//     be enabled later on an existing cluster.
+			//   • etcd CMEK (databaseEncryption.state: ENCRYPTED) — irreversible
+			//     at cluster level; KMS key provisioned by KmsComponent.
+			//
+			// Cost-first reversible defaults (will flip when real users arrive):
+			//   • enablePrivateNodes: false → no Cloud NAT
+			//   • managedPrometheus.enabled: false
+			//   • Spot e2-medium node pool 1-3 nodes
+			//
+			// See also docs/GKE_CLUSTER_MODE_DECISION.md for the Autopilot-vs-
+			// Standard reasoning and the OpenSpec change
+			// provision-prod-gcp-resources for the requirement scenarios.
+			if (!etcdCmekKeyName) {
+				throw new Error(
+					'etcdCmekKeyName is required for the prod cluster. Provision a KmsComponent and pass its keyName.',
+				)
+			}
 			const cluster = new gcp.container.Cluster(
 				`standard-cluster-${regionName}`,
 				{
 					name: `standard-cluster-${regionName}`,
-					location: `${region}-a`, // Zonal (single zone) — no management fee for first cluster
+					// Regional (3-zone). Irreversible after creation.
+					location: region,
+					deletionProtection: true,
+					network: networkId,
+					subnetwork: this.subnet.id,
+					removeDefaultNodePool: true,
+					initialNodeCount: 1,
+
+					// Dataplane V2 (eBPF). Always-on NetworkPolicy enforcement,
+					// network policy logging, and alignment with GCP's announced
+					// 2027-03-30 default. Cannot be enabled on an existing cluster.
+					datapathProvider: 'ADVANCED_DATAPATH',
+
+					// etcd Application-layer Secrets Encryption using a customer-
+					// managed Cloud KMS key. Encrypts Kubernetes Secret resources
+					// stored in etcd. Irreversible at cluster creation.
+					databaseEncryption: {
+						state: 'ENCRYPTED',
+						keyName: etcdCmekKeyName,
+					},
+
+					ipAllocationPolicy: {
+						clusterSecondaryRangeName: 'pods-range',
+						servicesSecondaryRangeName: 'services-range',
+					},
+
+					// Public nodes for the cost-first pre-launch phase. Mutable
+					// post-creation; flip to `enablePrivateNodes: true` and add
+					// Cloud NAT once real users arrive.
+					privateClusterConfig: {
+						enablePrivateNodes: false,
+						enablePrivateEndpoint: false,
+					},
+
+					workloadIdentityConfig: {
+						workloadPool: pulumi.interpolate`${project.projectId}.svc.id.goog`,
+					},
+
+					releaseChannel: {
+						channel: 'REGULAR',
+					},
+
+					costManagementConfig: {
+						enabled: true,
+					},
+
+					gatewayApiConfig: {
+						channel: 'CHANNEL_STANDARD',
+					},
+
+					// Workloads logs ingested for log-based AlertPolicies (same
+					// as dev). GMP / metric-based monitoring deferred until real
+					// traffic justifies the ingestion cost.
+					loggingConfig: {
+						enableComponents: ['SYSTEM_COMPONENTS', 'WORKLOADS'],
+					},
+					monitoringConfig: {
+						enableComponents: ['SYSTEM_COMPONENTS'],
+						managedPrometheus: {
+							enabled: false,
+						},
+					},
+				},
+				{ parent: this, dependsOn: enabledApis },
+			)
+
+			// 7. Spot Node Pool (e2-medium, regional → 1 node per zone × 3 zones
+			// at min, scaling to 3 per zone at max — cluster autoscaler manages
+			// per-zone node counts within the autoscaling bounds).
+			new gcp.container.NodePool(
+				`spot-pool-${regionName}`,
+				{
+					name: `spot-pool-${regionName}`,
+					cluster: cluster.id,
+					location: region,
+
+					autoscaling: {
+						minNodeCount: 1,
+						maxNodeCount: 3,
+					},
+
+					nodeConfig: {
+						machineType: 'e2-medium',
+						spot: true,
+						diskSizeGb: 30,
+						diskType: 'pd-standard',
+						serviceAccount: gkeNodeSa.email,
+						oauthScopes: [
+							'https://www.googleapis.com/auth/cloud-platform',
+						],
+						workloadMetadataConfig: {
+							mode: 'GKE_METADATA',
+						},
+						shieldedInstanceConfig: {
+							enableSecureBoot: true,
+							enableIntegrityMonitoring: true,
+						},
+						labels: {
+							'cloud.google.com/gke-spot': 'true',
+						},
+					},
+
+					management: {
+						autoRepair: true,
+						autoUpgrade: true,
+					},
+				},
+				{ parent: this, dependsOn: [cluster] },
+			)
+
+			this.registerOutputs({
+				clusterName: cluster.name,
+				clusterEndpoint: cluster.endpoint,
+				subnetId: this.subnet.id,
+				nodeServiceAccountEmail: this.nodeServiceAccountEmail,
+				backendAppServiceAccountEmail:
+					this.backendAppServiceAccountEmail,
+				otelCollectorServiceAccountEmail:
+					this.otelCollectorServiceAccountEmail,
+				zitadelServiceAccountEmail: this.zitadelServiceAccountEmail,
+				esoServiceAccountEmail: this.esoServiceAccountEmail,
+			})
+			return
+		}
+
+		if (environment === 'dev') {
+			// 6. GKE Standard Cluster (zonal, Spot node pool) — dev only.
+			//
+			// Mode rationale: Standard (not Autopilot) gives node-level control needed
+			// for aggressive dev cost optimization — custom node pool sizing, e2-medium
+			// Spot, 30 GB pd-standard boot disks, kube-dns autoscaler overrides, GMP
+			// disabled. Autopilot would block most of these.
+			//
+			// IMPORTANT: the $0.10/hr cluster management fee applies to BOTH Autopilot
+			// and Standard equally — choosing Standard does NOT eliminate it. The GKE
+			// free tier ($74.40/month per billing account ≈ one cluster's fee) covers
+			// either a zonal Standard cluster OR an Autopilot cluster. So the dev
+			// "Kubernetes Engine" line ≈ ¥0 comes from the free-tier credit, not from
+			// Standard mode itself. See docs/GKE_CLUSTER_MODE_DECISION.md.
+			//
+			// Public nodes (enablePrivateNodes: false) avoid the ~¥5,292/month Cloud
+			// NAT fixed cost. This is acceptable for DEV ONLY — prod must use private
+			// nodes for security regardless of cost.
+			const cluster = new gcp.container.Cluster(
+				`standard-cluster-${regionName}`,
+				{
+					name: `standard-cluster-${regionName}`,
+					location: `${region}-a`, // Zonal — eligible for $74.40/mo free-tier credit per billing account.
 					deletionProtection: false,
 					network: networkId,
 					subnetwork: this.subnet.id,

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -190,19 +190,14 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			)
 		}
 
-		// --- Prod Cost Reduction: Skip API Gateway infrastructure for production ---
-		if (environment === 'prod') {
-			this.registerOutputs({
-				networkName: this.network.name,
-				sqlZoneName: this.sqlZone.name,
-			})
-			return
-		}
-
 		// 4. Cloud Router + Cloud NAT (staging only)
-		// Dev uses public nodes (enablePrivateNodes: false), so Cloud NAT is not needed.
-		// Staging retains private nodes and requires NAT for internet egress.
-		if (environment !== 'dev') {
+		// Dev uses public nodes (enablePrivateNodes: false), so Cloud NAT is not
+		// needed. Prod currently mirrors dev's public-node + no-NAT setup as
+		// the cost-first pre-launch state (mutable; flip when real users
+		// arrive — see docs/PROD_BOOTSTRAP_DECISIONS.md D6). Only staging
+		// keeps private nodes today and therefore needs NAT for internet
+		// egress.
+		if (environment === 'staging') {
 			this.router = new gcp.compute.Router(
 				`nat-router-${regionName}`,
 				{
@@ -232,317 +227,131 @@ export class NetworkComponent extends pulumi.ComponentResource {
 			)
 		}
 
-		// 5. Public DNS Zone (for dev/staging subdomain delegation)
-		// We use a dedicated zone for the delegated subdomain to maintain ownership
-		// without manual registrar updates.
-		if (environment !== 'prod') {
-			// Derive publicDomain from environment (e.g., "dev.liverty-music.app")
-			const tld = 'liverty-music.app'
-			const managedZoneName = `${environment}.${tld}`
+		// 5. Public DNS zones + Certificate Manager + shared Gateway resources.
+		//
+		// DNS topology differs by environment but the per-service resource
+		// shape (DnsAuthorization + Certificate + CertificateMapEntry + A
+		// record + ACME-challenge CNAME) is identical. The provisioning code
+		// below is driven by two tables:
+		//
+		//   • SERVICES   — declarative catalog of every externally-facing
+		//                  hostname this stack manages.
+		//   • zoneTopology — env-derived list of Cloud DNS zones, each with
+		//                  the SERVICES that live inside it.
+		//
+		// Dev/staging keep the original single-zone-per-env layout
+		// (`<env>.liverty-music.app`); prod uses one zone per subdomain
+		// (`api.liverty-music.app`, `auth.liverty-music.app`) because the
+		// apex stays on Cloudflare. Pulumi resource names are preserved
+		// across the refactor so existing dev state is not disturbed.
 
-			// Enable Certificate Manager API
-			const certManagerApi = apiService.enableApis(
-				['certificatemanager.googleapis.com' as any],
-				this,
-			)
+		const certManagerApi = apiService.enableApis(
+			['certificatemanager.googleapis.com'],
+			this,
+		)
 
-			// Create public DNS zone
-			const publicZone = new gcp.dns.ManagedZone(
-				`${toKebabCase(tld)}-public-zone`,
-				{
-					name: `${toKebabCase(tld)}-public-zone`,
-					dnsName: `${managedZoneName}.`,
-					visibility: 'public',
-					description: `Public zone for ${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
+		const cloudflareProvider = new cloudflare.Provider(
+			'cloudflare-provider',
+			{ apiToken: cloudflareConfig.apiToken },
+			{ parent: this },
+		)
 
-			this.publicZone = publicZone
-			this.publicZoneNameservers = publicZone.nameServers
+		const tld = 'liverty-music.app'
 
-			const cloudflareProvider = new cloudflare.Provider(
-				'cloudflare-provider',
-				{
-					apiToken: cloudflareConfig.apiToken,
-				},
-				{ parent: this },
-			)
+		const zoneTopology = buildZoneTopology(environment, tld)
 
-			// Create NS records in Cloudflare for subdomain delegation
-			publicZone.nameServers.apply((nameservers) => {
-				nameservers.forEach((ns, index) => {
-					new cloudflare.DnsRecord(
-						`${toKebabCase(tld)}-dns-delegation-ns-${index}`,
-						{
-							zoneId: cloudflareConfig.zoneId,
-							name: environment, // Cloudflare automatically appends the zone name
-							type: 'NS',
-							content: ns.endsWith('.') ? ns : `${ns}.`,
-							ttl: 3600,
-							comment: `Delegate ${managedZoneName} to Cloud DNS`,
-						},
-						{
-							parent: this,
-							provider: cloudflareProvider,
-							// aliases: [
-							// 	{
-							// 		type: 'cloudflare:index/dnsRecord:DnsRecord',
-							// 	},
-							// ],
-						},
-					)
-				})
-			})
-
-			// Certificate Manager: DNS Authorization for Backend Server
-			const backendServerDnsAuth =
-				new gcp.certificatemanager.DnsAuthorization(
-					'backend-server-dns-auth',
+		// Provision each zone + its Cloudflare NS delegation. Returns
+		// per-zone bundles of (zone, services) used in the per-service loop.
+		const provisionedZones = zoneTopology.map(
+			({ zoneConfig, services }) => {
+				const zone = new gcp.dns.ManagedZone(
+					zoneConfig.resourceName,
 					{
-						name: 'backend-server-dns-auth',
-						location: 'global',
-						domain: `api.${managedZoneName}`,
+						name: zoneConfig.resourceName,
+						dnsName: zoneConfig.dnsName,
+						visibility: 'public',
+						description: `Public zone for ${zoneConfig.dnsName.replace(/\.$/, '')}`,
 					},
-					{ parent: this, dependsOn: certManagerApi },
+					{ parent: this, dependsOn: enabledApis },
 				)
 
-			// Certificate Manager: DNS Authorization for Web App
-			const webAppDnsAuth = new gcp.certificatemanager.DnsAuthorization(
-				'web-app-dns-auth',
-				{
-					name: 'web-app-dns-auth',
-					location: 'global',
-					domain: `${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+				// Cloudflare NS records: delegate this zone's apex to the
+				// Cloud DNS nameservers. One record per NS server returned
+				// by GCP (typically 4).
+				zone.nameServers.apply((nameservers) => {
+					nameservers.forEach((ns, index) => {
+						new cloudflare.DnsRecord(
+							`${zoneConfig.cloudflareNsResourcePrefix}-dns-delegation-ns-${index}`,
+							{
+								zoneId: cloudflareConfig.zoneId,
+								name: zoneConfig.cloudflareNsName,
+								type: 'NS',
+								content: ns.endsWith('.') ? ns : `${ns}.`,
+								ttl: 3600,
+								comment: `Delegate ${zoneConfig.dnsName.replace(/\.$/, '')} to Cloud DNS`,
+							},
+							{ parent: this, provider: cloudflareProvider },
+						)
+					})
+				})
 
-			// Certificate Manager: DNS Authorization for self-hosted Zitadel
-			// (`auth.<managedZoneName>`). Needed so the Google-managed cert can
-			// cover the Zitadel issuer hostname alongside api/web domains.
-			// Naming mirrors the sibling `backend-server-dns-auth` / `web-app-dns-auth`
-			// resources: the service name (`zitadel`) is the scope, not the
-			// subdomain prefix.
-			const zitadelDnsAuth = new gcp.certificatemanager.DnsAuthorization(
-				'zitadel-dns-auth',
-				{
-					name: 'zitadel-dns-auth',
-					location: 'global',
-					domain: `auth.${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+				return { zone, services }
+			},
+		)
 
-			// Certificate Manager: per-service Google-managed Certificates.
-			//
-			// Each service owns a single-hostname Certificate rather than a
-			// shared SAN cert. Rationale:
-			//   - GCP managed certs treat `domains` / `dnsAuthorizations` as
-			//     immutable — adding a hostname forces a replace (delete+create).
-			//     Delete is blocked by any CertificateMapEntry still pointing at
-			//     the cert, producing a hard deadlock when onboarding a new
-			//     hostname (as we hit when adding `auth.<tld>` for Zitadel).
-			//   - Matches the per-service granularity already established for
-			//     DnsAuthorization, CertificateMapEntry, and DNS records.
-			//   - Isolates ACME provisioning / rate-limit / rotation failures to
-			//     a single hostname.
-			const backendServerCert = new gcp.certificatemanager.Certificate(
-				'backend-server-cert',
-				{
-					name: 'backend-server-cert',
-					location: 'global',
-					scope: 'DEFAULT',
-					managed: {
-						domains: [`api.${managedZoneName}`],
-						dnsAuthorizations: [backendServerDnsAuth.id],
-					},
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+		// Expose the primary public zone for back-compat. For dev/staging
+		// there is a single zone covering all hostnames. For prod multiple
+		// zones exist; downstream consumers do not currently use this field
+		// for prod, so leaving it unset (undefined) is safe.
+		if (environment !== 'prod') {
+			this.publicZone = provisionedZones[0]?.zone
+			this.publicZoneNameservers = provisionedZones[0]?.zone.nameServers
+		}
 
-			const webAppCert = new gcp.certificatemanager.Certificate(
-				'web-app-cert',
-				{
-					name: 'web-app-cert',
-					location: 'global',
-					scope: 'DEFAULT',
-					managed: {
-						domains: [`${managedZoneName}`],
-						dnsAuthorizations: [webAppDnsAuth.id],
-					},
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+		// Shared Gateway resources: one CertificateMap and one static IP
+		// across all hostnames in this stack (Gateway is a single ingress).
+		const certMap = new gcp.certificatemanager.CertificateMap(
+			'api-gateway-cert-map',
+			{ name: 'api-gateway-cert-map' },
+			{ parent: this, dependsOn: certManagerApi },
+		)
 
-			const zitadelCert = new gcp.certificatemanager.Certificate(
-				'zitadel-cert',
-				{
-					name: 'zitadel-cert',
-					location: 'global',
-					scope: 'DEFAULT',
-					managed: {
-						domains: [`auth.${managedZoneName}`],
-						dnsAuthorizations: [zitadelDnsAuth.id],
-					},
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+		const staticIp = new gcp.compute.GlobalAddress(
+			'api-gateway-static-ip',
+			{
+				name: 'api-gateway-static-ip',
+				addressType: 'EXTERNAL',
+				ipVersion: 'IPV4',
+			},
+			{ parent: this },
+		)
 
-			// Certificate Manager: Certificate Map. The map itself is shared
-			// across services — it is the binding between the Gateway listener
-			// and the per-hostname certs below.
-			const certMap = new gcp.certificatemanager.CertificateMap(
-				'api-gateway-cert-map',
-				{
-					name: 'api-gateway-cert-map',
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
+		// Provision each service's hostname (DnsAuth + Cert + CertMapEntry
+		// + A record + ACME CNAME) into its assigned zone.
+		const certManagerAndDnsApis = [...certManagerApi, ...enabledApis]
+		for (const { zone, services } of provisionedZones) {
+			for (const svc of services) {
+				provisionManagedHostname(
+					this,
+					{ name: svc.name, hostname: svc.hostname, zone },
+					certMap,
+					staticIp,
+					certManagerAndDnsApis,
+				)
+			}
+		}
 
-			// Certificate Manager: Certificate Map Entry for Backend Server
-			new gcp.certificatemanager.CertificateMapEntry(
-				'backend-server-cert-map-entry',
-				{
-					name: 'backend-server-cert-map-entry',
-					map: certMap.name,
-					certificates: [backendServerCert.id],
-					hostname: `api.${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
-
-			// Certificate Manager: Certificate Map Entry for self-hosted Zitadel
-			new gcp.certificatemanager.CertificateMapEntry(
-				'zitadel-cert-map-entry',
-				{
-					name: 'zitadel-cert-map-entry',
-					map: certMap.name,
-					certificates: [zitadelCert.id],
-					hostname: `auth.${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
-
-			// Certificate Manager: Certificate Map Entry for Web App
-			new gcp.certificatemanager.CertificateMapEntry(
-				'web-app-cert-map-entry',
-				{
-					name: 'web-app-cert-map-entry',
-					map: certMap.name,
-					certificates: [webAppCert.id],
-					hostname: `${managedZoneName}`,
-				},
-				{ parent: this, dependsOn: certManagerApi },
-			)
-
-			// Static IP for Gateway
-			const staticIp = new gcp.compute.GlobalAddress(
-				'api-gateway-static-ip',
-				{
-					name: 'api-gateway-static-ip',
-					addressType: 'EXTERNAL',
-					ipVersion: 'IPV4',
-				},
-				{ parent: this },
-			)
-
-			// DNS CNAME record for Backend Server ACME challenge validation
-			new gcp.dns.RecordSet(
-				'backend-server-dns-auth-cname',
-				{
-					name: backendServerDnsAuth.dnsResourceRecords.apply(
-						(r) => r[0].name,
-					),
-					managedZone: publicZone.name,
-					type: 'CNAME',
-					ttl: 300,
-					rrdatas: backendServerDnsAuth.dnsResourceRecords.apply(
-						(r) => [r[0].data],
-					),
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// DNS CNAME record for Web App ACME challenge validation
-			new gcp.dns.RecordSet(
-				'web-app-dns-auth-cname',
-				{
-					name: webAppDnsAuth.dnsResourceRecords.apply(
-						(r) => r[0].name,
-					),
-					managedZone: publicZone.name,
-					type: 'CNAME',
-					ttl: 300,
-					rrdatas: webAppDnsAuth.dnsResourceRecords.apply((r) => [
-						r[0].data,
-					]),
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// DNS A record for Backend Server
-			new gcp.dns.RecordSet(
-				'backend-server-a-record',
-				{
-					name: `api.${managedZoneName}.`,
-					managedZone: publicZone.name,
-					type: 'A',
-					ttl: 300,
-					rrdatas: [staticIp.address],
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// DNS A record for Web App
-			new gcp.dns.RecordSet(
-				'web-app-a-record',
-				{
-					name: `${managedZoneName}.`,
-					managedZone: publicZone.name,
-					type: 'A',
-					ttl: 300,
-					rrdatas: [staticIp.address],
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// DNS CNAME record for self-hosted Zitadel ACME challenge validation
-			new gcp.dns.RecordSet(
-				'zitadel-dns-auth-cname',
-				{
-					name: zitadelDnsAuth.dnsResourceRecords.apply(
-						(r) => r[0].name,
-					),
-					managedZone: publicZone.name,
-					type: 'CNAME',
-					ttl: 300,
-					rrdatas: zitadelDnsAuth.dnsResourceRecords.apply((r) => [
-						r[0].data,
-					]),
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// DNS A record for self-hosted Zitadel — shares the Gateway static IP
-			// with api/web. The HTTPRoute in k8s/namespaces/zitadel/base/httproute.yaml
-			// routes traffic to the zitadel Service based on the Host header.
-			new gcp.dns.RecordSet(
-				'zitadel-a-record',
-				{
-					name: `auth.${managedZoneName}.`,
-					managedZone: publicZone.name,
-					type: 'A',
-					ttl: 300,
-					rrdatas: [staticIp.address],
-				},
-				{ parent: this, dependsOn: enabledApis },
-			)
-
-			// Postmark Email DNS Records (dev/staging: GCP Cloud DNS)
+		// Postmark Email DNS Records.
+		// dev/staging: GCP Cloud DNS, records placed in the single subdomain
+		// zone. prod: Cloudflare handles Postmark records at the apex (see
+		// `if (environment === 'prod')` Cloudflare provider block above);
+		// nothing to do here for prod.
+		if (environment !== 'prod') {
+			const publicZone = provisionedZones[0].zone
 			const mailSubdomain = `mail.${environment}`
 
-			// Postmark DKIM settings (https://account.postmarkapp.com/signature_domains/4169912)
+			// Postmark DKIM settings
+			// (https://account.postmarkapp.com/signature_domains/4169912)
 			new gcp.dns.RecordSet(
 				'postmark-dkim',
 				{
@@ -555,7 +364,8 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				{ parent: this, dependsOn: enabledApis },
 			)
 
-			// Postmark Return-Path settings (https://account.postmarkapp.com/signature_domains/4169912)
+			// Postmark Return-Path settings
+			// (https://account.postmarkapp.com/signature_domains/4169912)
 			new gcp.dns.RecordSet(
 				'postmark-return-path',
 				{
@@ -567,15 +377,208 @@ export class NetworkComponent extends pulumi.ComponentResource {
 				},
 				{ parent: this, dependsOn: enabledApis },
 			)
-
-			this.registerOutputs({
-				publicZoneNameservers: publicZone.nameServers,
-			})
 		}
 
 		this.registerOutputs({
 			networkName: this.network.name,
 			sqlZoneName: this.sqlZone.name,
+			publicZoneNameservers: this.publicZoneNameservers,
 		})
 	}
+}
+
+/**
+ * Declarative catalog of externally-facing services. Each entry maps a
+ * service to its subdomain prefix. `subdomain: null` denotes a service
+ * served at the zone apex (used by dev/staging where the apex is
+ * `<env>.<tld>`; excluded for prod because the prod apex stays on
+ * Cloudflare).
+ *
+ * The `name` is the Pulumi resource-name prefix and MUST NOT change for
+ * existing services — it is part of the stack URN.
+ */
+const SERVICES: ReadonlyArray<{
+	name: string
+	subdomain: string | null
+}> = [
+	{ name: 'backend-server', subdomain: 'api' },
+	{ name: 'web-app', subdomain: null },
+	{ name: 'zitadel', subdomain: 'auth' },
+]
+
+/**
+ * Config describing one Cloud DNS public zone and the Cloudflare NS
+ * delegation that points the parent zone at it.
+ */
+interface ZoneConfig {
+	/** Pulumi resource name for the gcp.dns.ManagedZone. */
+	resourceName: string
+	/** Cloud DNS `dnsName` (FQDN, trailing dot). */
+	dnsName: string
+	/**
+	 * Cloudflare DNS record `name` field. Cloudflare appends the parent
+	 * zone, so this is the subdomain label being delegated.
+	 */
+	cloudflareNsName: string
+	/**
+	 * Pulumi resource-name prefix for the Cloudflare NS DnsRecord resources.
+	 * Kept separate from {@link cloudflareNsName} so dev's pre-existing URN
+	 * (`liverty-music-app-dns-delegation-ns-*`) survives the refactor.
+	 */
+	cloudflareNsResourcePrefix: string
+}
+
+/**
+ * Per-zone bundle returned by {@link buildZoneTopology}. Each zone owns
+ * one or more services whose hostnames resolve inside it.
+ */
+interface ZoneTopologyEntry {
+	zoneConfig: ZoneConfig
+	services: Array<{ name: string; hostname: string }>
+}
+
+/**
+ * Build the (zone × services) assignment for the current environment.
+ *
+ * - **dev / staging**: a single zone `<env>.<tld>` containing every
+ *   service from {@link SERVICES}. The web app sits at the zone apex
+ *   (hostname == zone dnsName), api/auth at subdomains.
+ * - **prod**: one zone per non-apex service (apex stays on Cloudflare).
+ *   The web app is excluded.
+ *
+ * Pulumi resource names returned for dev/staging mirror the names that
+ * existed before this refactor, so the rewrite produces zero-diff on
+ * dev. Prod adds new resources with distinct names.
+ */
+function buildZoneTopology(
+	environment: string,
+	tld: string,
+): ZoneTopologyEntry[] {
+	if (environment === 'prod') {
+		return SERVICES.filter((svc) => svc.subdomain !== null).map((svc) => {
+			const subdomain = svc.subdomain as string
+			const fqdn = `${subdomain}.${tld}`
+			return {
+				zoneConfig: {
+					resourceName: `${subdomain}-${toKebabCase(tld)}-public-zone`,
+					dnsName: `${fqdn}.`,
+					cloudflareNsName: subdomain,
+					cloudflareNsResourcePrefix: subdomain,
+				},
+				services: [{ name: svc.name, hostname: fqdn }],
+			}
+		})
+	}
+
+	// dev / staging
+	const managedZoneName = `${environment}.${tld}`
+	return [
+		{
+			zoneConfig: {
+				resourceName: `${toKebabCase(tld)}-public-zone`,
+				dnsName: `${managedZoneName}.`,
+				cloudflareNsName: environment,
+				cloudflareNsResourcePrefix: toKebabCase(tld),
+			},
+			services: SERVICES.map((svc) => ({
+				name: svc.name,
+				hostname: svc.subdomain
+					? `${svc.subdomain}.${managedZoneName}`
+					: managedZoneName,
+			})),
+		},
+	]
+}
+
+/**
+ * Provision the per-hostname Pulumi resources that wire a service into
+ * Google-managed TLS and DNS:
+ *
+ *   - `<name>-dns-auth`           — Certificate Manager DnsAuthorization
+ *   - `<name>-cert`               — single-hostname Google-managed Certificate
+ *   - `<name>-cert-map-entry`     — binds the cert to the shared
+ *                                    {@link gcp.certificatemanager.CertificateMap}
+ *   - `<name>-a-record`           — A record in {@link service.zone}
+ *                                    pointing at {@link staticIp}
+ *   - `<name>-dns-auth-cname`     — CNAME record satisfying the ACME
+ *                                    DNS-01 challenge for the cert
+ *
+ * Per-service single-hostname certificates (rather than a shared SAN
+ * cert) are intentional: GCP managed certs treat `domains` /
+ * `dnsAuthorizations` as immutable, so adding a hostname to a shared
+ * cert forces replace, which deadlocks against any CertificateMapEntry
+ * still referencing the cert. Single-hostname certs isolate that risk
+ * and match the per-service granularity used everywhere else.
+ */
+function provisionManagedHostname(
+	parent: pulumi.ComponentResource,
+	service: {
+		name: string
+		hostname: string
+		zone: gcp.dns.ManagedZone
+	},
+	certMap: gcp.certificatemanager.CertificateMap,
+	staticIp: gcp.compute.GlobalAddress,
+	dependsOn: pulumi.Resource[],
+): void {
+	const { name, hostname, zone } = service
+
+	const dnsAuth = new gcp.certificatemanager.DnsAuthorization(
+		`${name}-dns-auth`,
+		{
+			name: `${name}-dns-auth`,
+			location: 'global',
+			domain: hostname,
+		},
+		{ parent, dependsOn },
+	)
+
+	const cert = new gcp.certificatemanager.Certificate(
+		`${name}-cert`,
+		{
+			name: `${name}-cert`,
+			location: 'global',
+			scope: 'DEFAULT',
+			managed: {
+				domains: [hostname],
+				dnsAuthorizations: [dnsAuth.id],
+			},
+		},
+		{ parent, dependsOn },
+	)
+
+	new gcp.certificatemanager.CertificateMapEntry(
+		`${name}-cert-map-entry`,
+		{
+			name: `${name}-cert-map-entry`,
+			map: certMap.name,
+			certificates: [cert.id],
+			hostname,
+		},
+		{ parent, dependsOn },
+	)
+
+	new gcp.dns.RecordSet(
+		`${name}-a-record`,
+		{
+			name: `${hostname}.`,
+			managedZone: zone.name,
+			type: 'A',
+			ttl: 300,
+			rrdatas: [staticIp.address],
+		},
+		{ parent, dependsOn },
+	)
+
+	new gcp.dns.RecordSet(
+		`${name}-dns-auth-cname`,
+		{
+			name: dnsAuth.dnsResourceRecords.apply((r) => r[0].name),
+			managedZone: zone.name,
+			type: 'CNAME',
+			ttl: 300,
+			rrdatas: dnsAuth.dnsResourceRecords.apply((r) => [r[0].data]),
+		},
+		{ parent, dependsOn },
+	)
 }

--- a/src/gcp/components/postgres.ts
+++ b/src/gcp/components/postgres.ts
@@ -89,10 +89,6 @@ export class PostgresComponent extends pulumi.ComponentResource {
 			'servicenetworking.googleapis.com', // Required for PSC
 		])
 
-		if (environment === 'prod') {
-			return
-		}
-
 		// 2. Provision Cloud SQL Instance (Producer)
 		const postgresDbName = `postgres-${regionName}`
 		const instance = new gcp.sql.DatabaseInstance(

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -1,6 +1,7 @@
 import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from '../cloudflare/config.js'
+import { KmsComponent } from './components/kms.js'
 import { KubernetesComponent } from './components/kubernetes.js'
 import { MonitoringComponent } from './components/monitoring.js'
 // import { ConcertDataStore } from './components/concert-data-store.js'
@@ -144,6 +145,19 @@ export class Gcp {
 			{ parent: this.project },
 		)
 
+		// 4.5. Cloud KMS — etcd CMEK key for the prod GKE cluster.
+		// Application-layer Secrets Encryption is irreversible at cluster
+		// creation, so the key must exist before KubernetesComponent runs.
+		// Skipped for dev: dev cluster does not enable etcd CMEK to keep the
+		// dev resource footprint minimal.
+		const kms =
+			environment === 'prod'
+				? new KmsComponent('gke-cluster-kms', {
+						project: this.project,
+						region: Regions.Osaka,
+					})
+				: undefined
+
 		// 5. GKE Autopilot Cluster
 		const osakaConfig = NetworkConfig.Osaka
 		const kubernetes = new KubernetesComponent('kubernetes-cluster', {
@@ -156,6 +170,7 @@ export class Gcp {
 			podsCidr: osakaConfig.podsCidr,
 			servicesCidr: osakaConfig.servicesCidr,
 			masterCidr: osakaConfig.masterCidr,
+			etcdCmekKeyName: kms?.keyName,
 			artifactRegistries: [
 				backendArtifactRegistry,
 				frontendArtifactRegistry,

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -27,6 +27,8 @@ export type GoogleApis =
 	| 'secretmanager.googleapis.com'
 	| 'clouderrorreporting.googleapis.com'
 	| 'places.googleapis.com'
+	| 'cloudkms.googleapis.com'
+	| 'certificatemanager.googleapis.com'
 
 export class ApiService {
 	constructor(private project: gcp.organizations.Project) {}


### PR DESCRIPTION
## 🔗 Related Issue

No tracking issue. Implementation of OpenSpec change `provision-prod-gcp-resources` (companion PR: liverty-music/specification#445).

## 📝 Summary of Changes

End the `if (environment === 'prod') return;` short-circuit that has left the prod GCP stack empty since 2026-02-05. Provisions the prod GKE cluster + KMS + Cloud SQL + DNS / certs in a single coherent landing.

### Irreversible decisions baked in at creation

| Decision | Value | Notes |
|---|---|---|
| Cluster topology | Regional `asia-northeast2` | Zonal would risk total prod outage on any single AZ event |
| Dataplane | V2 (`ADVANCED_DATAPATH`) | Becomes GCP's new default 2027-03-30 |
| etcd encryption | CMEK via new Cloud KMS key | Pre-empts SOC2 / blockchain audit asks; ~$0.20/mo |
| Secondary IP ranges | Same CIDR as dev | Project-isolated VPCs |

### Reversible cost-first defaults (mutable later)

Public nodes, no Cloud NAT, Spot e2-medium 1-3 nodes, 30 GB pd-standard, GMP off, Cloud SQL `db-f1-micro` REGIONAL.

### Code structure

- **New `KmsComponent`** ([src/gcp/components/kms.ts](src/gcp/components/kms.ts)) — KeyRing + CryptoKey 🔒 + GKE service-agent IAM binding. `protect: true` against accidental destroy.
- **`KubernetesComponent`** — prod branch added alongside dev branch. Full regional cluster + Spot pool definition.
- **`NetworkComponent`** — refactored to drive per-service hostname resources off a declarative `SERVICES` catalog + env-aware `buildZoneTopology()` mapper. Single `provisionManagedHostname()` helper for the 5-resource bundle. **ZERO functional diff on dev** (preview proof below).
- **`PostgresComponent`** — prod-only `return` removed; existing shape provisions for prod with `db-f1-micro`.
- **Places API gate** — `places.googleapis.com` API enablement gated to `environment === 'dev'` to match the existing `gcp-cost-guardrails` spec (discovered during implementation; preview shows the Service being deleted from prod).
- **API type** — `certificatemanager.googleapis.com` and `cloudkms.googleapis.com` added to the `GoogleApis` union type; prior `as any` cast removed.

### Documentation (4 new files)

- [`docs/PROD_BOOTSTRAP_DECISIONS.md`](docs/PROD_BOOTSTRAP_DECISIONS.md) — decision log + future-revisit triggers + KMS-based blockchain signing approach.
- [`docs/GKE_CLUSTER_MODE_DECISION.md`](docs/GKE_CLUSTER_MODE_DECISION.md) — Autopilot vs Standard analysis + immutable-vs-mutable reference table.
- [`docs/DEV_VS_PROD_DIFFERENCES.md`](docs/DEV_VS_PROD_DIFFERENCES.md) — operator-facing 30-row diff table.
- [`docs/runbooks/prod-cluster-credentials.md`](docs/runbooks/prod-cluster-credentials.md) — kubectl auth + verification snippet for the 3 irreversible cluster settings.

## 🌍 Affected Stacks

- [x] Dev — refactor-only changes, zero functional diff (preview proof below)
- [x] Prod — new resources created, see preview

## 🔮 Pulumi Preview

### Dev (`pulumi preview --stack dev --diff`)

```
Resources:
    ~ 1 to update     (Zitadel dashboard drift — unrelated to this PR)
    232 unchanged     ← all NetworkComponent resources URN-preserved across the refactor
```

The single update is `gcp:liverty-music:ZitadelMonitoringComponent$gcp:monitoring/dashboard:Dashboard::dashboard-zitadel-observability` showing `tiles[0].xPos: 0` + `tiles[1].xPos: 0` additions and `etag`/`name` clears — pure dashboard drift from a different change.

### Prod (`pulumi preview --stack prod --diff`)

```
Resources:
    + 40 to create
    ~ 15 to update    (mostly Pulumi provider version drift)
    -  2 to delete    (places.googleapis.com Service + obsolete pga-restricted-googleapis-a)
    57 changes. 111 unchanged
```

Every required resource present:

- ✅ `KmsComponent` (KeyRing `gke-cluster` + CryptoKey `gke-etcd-encryption` 🔒 + IAM binding to `service-108947861615@container-engine-robot`)
- ✅ Cluster: `location: asia-northeast2`, `datapathProvider: ADVANCED_DATAPATH`, `databaseEncryption: {state: ENCRYPTED, keyName: <KMS>}`, `enablePrivateNodes: false`, `deletionProtection: true`, `managedPrometheus.enabled: false`, `loggingConfig: [SYSTEM_COMPONENTS, WORKLOADS]`
- ✅ NodePool: `spot: true`, `e2-medium`, 30 GB `pd-standard`, autoscale 1-3, Shielded Nodes, GKE_METADATA, `cloud.google.com/gke-spot: "true"` label
- ✅ Cloud SQL `postgres-osaka`: `db-f1-micro`, `availabilityType: REGIONAL`, PSC, IAM auth, deletion protection
- ✅ Cloud DNS: `api-liverty-music-app-public-zone` + `auth-liverty-music-app-public-zone`
- ✅ Per-service hostname resources for `backend-server` (api.liverty-music.app) and `zitadel` (auth.liverty-music.app); web-app correctly excluded (apex stays on Cloudflare)
- ✅ Shared `api-gateway-cert-map` + `api-gateway-static-ip`
- ✅ `places.googleapis.com` Service deletion (Places API gate working)

### Note on Cloudflare NS delegation records

The `api-dns-delegation-ns-*` and `auth-dns-delegation-ns-*` Cloudflare records do not appear in the preview because they are registered inside a `zone.nameServers.apply((nameservers) => { ... })` callback — a known Pulumi behavior where resources depending on unresolved Outputs are deferred to apply-time. They will be created at `pulumi up` time after the zones materialize. Same pattern as the existing dev `liverty-music-app-dns-delegation-ns-*` records.

## 📦 State Changes

No `pulumi state mv` / `import` required. Pure additions for prod + 2 expected deletions:

1. `gcp:projects/service:Service::places` — Places API disablement (gate added to match `gcp-cost-guardrails` spec).
2. `gcp:dns/recordSet:RecordSet::pga-restricted-googleapis-a` — leftover from prior PGA restricted→private migration. No live workloads depend on it (private VIP A record being created concurrently).

The CryptoKey is protected via Pulumi `protect: true` so accidental destroy is blocked.

## ✅ Checklist

- [x] `make lint-ts` passes locally (biome + tsc, 0 warnings)
- [x] `pulumi preview --stack dev --diff` shows zero functional diff
- [x] `pulumi preview --stack prod --diff` matches design.md spec
- [x] No unintended destructive changes (the 2 deletes are expected and documented)
- [x] Secrets managed via ESC (no hardcoded values in code)
- [x] CMEK key protected against accidental destroy

## ⏭️ Out of scope (follow-up PRs)

- K8s manifests for prod (`k8s/argocd-apps/prod/` + per-namespace `overlays/prod/`). Tracked in `tasks.md` §6 of the OpenSpec change. ArgoCD will idle until those land.
- ESC config (`esc env set liverty-music/prod pulumiConfig.<key>`) — operator step before first `pulumi up --stack prod`.
- First `pulumi up --stack prod` itself — manual-trigger per the existing `deployment-infrastructure` spec.
