### PR TITLE
feat(backend-k8s): cutover backend to read zitadel-machine-key-for-backend-app (PR 3/11 of rename-zitadel-machine-keys)

### DIFF
--- a/k8s/namespaces/backend/base/consumer/configmap.env
+++ b/k8s/namespaces/backend/base/consumer/configmap.env
@@ -20,8 +20,13 @@ NATS_URL=TO_REPLACE_BY_OVERLAY
 GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
 # OIDC (Zitadel domain for API calls)
 OIDC_ISSUER_URL=TO_REPLACE_BY_OVERLAY
-# Zitadel Machine Key (Email Verification)
+# Zitadel Machine Key (Email Verification).
+# Backend's ResolveZitadelMachineKeyPath() prefers the FOR_BACKEND_APP
+# path and falls back to the legacy one. Both are set during the
+# rename-zitadel-machine-keys migration; the legacy var is removed in
+# PR 4 and the legacy Go field in PR 5.
 ZITADEL_MACHINE_KEY_PATH=/secrets/zitadel/zitadel-machine-key.json
+ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json
 # Push Notifications (VAPID)
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY
 VAPID_CONTACT=mailto:pepperoni9@gmail.com

--- a/k8s/namespaces/backend/base/consumer/deployment.yaml
+++ b/k8s/namespaces/backend/base/consumer/deployment.yaml
@@ -16,6 +16,10 @@ spec:
           items:
           - key: zitadel-machine-key.json
             path: zitadel-machine-key.json
+          # Transitional second item during the rename-zitadel-machine-keys
+          # migration. Removed in PR 4 alongside the legacy entry above.
+          - key: zitadel-machine-key-for-backend-app.json
+            path: zitadel-machine-key-for-backend-app.json
       containers:
       - name: consumer
         image: consumer

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -37,8 +37,13 @@ TICKET_SBT_ADDRESS=TO_REPLACE_BY_OVERLAY
 # ZKP (Entry Verification)
 ZKP_VERIFICATION_KEY_PATH=/configs/zkp/zkp-verification-key.json
 
-# Zitadel Machine Key (Email Verification)
+# Zitadel Machine Key (Email Verification).
+# Backend's ResolveZitadelMachineKeyPath() prefers the FOR_BACKEND_APP
+# path and falls back to the legacy one. Both are set during the
+# rename-zitadel-machine-keys migration; the legacy var is removed in
+# PR 4 and the legacy Go field in PR 5.
 ZITADEL_MACHINE_KEY_PATH=/secrets/zitadel/zitadel-machine-key.json
+ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json
 
 # NATS
 NATS_URL=TO_REPLACE_BY_OVERLAY

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -25,6 +25,10 @@ spec:
           items:
           - key: zitadel-machine-key.json
             path: zitadel-machine-key.json
+          # Transitional second item during the rename-zitadel-machine-keys
+          # migration. Removed in PR 4 alongside the legacy entry above.
+          - key: zitadel-machine-key-for-backend-app.json
+            path: zitadel-machine-key-for-backend-app.json
       containers:
       - name: server
         image: server

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -32,3 +32,8 @@ spec:
   - secretKey: zitadel-machine-key.json
     remoteRef:
       key: zitadel-machine-key
+  # Transitional dual-mount during the rename-zitadel-machine-keys
+  # migration. Removed (along with the legacy entry above) in PR 4.
+  - secretKey: zitadel-machine-key-for-backend-app.json
+    remoteRef:
+      key: zitadel-machine-key-for-backend-app


### PR DESCRIPTION
## Summary

Step 3 of the **backend-app key rename arc** in openspec change `rename-zitadel-machine-keys`. Cuts the backend deployment over to read the new GSM-mirrored key file at the new env var path, while keeping the legacy entries set so a rollback is a single revert.

## Changes (server + consumer)

| Layer | What changes |
|---|---|
| `ExternalSecret` `server-backend-secrets` | Add `data[]` entry mapping `secretKey: zitadel-machine-key-for-backend-app.json` to `remoteRef.key: zitadel-machine-key-for-backend-app`. The shared K8s Secret `backend-secrets` (used by both `server` and `consumer` pods) gains a second key. |
| `server/deployment.yaml` + `consumer/deployment.yaml` | Add a second `secret.items[]` entry to the existing `zitadel-machine-key` volume. Mount point unchanged (`/secrets/zitadel/`). Result: pods see **both** `/secrets/zitadel/zitadel-machine-key.json` (legacy) **and** `/secrets/zitadel/zitadel-machine-key-for-backend-app.json` (new). |
| `server/configmap.env` + `consumer/configmap.env` | Add `ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json`. Keep `ZITADEL_MACHINE_KEY_PATH` set. |

After ArgoCD syncs + Reloader-driven pod restart, [backend's `ResolveZitadelMachineKeyPath()`](https://github.com/liverty-music/backend/blob/main/pkg/config/config.go) returns the **new** path (it prefers `ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH` when set), so the email-verification path now reads from the new GSM-mirrored file.

## Why the volume name stays `zitadel-machine-key`

The volume name is a pod-internal label only — Reloader watches the K8s Secret name, not the volume name. Renaming would make the diff noisier without functional benefit. PR 4 (or a future cleanup) can rename if desired; for now, the volume's items[] list tells the full story.

## Migration context

```
PR 1 (merged) ──► PR 2 (merged) ──► PR 3 (this) ──► PR 4 ─► PR 5 ─► PR 6
 add new GSM      Go accepts new   k8s cutover     drop    drop    destroy
                  env w/ fallback                  old     Go      old GSM
                                                   env     field   resource
```

Depends on:
- PR 1 ([cp#240](https://github.com/liverty-music/cloud-provisioning/pull/240), merged) — new GSM secret exists and is populated.
- PR 2 ([be#293](https://github.com/liverty-music/backend/pull/293), merged) — backend Config has `ZitadelMachineKeyForBackendAppPath` field + `ResolveZitadelMachineKeyPath()` method.

PR 4 (next step, ≥24h after this PR's dev rollout) drops the legacy `data[]` entry, legacy `items[]` entry, and legacy `ZITADEL_MACHINE_KEY_PATH` from configmaps. After that, backend reads new-only.

## Test plan

- [ ] `kubectl kustomize k8s/namespaces/backend/overlays/dev` renders both env vars and both file mounts (verified locally).
- [ ] `make lint-ts` — no TypeScript changes; trivially green.
- [ ] After merge + ArgoCD sync + Reloader-driven pod restart:
  - [ ] `kubectl exec deploy/server-app -n backend -- ls /secrets/zitadel/` shows both files.
  - [ ] `kubectl exec deploy/server-app -n backend -- env | grep ZITADEL_MACHINE_KEY` shows both env vars.
  - [ ] Backend → Zitadel API smoke test (e.g., `ResendEmailVerification` against a dev test user) succeeds; logs should now show the new path being read (via `ResolveZitadelMachineKeyPath()`'s preference).
- [ ] Soak ≥24h before authoring PR 4.

## Rollback

Single revert of this commit. Backend's `ResolveZitadelMachineKeyPath()` falls back to the legacy env var automatically.
