### PR TITLE
feat(backend-k8s): drop legacy zitadel-machine-key entries from backend (PR 4/11 of rename-zitadel-machine-keys)

### DIFF
--- a/k8s/namespaces/backend/base/consumer/configmap.env
+++ b/k8s/namespaces/backend/base/consumer/configmap.env
@@ -20,12 +20,7 @@ NATS_URL=TO_REPLACE_BY_OVERLAY
 GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
 # OIDC (Zitadel domain for API calls)
 OIDC_ISSUER_URL=TO_REPLACE_BY_OVERLAY
-# Zitadel Machine Key (Email Verification).
-# Backend's ResolveZitadelMachineKeyPath() prefers the FOR_BACKEND_APP
-# path and falls back to the legacy one. Both are set during the
-# rename-zitadel-machine-keys migration; the legacy var is removed in
-# PR 4 and the legacy Go field in PR 5.
-ZITADEL_MACHINE_KEY_PATH=/secrets/zitadel/zitadel-machine-key.json
+# Zitadel Machine Key (Email Verification)
 ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json
 # Push Notifications (VAPID)
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY

--- a/k8s/namespaces/backend/base/consumer/deployment.yaml
+++ b/k8s/namespaces/backend/base/consumer/deployment.yaml
@@ -14,10 +14,6 @@ spec:
         secret:
           secretName: backend-secrets
           items:
-          - key: zitadel-machine-key.json
-            path: zitadel-machine-key.json
-          # Transitional second item during the rename-zitadel-machine-keys
-          # migration. Removed in PR 4 alongside the legacy entry above.
           - key: zitadel-machine-key-for-backend-app.json
             path: zitadel-machine-key-for-backend-app.json
       containers:

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -37,12 +37,7 @@ TICKET_SBT_ADDRESS=TO_REPLACE_BY_OVERLAY
 # ZKP (Entry Verification)
 ZKP_VERIFICATION_KEY_PATH=/configs/zkp/zkp-verification-key.json
 
-# Zitadel Machine Key (Email Verification).
-# Backend's ResolveZitadelMachineKeyPath() prefers the FOR_BACKEND_APP
-# path and falls back to the legacy one. Both are set during the
-# rename-zitadel-machine-keys migration; the legacy var is removed in
-# PR 4 and the legacy Go field in PR 5.
-ZITADEL_MACHINE_KEY_PATH=/secrets/zitadel/zitadel-machine-key.json
+# Zitadel Machine Key (Email Verification)
 ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json
 
 # NATS

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -23,10 +23,6 @@ spec:
         secret:
           secretName: backend-secrets
           items:
-          - key: zitadel-machine-key.json
-            path: zitadel-machine-key.json
-          # Transitional second item during the rename-zitadel-machine-keys
-          # migration. Removed in PR 4 alongside the legacy entry above.
           - key: zitadel-machine-key-for-backend-app.json
             path: zitadel-machine-key-for-backend-app.json
       containers:

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -29,11 +29,6 @@ spec:
   - secretKey: FANARTTV_API_KEY
     remoteRef:
       key: fanarttv-api-key
-  - secretKey: zitadel-machine-key.json
-    remoteRef:
-      key: zitadel-machine-key
-  # Transitional dual-mount during the rename-zitadel-machine-keys
-  # migration. Removed (along with the legacy entry above) in PR 4.
   - secretKey: zitadel-machine-key-for-backend-app.json
     remoteRef:
       key: zitadel-machine-key-for-backend-app


### PR DESCRIPTION
## Summary

Step 4 of the **backend-app key rename arc** in openspec change `rename-zitadel-machine-keys`. After PR 3 ([cp#244](https://github.com/liverty-music/cloud-provisioning/pull/244)) cut backend over to read the new env var path, the legacy ExternalSecret data, secret items, and configmap env var are no longer consumed by any pod. This PR cleans those entries up.

## Changes (server + consumer)

| Layer | What changes |
|---|---|
| `ExternalSecret` `server-backend-secrets` | Drop `data[]` entry that mirrored GSM `zitadel-machine-key` into K8s Secret. |
| `server/deployment.yaml` + `consumer/deployment.yaml` | Drop legacy `secret.items[]` entry. Pod no longer mounts `/secrets/zitadel/zitadel-machine-key.json`. Volume name `zitadel-machine-key` is left as-is (pod-internal label, no functional effect). |
| `server/configmap.env` + `consumer/configmap.env` | Drop `ZITADEL_MACHINE_KEY_PATH` env var. Only `ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH` remains. |

Backend's `ResolveZitadelMachineKeyPath()` already returns the new path (verified post-PR 3 dev rollout — both env vars present, new path preferred). After this PR rolls out and Reloader restarts the pod, `ZITADEL_MACHINE_KEY_PATH` is empty, so the fallback path is exercised in the "neither set" branch only when the new var is also empty (i.e., never in dev).

## What is NOT in this PR

The underlying GSM `SecretManagerSecret` resource for `zitadel-machine-key` is **not** destroyed here. That's PR 6 ([cp src/gcp/index.ts](https://github.com/liverty-music/cloud-provisioning/blob/main/src/gcp/index.ts) entry removal). Splitting the consumer cleanup (this PR) from the resource destroy (PR 6) keeps rollback granularity:

- **Rollback of this PR**: re-introduces the K8s consumer entries; Pulumi state untouched; GSM secret still alive and being reconciled. Backend reads legacy again via the fallback method.
- **PR 6 rollback** (after destroy): would require recreating the GSM resource — much heavier.

The legacy GSM secret stays alive between PR 4 and PR 6 deploys but is no longer consumed by any pod.

## Migration context

```
PR 1 (merged) → PR 2 (merged) → PR 3 (merged) → PR 4 (this) → PR 5 → PR 6
add new GSM    Go fallback     k8s cutover     drop legacy   drop  destroy
                                                k8s entries  Go    GSM
                                                             field resource
```

Depends on:
- PR 3 ([cp#244](https://github.com/liverty-music/cloud-provisioning/pull/244), merged) — backend reads new path; verified post-rollout (both env vars + both mounted files, server + consumer pods started cleanly).

## Test plan

- [ ] `kubectl kustomize k8s/namespaces/backend/overlays/dev` renders only the new path/env var (verified locally).
- [ ] After merge + ArgoCD sync + Reloader pod restart:
  - [ ] K8s Secret `backend-secrets` has `zitadel-machine-key-for-backend-app.json` only (no `zitadel-machine-key.json` key).
  - [ ] Pod env shows `ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH` only.
  - [ ] Backend → Zitadel API smoke test (e.g., trigger `ResendEmailVerification`) succeeds.
- [ ] Confirm GSM secret `zitadel-machine-key` still exists (orphaned but alive) — verifies the split from PR 6 is working.

## Rollback

Single revert. The legacy `data[]` / `items[]` / env var come back; backend's `ResolveZitadelMachineKeyPath()` once again prefers new but falls back to legacy if new becomes unavailable.
