### PR TITLE
feat(secret): destroy legacy GSM secret zitadel-machine-key (PR 6/11 of rename-zitadel-machine-keys)

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -241,14 +241,6 @@ export class Gcp {
 				...(zitadelMachineKey
 					? [
 							{
-								name: 'zitadel-machine-key',
-								value: pulumi.secret(zitadelMachineKey),
-							},
-							// Transitional dual-write: backend reads from the new
-							// name with fallback to the old. PR 4 of openspec change
-							// `rename-zitadel-machine-keys` removes the old entry;
-							// PR 6 destroys the underlying GSM resource.
-							{
 								name: 'zitadel-machine-key-for-backend-app',
 								value: pulumi.secret(zitadelMachineKey),
 							},
@@ -270,7 +262,7 @@ export class Gcp {
 				// the `zitadel` namespace mirrors this into a K8s Secret which the
 				// pod mounts as a file referenced by ZITADEL_SERVICE_USER_TOKEN_FILE.
 				// Backend-app does not need access — the backend talks to Zitadel
-				// via its own JWT-key (zitadel-machine-key), not this PAT.
+				// via its own JWT-key (zitadel-machine-key-for-backend-app), not this PAT.
 				...(zitadelLoginPat
 					? [
 							{


### PR DESCRIPTION
## Summary

Step 6 (final destroy) of the **backend-app key rename arc** in openspec change `rename-zitadel-machine-keys`. [PR 4 (cp#245)](https://github.com/liverty-music/cloud-provisioning/pull/245) removed all in-cluster consumers of `zitadel-machine-key`. [PR 5 (be#295)](https://github.com/liverty-music/backend/pull/295) removed the legacy Go field that referenced it. The GSM resource itself is now fully orphaned.

This PR removes the corresponding entry from the `secrets:` array in `src/gcp/index.ts`, which causes Pulumi to destroy the legacy `gcp:secretmanager:Secret zitadel-machine-key` resource and its associated `SecretVersion`. `zitadel-machine-key-for-backend-app` remains as the sole entry holding the same value.

Also updates one trailing comment reference in `src/gcp/index.ts` (`// via its own JWT-key (zitadel-machine-key) ...` → new name).

## Test plan

- [ ] `pulumi preview` against **dev** shows exactly one `- destroy` for `gcp:secretmanager:Secret zitadel-machine-key` and its associated resources (SecretVersion + IAM bindings). NO other resource churn — `zitadel-machine-key-for-backend-app` is untouched.
- [ ] After merge, `pulumi-cloud-deployments` dev apply completes. `gcloud secrets describe zitadel-machine-key --project=liverty-music-dev` returns NOT_FOUND.
- [ ] `gcloud secrets describe zitadel-machine-key-for-backend-app --project=liverty-music-dev` still returns the resource (untouched).
- [ ] Backend → Zitadel API smoke test still works.

## Rollback

- **Before merge**: single revert.
- **After merge**: requires re-creating the GSM resource. Operator can pull the byte-identical value from `zitadel-machine-key-for-backend-app` and seed a fresh `zitadel-machine-key` secret if needed — but this is unlikely; the only post-merge regression scenario would be a runaway revert of PR 1-5, which would also need the rest of the migration undone.

## Migration context

```
PR 1 (merged) → PR 2 (merged) → PR 3 (merged) → PR 4 (merged) → PR 5 → PR 6 (this) → COMPLETE
add new GSM    Go fallback     k8s cutover      drop legacy     drop  destroy
                                                k8s entries     Go    GSM
```

Depends on:
- [PR 4 (cp#245, merged)](https://github.com/liverty-music/cloud-provisioning/pull/245).
- [PR 5 (be#295)](https://github.com/liverty-music/backend/pull/295) — should be merged + deployed before this PR's apply runs (otherwise pods would briefly try the legacy field which no longer exists in Go).

PR 6 deploy ordering: ensure PR 5 has rolled out in dev (ArgoCD synced, pods restarted, env-var read pattern simplified) **before** the Pulumi apply for this PR. Practically, the order is "merge PR 5 → wait for ArgoCD → merge this PR → wait for Pulumi". Both deployments are fast (~few minutes each).
