### PR TITLE
refactor(zitadel): provider auth reads from zitadel-machine-key-for-pulumi-admin (PR 11/12 of rename-zitadel-machine-keys)

### DIFF
--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -31,7 +31,8 @@ export * from './dynamic/index.js'
 export interface ZitadelArgs {
 	env: Environment
 	/** GCP project ID (e.g. `liverty-music-dev`) holding the GSM secret
-	 *  `zitadel-admin-sa-key` populated by the in-cluster bootstrap-uploader. */
+	 *  `zitadel-machine-key-for-pulumi-admin` populated by the in-cluster
+	 *  bootstrap-uploader. */
 	gcpProjectId: pulumi.Input<string>
 	/** Postmark Server API Token — used as both SMTP username and password. */
 	postmarkServerApiToken: string
@@ -83,8 +84,8 @@ export interface ZitadelArgs {
  *   accounts.
  *
  * Pulumi authenticates as `pulumi-admin` (admin org), reads the JWT
- * profile JSON from GSM `zitadel-admin-sa-key`, and provisions
- * everything else from there.
+ * profile JSON from GSM `zitadel-machine-key-for-pulumi-admin`, and
+ * provisions everything else from there.
  *
  * Cutover scope is dev-only. Staging / prod adoption is a separate
  * change; the `env` guard below makes a staging / prod attempt fail
@@ -159,7 +160,7 @@ export class Zitadel {
 			gcp.secretmanager
 				.getSecretVersionOutput({
 					project: gcpProjectId,
-					secret: 'zitadel-admin-sa-key',
+					secret: 'zitadel-machine-key-for-pulumi-admin',
 					version: 'latest',
 				})
 				.apply((v) => v.secretData),


### PR DESCRIPTION
## Summary

Step 2 of the **pulumi-admin key rename arc** in openspec change `rename-zitadel-machine-keys`. Switches the `@pulumiverse/zitadel` provider's `jwtProfileJson` source from `zitadel-admin-sa-key` (legacy) to `zitadel-machine-key-for-pulumi-admin` (new).

Single-file diff in `src/zitadel/index.ts`: the `secret:` field of the `gcp.secretmanager.getSecretVersionOutput` call + 2 doc comments that named the legacy secret. The Pulumi side is the only consumer of this GSM secret, so the switch is functionally complete with this one edit.

## Why this is safe to merge now

The new GSM secret has been prepared during PR 10's rollout:

- **GSM resource shell** created by PR 10 ([#242](https://github.com/liverty-music/cloud-provisioning/pull/242), merged) via the new `pulumiAdminMachineKeySecret` declaration in `secrets.ts`.
- **GSM secret version 1** seeded manually because dev's Zitadel was already bootstrapped (the dual-write `bootstrap-uploader` loop only fires on first-instance bootstrap — see [design.md R7](https://github.com/liverty-music/specification/blob/main/openspec/changes/rename-zitadel-machine-keys/design.md) and the merged [R7 doc PR #447](https://github.com/liverty-music/specification/pull/447)). Value verified byte-identical to legacy `zitadel-admin-sa-key` via `diff -q`.

Result: when this PR's `pulumi preview` runs, `getSecretVersionOutput({secret: 'zitadel-machine-key-for-pulumi-admin'})` resolves to the same JWT-profile JSON as the legacy lookup did. Provider auth is byte-equivalent.

## Migration context

```
PR 10 (merged) ──► [manual seed]  ──► PR 11 (this PR) ──► PR 12 (cleanup)
 dual-write          one-shot           Pulumi reads NEW    destroy legacy
                                        ↑ here
```

Depends on:
- PR 10 deployed in dev ✅ (Pulumi Cloud Deployments dev apply already complete)
- One-shot seed of `zitadel-machine-key-for-pulumi-admin` ✅ (version 1 enabled, 2026-05-13T01:11:11)

Independent of:
- Backend-app key migration (PRs 1–6, 7–8). Those use a different MachineKey + GSM secret.

## Test plan

- [ ] `pulumi preview` against **dev** resolves `getSecretVersionOutput` for the new secret cleanly (no auth error). Diff should be effectively a no-op against current state because the legacy and new secrets hold byte-identical values — the provider config change is internal.
- [ ] `pulumi preview` against **prod** is informational only at this stage (prod stack does not yet have the new secret seeded; staging/prod rollout is a separate change window). **DO NOT MERGE** if prod preview shows it would try to apply this change against an empty GSM secret.
- [ ] After merge, monitor `pulumi-cloud-deployments` dev job. Confirm completion + a follow-up `pulumi up` cycle authenticates via the new secret without error.
- [ ] Soak ≥ 1 successful Pulumi apply cycle in dev before authoring PR 12.

## Why not include legacy-name comment cleanup in `constants.ts` / `src/index.ts`?

Those references are scheduled for PR 12 alongside the legacy GSM resource destroy. Keeping PR 11's diff to a single file (`src/zitadel/index.ts`) keeps the Pulumi preview clean and the auth-switch reviewable in isolation.
