### PR TITLE
feat(zitadel): dual-write admin SA key to new GSM name (PR 10/11 of rename-zitadel-machine-keys)

### DIFF
--- a/k8s/namespaces/zitadel/base/deployment-api.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-api.yaml
@@ -132,18 +132,24 @@ spec:
         - |
           set -eu
           KEY_FILE=/var/zitadel/bootstrap/admin-sa.json
-          SECRET_NAME=zitadel-admin-sa-key
+          # Transitional dual-write during the rename from
+          # `zitadel-admin-sa-key` to `zitadel-machine-key-for-pulumi-admin`
+          # (openspec change rename-zitadel-machine-keys). The legacy name
+          # is removed in a later PR.
+          SECRET_NAMES="zitadel-admin-sa-key zitadel-machine-key-for-pulumi-admin"
           echo "bootstrap-uploader: waiting for $KEY_FILE"
           while [ ! -f "$KEY_FILE" ]; do sleep 2; done
-          if existing=$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null); then
-            if [ "$existing" = "$(cat "$KEY_FILE")" ]; then
-              echo "bootstrap-uploader: stored version already matches, skipping upload"
-              exec tail -f /dev/null
+          for SECRET_NAME in $SECRET_NAMES; do
+            if existing=$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null); then
+              if [ "$existing" = "$(cat "$KEY_FILE")" ]; then
+                echo "bootstrap-uploader: $SECRET_NAME stored version already matches, skipping upload"
+                continue
+              fi
             fi
-          fi
-          echo "bootstrap-uploader: uploading new admin-sa key"
-          gcloud secrets versions add "$SECRET_NAME" --data-file="$KEY_FILE"
-          echo "bootstrap-uploader: upload complete"
+            echo "bootstrap-uploader: uploading new admin-sa key to $SECRET_NAME"
+            gcloud secrets versions add "$SECRET_NAME" --data-file="$KEY_FILE"
+            echo "bootstrap-uploader: $SECRET_NAME upload complete"
+          done
           exec tail -f /dev/null
         volumeMounts:
         - name: bootstrap

