### PR TITLE
feat(secret): add GSM secret zitadel-machine-key-for-backend-app (PR 1/11 of rename-zitadel-machine-keys)

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -244,6 +244,14 @@ export class Gcp {
 								name: 'zitadel-machine-key',
 								value: pulumi.secret(zitadelMachineKey),
 							},
+							// Transitional dual-write: backend reads from the new
+							// name with fallback to the old. PR 4 of openspec change
+							// `rename-zitadel-machine-keys` removes the old entry;
+							// PR 6 destroys the underlying GSM resource.
+							{
+								name: 'zitadel-machine-key-for-backend-app',
+								value: pulumi.secret(zitadelMachineKey),
+							},
 						]
 					: []),
 			],


### PR DESCRIPTION
## Summary

- Step 1 of openspec change `rename-zitadel-machine-keys` (backend-app key arc).
- Adds GSM secret `zitadel-machine-key-for-backend-app` alongside the legacy `zitadel-machine-key`. Both are populated from the same `MachineKey.keyDetails` output, so backend consumers can transition from old → new in subsequent PRs without downtime.
- Non-destructive, additive only: no existing secret is renamed, replaced, or removed by this PR.

## Migration context

This is the first of 11 PRs implementing the GSM secret rename from `zitadel-machine-key` / `zitadel-admin-sa-key` to the uniform pattern `zitadel-machine-key-for-<principal>`. See the openspec change for the full plan (`specification/openspec/changes/rename-zitadel-machine-keys/`).

Subsequent backend-app PRs (sequential):
- **PR 2 (backend)**: backend reads new env var with fallback to old.
- **PR 3 (this repo)**: ExternalSecret + deployment + configmap cutover to new path.
- **PR 4 (this repo)**: remove old GSM writer + drop old ESO/configmap/mount entries.
- **PR 5 (backend)**: drop old env var fallback from Go (post 7-day soak).
- **PR 6 (this repo)**: destroy the old `zitadel-machine-key` GSM SecretManagerSecret resource.

Parallel-safe with `PR 7` (MachineKey Pulumi URN rename via `aliases`) and the pulumi-admin migration (PRs 10–12).

Depends on: none — first step of the backend-app migration.

## Test plan

- [ ] `pulumi preview` against dev shows exactly one `+ create` for `SecretManagerSecret` `zitadel-machine-key-for-backend-app` and its `SecretManagerSecretVersion`. **NO** `replace` / `delete` lines on the existing `zitadel-machine-key`, `MachineKey`, or other resources.
- [ ] After merge, `pulumi-cloud-deployments` dev job completes successfully.
- [ ] Post-deploy: both GSM secrets exist:
  - `gcloud secrets versions list zitadel-machine-key --project=liverty-music-dev`
  - `gcloud secrets versions list zitadel-machine-key-for-backend-app --project=liverty-music-dev`
- [ ] Backend pods continue serving (no consumer change in this PR; pods read from `zitadel-machine-key` still).
