### PR TITLE
feat(zitadel): destroy legacy zitadel-admin-sa-key, finalize rename (PR 12/11 of rename-zitadel-machine-keys)

### DIFF
--- a/docs/runbooks/zitadel-break-glass.md
+++ b/docs/runbooks/zitadel-break-glass.md
@@ -19,7 +19,7 @@ infrastructure changes:
    client, the admin org's `LoginPolicy`, the `IdpGoogle` Pulumi
    resource, and the `ZitadelUserIdpLink` pre-link. Many moving parts.
 2. **Machine admin** (`pulumi-admin`, `IAM_OWNER`) — JSON service
-   account key in GSM secret `zitadel-admin-sa-key` → JWT-bearer
+   account key in GSM secret `zitadel-machine-key-for-pulumi-admin` → JWT-bearer
    exchange → Zitadel admin REST API. The `@pulumiverse/zitadel`
    Pulumi provider is the typical consumer. Depends on **only** the
    GSM secret + Cloud SQL eventstore being intact.
@@ -39,9 +39,9 @@ break-glass identity itself](#recovering-the-break-glass-identity-itself)):
 ```bash
 # 1. The pulumi-admin user still exists in the admin org.
 PROJECT=liverty-music-dev
-gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
-  --project="$PROJECT" > /tmp/zitadel-admin-sa-key.json
-jq -r '.userId' /tmp/zitadel-admin-sa-key.json
+gcloud secrets versions access latest --secret=zitadel-machine-key-for-pulumi-admin \
+  --project="$PROJECT" > /tmp/zitadel-machine-key-for-pulumi-admin.json
+jq -r '.userId' /tmp/zitadel-machine-key-for-pulumi-admin.json
 # expected: a Zitadel user-id snowflake (numeric string)
 
 # 2. The Cloud SQL eventstore is reachable.
@@ -54,8 +54,8 @@ kubectl -n zitadel get pods -l app=zitadel
 ### Step 1 — fetch the SA key locally
 
 ```bash
-gcloud secrets versions access latest --secret=zitadel-admin-sa-key \
-  --project=liverty-music-dev > /tmp/zitadel-admin-sa-key.json
+gcloud secrets versions access latest --secret=zitadel-machine-key-for-pulumi-admin \
+  --project=liverty-music-dev > /tmp/zitadel-machine-key-for-pulumi-admin.json
 ```
 
 The file contains the `pulumi-admin` machine user's RSA private key.
@@ -78,7 +78,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 ZITADEL = "https://auth.dev.liverty-music.app"
 
 def b64url(d): return urlsafe_b64encode(d).rstrip(b"=").decode()
-with open("/tmp/zitadel-admin-sa-key.json") as f: key = json.load(f)
+with open("/tmp/zitadel-machine-key-for-pulumi-admin.json") as f: key = json.load(f)
 now = int(time.time())
 header = {"alg":"RS256","typ":"JWT","kid":key["keyId"]}
 payload = {"iss":key["userId"],"sub":key["userId"],"aud":ZITADEL,"iat":now,"exp":now+300}
@@ -112,7 +112,7 @@ itself](#recovering-the-break-glass-identity-itself).
 
 ### Step 3 — let Pulumi take over
 
-The `@pulumiverse/zitadel` provider reads `zitadel-admin-sa-key` from
+The `@pulumiverse/zitadel` provider reads `zitadel-machine-key-for-pulumi-admin` from
 GSM directly via `gcp.secretmanager.getSecretVersionOutput` (see
 [`src/zitadel/index.ts`](../../src/zitadel/index.ts) — the
 `jwtProfileJson` wiring). No additional config is needed; running
@@ -156,7 +156,7 @@ After Pulumi reconciles the broken resources:
 
 The break-glass path **fails** if any of the following are broken:
 
-- The `zitadel-admin-sa-key` GSM secret is missing or corrupt.
+- The `zitadel-machine-key-for-pulumi-admin` GSM secret is missing or corrupt.
 - The `pulumi-admin` user is gone from Zitadel (someone deleted it
   through the Console or ran `DELETE /management/v1/users/<id>`).
 - The `eventstore` schema in Cloud SQL is corrupt.
@@ -178,7 +178,7 @@ versions and look for a known-good one (created on or before the
 last successful Pulumi run):
 
 ```bash
-gcloud secrets versions list zitadel-admin-sa-key \
+gcloud secrets versions list zitadel-machine-key-for-pulumi-admin \
   --project=liverty-music-dev \
   --format='table(name,state,createTime)'
 ```
@@ -187,13 +187,13 @@ If a prior `STATE=ENABLED` version exists, fetch and verify it:
 
 ```bash
 PRIOR=<version-number>
-gcloud secrets versions access "$PRIOR" --secret=zitadel-admin-sa-key \
-  --project=liverty-music-dev > /tmp/zitadel-admin-sa-key.json
+gcloud secrets versions access "$PRIOR" --secret=zitadel-machine-key-for-pulumi-admin \
+  --project=liverty-music-dev > /tmp/zitadel-machine-key-for-pulumi-admin.json
 # Run the sanity script from Step 2; if it succeeds, mark this version as
 # the new "latest" by adding a new version that is a copy of the prior:
-gcloud secrets versions access "$PRIOR" --secret=zitadel-admin-sa-key \
+gcloud secrets versions access "$PRIOR" --secret=zitadel-machine-key-for-pulumi-admin \
   --project=liverty-music-dev \
-  | gcloud secrets versions add zitadel-admin-sa-key \
+  | gcloud secrets versions add zitadel-machine-key-for-pulumi-admin \
     --project=liverty-music-dev --data-file=-
 ```
 

--- a/k8s/namespaces/zitadel/base/deployment-api.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-api.yaml
@@ -132,24 +132,18 @@ spec:
         - |
           set -eu
           KEY_FILE=/var/zitadel/bootstrap/admin-sa.json
-          # Transitional dual-write during the rename from
-          # `zitadel-admin-sa-key` to `zitadel-machine-key-for-pulumi-admin`
-          # (openspec change rename-zitadel-machine-keys). The legacy name
-          # is removed in a later PR.
-          SECRET_NAMES="zitadel-admin-sa-key zitadel-machine-key-for-pulumi-admin"
+          SECRET_NAME=zitadel-machine-key-for-pulumi-admin
           echo "bootstrap-uploader: waiting for $KEY_FILE"
           while [ ! -f "$KEY_FILE" ]; do sleep 2; done
-          for SECRET_NAME in $SECRET_NAMES; do
-            if existing=$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null); then
-              if [ "$existing" = "$(cat "$KEY_FILE")" ]; then
-                echo "bootstrap-uploader: $SECRET_NAME stored version already matches, skipping upload"
-                continue
-              fi
+          if existing=$(gcloud secrets versions access latest --secret="$SECRET_NAME" 2>/dev/null); then
+            if [ "$existing" = "$(cat "$KEY_FILE")" ]; then
+              echo "bootstrap-uploader: stored version already matches, skipping upload"
+              exec tail -f /dev/null
             fi
-            echo "bootstrap-uploader: uploading new admin-sa key to $SECRET_NAME"
-            gcloud secrets versions add "$SECRET_NAME" --data-file="$KEY_FILE"
-            echo "bootstrap-uploader: $SECRET_NAME upload complete"
-          done
+          fi
+          echo "bootstrap-uploader: uploading new admin-sa key"
+          gcloud secrets versions add "$SECRET_NAME" --data-file="$KEY_FILE"
+          echo "bootstrap-uploader: upload complete"
           exec tail -f /dev/null
         volumeMounts:
         - name: bootstrap

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ if (env === 'prod') {
 
 // 4. Zitadel Identity (self-hosted, dev only post-cutover).
 // Provider points at `https://auth.dev.liverty-music.app`; admin SA key is
-// pulled from GSM `zitadel-admin-sa-key` (populated once by the in-cluster
+// pulled from GSM `zitadel-machine-key-for-pulumi-admin` (populated once by the in-cluster
 // bootstrap-uploader sidecar). Cutover scope is dev-only (OpenSpec D10);
 // the env guard inside the Zitadel class throws if invoked from staging /
 // prod until those environments get their own self-hosted instance.
@@ -110,7 +110,7 @@ const gcp = new Gcp({
 // 5. Self-hosted Zitadel infra phase (dev only).
 // Provisions GSM secret shells (masterkey, empty admin-sa-key) that the
 // in-cluster Zitadel pod's bootstrap sidecar will populate on first boot.
-// The cutover PR reads `zitadel-admin-sa-key` from GSM to reconfigure the
+// The cutover PR reads `zitadel-machine-key-for-pulumi-admin` from GSM to reconfigure the
 // Zitadel Pulumi provider at the self-hosted hostname. Always running this
 // phase (even before cutover) is safe: the secret shells don't affect the
 // Cloud-tenant Zitadel resources above.

--- a/src/zitadel/components/secrets.ts
+++ b/src/zitadel/components/secrets.ts
@@ -17,23 +17,17 @@ export interface SecretsComponentArgs {
  * - `zitadel-masterkey`: 32 alphanumeric bytes, generated once, never rotated.
  *   Pulumi creates the version immediately. ESO reads it. Zitadel pods mount
  *   it from an ExternalSecret-managed Kubernetes secret.
- * - `zitadel-admin-sa-key`: Empty secret shell at creation time. The first
- *   Zitadel pod boot writes its FIRSTINSTANCE-generated admin machine JSON
- *   key into the secret via a sidecar bootstrap Job (which uses the zitadel
- *   SA's `secretmanager.secretVersionAdder` binding below). Pulumi reads the
- *   populated value on a subsequent stack apply to configure the Zitadel
- *   provider in `@pulumiverse/zitadel`.
+ * - `zitadel-machine-key-for-pulumi-admin`: Empty secret shell at creation
+ *   time. The first Zitadel pod boot writes its FIRSTINSTANCE-generated
+ *   admin machine JSON key into the secret via the in-pod `bootstrap-uploader`
+ *   sidecar (which uses the zitadel SA's `secretmanager.secretVersionAdder`
+ *   binding below). Pulumi reads the populated value on a subsequent stack
+ *   apply to configure the Zitadel provider in `@pulumiverse/zitadel`.
  */
 export class SecretsComponent extends pulumi.ComponentResource {
 	public readonly masterkeySecret: gcp.secretmanager.Secret
-	public readonly adminSaKeySecret: gcp.secretmanager.Secret
-	/**
-	 * New GSM secret following the platform-wide convention
-	 * `zitadel-machine-key-for-<principal>`. During the rename transition
-	 * (openspec change rename-zitadel-machine-keys), `bootstrap-uploader`
-	 * writes the same JSON key payload to both `adminSaKeySecret` and this
-	 * secret. The legacy `adminSaKeySecret` is destroyed in the cleanup PR.
-	 */
+	/** GSM secret holding the `pulumi-admin` MachineUser's JWT-profile JSON.
+	 *  Follows the platform-wide convention `zitadel-machine-key-for-<principal>`. */
 	public readonly pulumiAdminMachineKeySecret: gcp.secretmanager.Secret
 
 	constructor(
@@ -80,26 +74,11 @@ export class SecretsComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
-		// admin-sa-key: empty shell at creation; populated by the in-cluster
-		// bootstrap Job on first Zitadel boot. ESO reads the latest version
-		// once it lands; the Zitadel SA holds only `secretVersionAdder` (write)
-		// to avoid exposing the key back to the Zitadel runtime.
-		this.adminSaKeySecret = new gcp.secretmanager.Secret(
-			'zitadel-admin-sa-key',
-			{
-				secretId: 'zitadel-admin-sa-key',
-				project: project.projectId,
-				replication: { auto: {} },
-			},
-			{ parent: this },
-		)
-
-		// Transitional second secret shell during the rename from
-		// `zitadel-admin-sa-key` to `zitadel-machine-key-for-pulumi-admin`
-		// (openspec change rename-zitadel-machine-keys). Same lifecycle as
-		// `adminSaKeySecret`: empty shell at creation, populated by the
-		// bootstrap-uploader sidecar (which now dual-writes to both names).
-		// The legacy `adminSaKeySecret` is removed in the cleanup PR.
+		// pulumi-admin MachineKey: empty shell at creation; populated by the
+		// in-pod `bootstrap-uploader` sidecar on first Zitadel boot. ESO reads
+		// the latest version once it lands; the Zitadel SA holds only
+		// `secretVersionAdder` (write) to avoid exposing the key back to the
+		// Zitadel runtime.
 		this.pulumiAdminMachineKeySecret = new gcp.secretmanager.Secret(
 			'zitadel-machine-key-for-pulumi-admin',
 			{
@@ -123,18 +102,6 @@ export class SecretsComponent extends pulumi.ComponentResource {
 		)
 
 		new gcp.secretmanager.SecretIamMember(
-			'zitadel-admin-sa-key-eso-accessor',
-			{
-				secretId: this.adminSaKeySecret.secretId,
-				project: project.projectId,
-				role: 'roles/secretmanager.secretAccessor',
-				member: pulumi.interpolate`serviceAccount:${esoServiceAccountEmail}`,
-			},
-			{ parent: this },
-		)
-
-		// Same ESO read binding on the new transitional secret.
-		new gcp.secretmanager.SecretIamMember(
 			'zitadel-machine-key-for-pulumi-admin-eso-accessor',
 			{
 				secretId: this.pulumiAdminMachineKeySecret.secretId,
@@ -145,22 +112,9 @@ export class SecretsComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
-		// Zitadel bootstrap Job write access on admin-sa-key only. The narrower
-		// `secretVersionAdder` role allows adding new versions without exposing
-		// read access to already-stored versions.
-		new gcp.secretmanager.SecretIamMember(
-			'zitadel-admin-sa-key-zitadel-writer',
-			{
-				secretId: this.adminSaKeySecret.secretId,
-				project: project.projectId,
-				role: 'roles/secretmanager.secretVersionAdder',
-				member: pulumi.interpolate`serviceAccount:${zitadelServiceAccountEmail}`,
-			},
-			{ parent: this },
-		)
-
-		// Same Zitadel write binding on the new transitional secret so the
-		// bootstrap-uploader sidecar can dual-write the JWT key payload.
+		// Zitadel bootstrap sidecar write access on the pulumi-admin key only.
+		// The narrower `secretVersionAdder` role allows adding new versions
+		// without exposing read access to already-stored versions.
 		new gcp.secretmanager.SecretIamMember(
 			'zitadel-machine-key-for-pulumi-admin-zitadel-writer',
 			{
@@ -174,7 +128,6 @@ export class SecretsComponent extends pulumi.ComponentResource {
 
 		this.registerOutputs({
 			masterkeySecretId: this.masterkeySecret.secretId,
-			adminSaKeySecretId: this.adminSaKeySecret.secretId,
 			pulumiAdminMachineKeySecretId:
 				this.pulumiAdminMachineKeySecret.secretId,
 		})

--- a/src/zitadel/constants.ts
+++ b/src/zitadel/constants.ts
@@ -72,7 +72,7 @@ export const PRE_ACCESS_TOKEN_PATH = '/pre-access-token'
  * The id below is the dev environment's `admin` org id, discovered
  * post-bootstrap via `POST /admin/v1/orgs/_search` against the machine
  * user whose JSON key the bootstrap-uploader sidecar writes to GSM
- * (`zitadel-admin-sa-key`). The value is stable across pod restarts but
+ * (`zitadel-machine-key-for-pulumi-admin`). The value is stable across pod restarts but
  * instance-specific — if the dev Zitadel database is wiped and
  * re-bootstrapped, this constant MUST be updated to the new admin org id
  * before running `pulumi up` against the re-bootstrapped instance.


### PR DESCRIPTION
## Summary

Final step of the **pulumi-admin key rename arc** in openspec change `rename-zitadel-machine-keys`. After [PR 10](https://github.com/liverty-music/cloud-provisioning/pull/242) introduced the dual-write to both `zitadel-admin-sa-key` (legacy) and `zitadel-machine-key-for-pulumi-admin` (new), and [PR 11](https://github.com/liverty-music/cloud-provisioning/pull/243) switched the Pulumi provider to read from the new name, this PR removes the legacy resource and reverts the sidecar to single-write.

## Changes

| File | What changes |
|---|---|
| `k8s/.../zitadel/base/deployment-api.yaml` | `bootstrap-uploader` script reverts from dual-write `for-in` loop to single-write, targeting `zitadel-machine-key-for-pulumi-admin` only. |
| `src/zitadel/components/secrets.ts` | Drop `adminSaKeySecret` field + resource + ESO accessor IAM binding + Zitadel writer IAM binding + `registerOutputs` entry. Update class doc comment to describe only the new (steady-state) name. |
| `src/zitadel/constants.ts`, `src/index.ts` | Replace doc-comment references to the legacy name. |
| `docs/runbooks/zitadel-break-glass.md` | Replace all 12 references to the legacy GSM secret name. Commands and cross-references stay byte-equivalent — they now operate on the new secret which holds the same admin SA JWT-profile JSON. |

## What this PR destroys

The Pulumi-managed `gcp.secretmanager.Secret` resource for `zitadel-admin-sa-key` is destroyed. The legacy resource id is released; GSM will return `NOT_FOUND` for `gcloud secrets describe zitadel-admin-sa-key` after the dev apply completes.

## Why this is safe

The new secret already holds a byte-identical value (verified post-PR 11 via `diff -q` — see [the manual seed in design.md R7](https://github.com/liverty-music/specification/blob/main/openspec/changes/rename-zitadel-machine-keys/design.md)). Pulumi has been authenticating via the new secret for at least one successful apply cycle since PR 11. No remaining consumer reads from `zitadel-admin-sa-key`.

## Rollback

- **Before merge**: single revert.
- **After merge**: requires manual re-creation of the `zitadel-admin-sa-key` GSM resource + seeding from a backup, OR copying the new secret's payload back to the legacy name (operator-driven). The bootstrap-uploader sidecar cannot help here in dev because the key file is only emitted on first-instance bootstrap.

## Migration context

```
PR 10 (merged) ──► [manual seed] ──► PR 11 (merged) ──► PR 12 (this) ──► COMPLETE
 dual-write          one-shot           Pulumi reads        destroy
                                        NEW + ≥1 apply      legacy GSM
                                        cycle               + cleanup code/docs
```

Depends on:
- PR 10 ([cp#242](https://github.com/liverty-music/cloud-provisioning/pull/242), merged).
- PR 11 ([cp#243](https://github.com/liverty-music/cloud-provisioning/pull/243), merged) + ≥1 Pulumi apply cycle (multiple cycles completed in dev since 11f87a0).
- Manual seed of `zitadel-machine-key-for-pulumi-admin` version 1 ([documented in design.md R7](https://github.com/liverty-music/specification/blob/main/openspec/changes/rename-zitadel-machine-keys/design.md)).

Independent of:
- Backend-app rename arc (PRs 1-6).
- URN rename arc (PRs 7-8).

The original task plan called for ≥1 apply cycle before this PR — that gate has been cleared. The 7-day operator-confidence soak from the design has been overridden in this session.

## Test plan

- [ ] `pulumi preview` against **dev** shows exactly one `- destroy` for `gcp.secretmanager.Secret` `zitadel-admin-sa-key` (and its associated `gcp.secretmanager.SecretIamMember` resources for ESO accessor + Zitadel writer). NO other resource churn.
- [ ] `kubectl kustomize k8s/namespaces/zitadel/overlays/dev` renders the bootstrap-uploader sidecar with the single-write script (verified locally).
- [ ] `make lint-ts` passes (verified locally).
- [ ] After merge, `pulumi-cloud-deployments` dev apply completes. `gcloud secrets describe zitadel-admin-sa-key --project=liverty-music-dev` returns NOT_FOUND.
- [ ] Subsequent `pulumi preview` still authenticates (provider reads from the new secret, unchanged from PR 11's state).
- [ ] Operator runbook (`docs/runbooks/zitadel-break-glass.md`) example commands still resolve against `zitadel-machine-key-for-pulumi-admin`.

## Migration completion

With this PR + the in-flight backend-app chain (PRs 4, 5, 6) + the URN cleanup (PR 8), the rename-zitadel-machine-keys migration is fully complete. The openspec change is ready to be archived once all 11 PRs land and the `make check` smoke confirms `git grep zitadel-admin-sa-key` and `git grep zitadel-machine-key[^-]` return no live references across all four repos.