--- a/src/zitadel/components/secrets.ts
+++ b/src/zitadel/components/secrets.ts
@@ -27,6 +27,14 @@ export interface SecretsComponentArgs {
 export class SecretsComponent extends pulumi.ComponentResource {
 	public readonly masterkeySecret: gcp.secretmanager.Secret
 	public readonly adminSaKeySecret: gcp.secretmanager.Secret
+	/**
+	 * New GSM secret following the platform-wide convention
+	 * `zitadel-machine-key-for-<principal>`. During the rename transition
+	 * (openspec change rename-zitadel-machine-keys), `bootstrap-uploader`
+	 * writes the same JSON key payload to both `adminSaKeySecret` and this
+	 * secret. The legacy `adminSaKeySecret` is destroyed in the cleanup PR.
+	 */
+	public readonly pulumiAdminMachineKeySecret: gcp.secretmanager.Secret
 
 	constructor(
 		name: string,
@@ -86,6 +94,22 @@ export class SecretsComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
+		// Transitional second secret shell during the rename from
+		// `zitadel-admin-sa-key` to `zitadel-machine-key-for-pulumi-admin`
+		// (openspec change rename-zitadel-machine-keys). Same lifecycle as
+		// `adminSaKeySecret`: empty shell at creation, populated by the
+		// bootstrap-uploader sidecar (which now dual-writes to both names).
+		// The legacy `adminSaKeySecret` is removed in the cleanup PR.
+		this.pulumiAdminMachineKeySecret = new gcp.secretmanager.Secret(
+			'zitadel-machine-key-for-pulumi-admin',
+			{
+				secretId: 'zitadel-machine-key-for-pulumi-admin',
+				project: project.projectId,
+				replication: { auto: {} },
+			},
+			{ parent: this },
+		)
+
 		// ESO read access on both secrets.
 		new gcp.secretmanager.SecretIamMember(
 			'zitadel-masterkey-eso-accessor',
@@ -109,6 +133,18 @@ export class SecretsComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
+		// Same ESO read binding on the new transitional secret.
+		new gcp.secretmanager.SecretIamMember(
+			'zitadel-machine-key-for-pulumi-admin-eso-accessor',
+			{
+				secretId: this.pulumiAdminMachineKeySecret.secretId,
+				project: project.projectId,
+				role: 'roles/secretmanager.secretAccessor',
+				member: pulumi.interpolate`serviceAccount:${esoServiceAccountEmail}`,
+			},
+			{ parent: this },
+		)
+
 		// Zitadel bootstrap Job write access on admin-sa-key only. The narrower
 		// `secretVersionAdder` role allows adding new versions without exposing
 		// read access to already-stored versions.
@@ -123,9 +159,24 @@ export class SecretsComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
+		// Same Zitadel write binding on the new transitional secret so the
+		// bootstrap-uploader sidecar can dual-write the JWT key payload.
+		new gcp.secretmanager.SecretIamMember(
+			'zitadel-machine-key-for-pulumi-admin-zitadel-writer',
+			{
+				secretId: this.pulumiAdminMachineKeySecret.secretId,
+				project: project.projectId,
+				role: 'roles/secretmanager.secretVersionAdder',
+				member: pulumi.interpolate`serviceAccount:${zitadelServiceAccountEmail}`,
+			},
+			{ parent: this },
+		)
+
 		this.registerOutputs({
 			masterkeySecretId: this.masterkeySecret.secretId,
 			adminSaKeySecretId: this.adminSaKeySecret.secretId,
+			pulumiAdminMachineKeySecretId:
+				this.pulumiAdminMachineKeySecret.secretId,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Step 1 of the **pulumi-admin key rename arc** in openspec change `rename-zitadel-machine-keys`.
- `bootstrap-uploader` sidecar now writes the FIRSTINSTANCE-generated admin machine JSON key to **both** `zitadel-admin-sa-key` (legacy) and `zitadel-machine-key-for-pulumi-admin` (new). The script loops over a `SECRET_NAMES` list and dedup-uploads to each, preserving the idempotency of the original implementation.
- Pulumi provisions a second `SecretManagerSecret` shell + ESO read + Zitadel writer IAM bindings for the new name.

## Migration context

This is the first of three PRs covering the pulumi-admin migration:

- **PR 10 (this PR)**: dual-write to both GSM names.
- **PR 11**: switch the `@pulumiverse/zitadel` provider to read from the new name (`zitadel-machine-key-for-pulumi-admin`). Independent file (`src/zitadel/index.ts`), so won't conflict with this PR.
- **PR 12**: remove the legacy `zitadel-admin-sa-key` GSM resource + IAM bindings + bootstrap-uploader's old name + operator runbook updates.

The pulumi-admin arc is **independent** of the backend-app GSM rename (PRs 1-6) and the Pulumi MachineKey URN rename (PRs 7-8). It can run in parallel with those.

Depends on: none — first step of the pulumi-admin migration.

## Test plan

- [ ] `pulumi preview` against dev shows a `+ create` for `SecretManagerSecret` `zitadel-machine-key-for-pulumi-admin`, plus `+ create` for two `SecretIamMember` resources (`-eso-accessor`, `-zitadel-writer`). **NO** modifications to `zitadel-admin-sa-key` or its IAM bindings.
- [ ] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders the bootstrap-uploader sidecar with the dual-write loop (verified locally).
- [ ] After merge, `pulumi-cloud-deployments` dev apply completes successfully.
- [ ] Trigger a Zitadel API pod restart in dev (or wait for natural rotation). Verify `bootstrap-uploader` logs in `kubectl logs deploy/zitadel-api -c bootstrap-uploader` show successful upload (or "already matches") for BOTH `zitadel-admin-sa-key` AND `zitadel-machine-key-for-pulumi-admin`.
- [ ] Confirm both GSM secrets have the same payload:
  ```
  gcloud secrets versions access latest --secret=zitadel-admin-sa-key --project=liverty-music-dev | sha256sum
  gcloud secrets versions access latest --secret=zitadel-machine-key-for-pulumi-admin --project=liverty-music-dev | sha256sum
  ```
- [ ] No backend impact in this PR — backend reads the admin key only indirectly via Pulumi, and Pulumi still reads from the legacy name until PR 11.

## Why dual-write via a for-loop (not env-var array)

Shell `for-in` over a space-separated variable is the standard idempotent pattern for this. An `EXTRA_SECRET_NAME` env var would have worked too but produced a less symmetric script. The dual-write path is removed in PR 12 (back to a single secret name) so over-engineering the env-var interface isn't justified.
