### PR TITLE
refactor(zitadel): rename MachineKey Pulumi URN via aliases (PR 7/11 of rename-zitadel-machine-keys)

### DIFF
--- a/src/zitadel/components/machine-user.ts
+++ b/src/zitadel/components/machine-user.ts
@@ -56,7 +56,7 @@ export class MachineUserComponent extends pulumi.ComponentResource {
 		)
 
 		this.machineKey = new zitadel.MachineKey(
-			'backend-app-key',
+			'machine-key-for-backend-app',
 			{
 				orgId,
 				userId: this.machineUser.id,
@@ -83,7 +83,18 @@ export class MachineUserComponent extends pulumi.ComponentResource {
 				// three sources of truth (Zitadel DB, GSM, Pulumi state).
 				expirationDate: '2099-01-01T00:00:00Z',
 			},
-			{ ...resourceOptions, dependsOn: [this.machineUser] },
+			{
+				...resourceOptions,
+				dependsOn: [this.machineUser],
+				// Map the legacy Pulumi URN onto the new one so existing
+				// state aligns to the new logical name WITHOUT triggering a
+				// create-replace-delete cycle. Without this, renaming the
+				// resource id would re-mint the MachineKey — the exact
+				// failure mode the §13.15 incident produced
+				// (Errors.AuthNKey.NotFound). Removed by a follow-up PR
+				// after a ≥ 14-day soak.
+				aliases: [{ name: 'backend-app-key' }],
+			},
 		)
 
 		this.orgMember = new zitadel.OrgMember(


### PR DESCRIPTION
## Summary

- Rename the Pulumi URN of the backend-app `MachineKey` resource from `backend-app-key` to `machine-key-for-backend-app`, aligning with the platform-wide convention `zitadel-machine-key-for-<principal>` introduced by openspec change `rename-zitadel-machine-keys`.
- Attach `aliases: [{ name: 'backend-app-key' }]` so Pulumi maps the legacy URN onto the new one — the resource is **updated in place, NOT replaced**.

## Why aliases matter here

Replacing the `MachineKey` resource would re-mint the JWT key and trigger the §13.15 failure mode: `Errors.AuthNKey.NotFound` from the Zitadel API when backend tries to authenticate with the new key before the new `keyId` propagates through GSM → ESO → K8s Secret → Pod. The `aliases` mechanism avoids this entirely by telling Pulumi "the resource at the old URN is the same one as the resource at the new URN."

The `aliases` line is operationally dead code once the state is keyed on the new URN. It is removed by a follow-up PR after a ≥ 14-day soak.

## Migration context

Part of openspec change `rename-zitadel-machine-keys` — this PR + a follow-up alias-removal PR cover the Pulumi-side rename. **Parallel-safe** with:
- the backend-app GSM rename arc (PRs 1, 3, 4, 6)
- the backend env-var rename (PRs 2, 5)
- the pulumi-admin migration (PRs 10, 11, 12)

Depends on: none — parallel-safe with all other PRs of this openspec change.

## Test plan

- [ ] `pulumi preview` against dev shows the MachineKey resource with **an in-place URN update** (`old urn: ...::backend-app-key` → `new urn: ...::machine-key-for-backend-app`) — NO `+ create` / `~ replace` / `- delete` lines on it. If preview shows a replacement, the alias spec is misconfigured; **DO NOT MERGE**.
- [ ] After merge, `pulumi-cloud-deployments` dev apply completes successfully with the MachineKey shown as an in-place URN update.
- [ ] Post-deploy smoke test: trigger a backend → Zitadel API call against dev (e.g., `ResendEmailVerification` for a test user) and confirm no `Errors.AuthNKey.NotFound`.

## Follow-up

A subsequent PR (after ≥ 14-day soak) removes the `aliases: [{ name: 'backend-app-key' }]` line. By then Pulumi state is keyed solely on the new URN and the alias is dead code.
