### PR TITLE
fix(infra): drop monitoringConfig on prod Autopilot cluster (hotfix for migrate-prod-to-autopilot)

### DIFF
--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -406,13 +406,24 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 			// unavoidable GMP managed collection.
 			//
 			// GMP cost control on Autopilot ≥ 1.25 (managed collection cannot
-			// be disabled per GCP docs) is enforced here by setting
-			// `monitoringConfig.managedPrometheus.autoMonitoringConfig.scope =
-			// 'NONE'`. That flag turns off GKE's auto-discovery of application
-			// Pods, leaving only the unavoidable GKE-managed system pipeline
-			// (kubelet/cAdvisor + kube-state-metrics) as the cost floor. User
-			// workload metrics become opt-in via per-namespace PodMonitoring
-			// CRDs deferred to the prod-k8s-manifests follow-up.
+			// be disabled per GCP docs) relies on Autopilot's *default*
+			// `monitoringConfig.managedPrometheus.autoMonitoringConfig.scope:
+			// NONE` (per [GMP auto-monitoring docs](https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/auto-monitoring):
+			// *"Automatic application monitoring is OFF by default for both
+			// Autopilot and Standard clusters. You must explicitly enable it."*).
+			// We deliberately do NOT set `monitoringConfig` here — earlier
+			// attempts to set it with only `managedPrometheus` were rejected
+			// by Autopilot at create time with `Error 400: Autopilot clusters
+			// must have monitoring enabled` because the Pulumi/Terraform
+			// provider serialized the missing `enableComponents` as an empty
+			// list. Leaving the entire block out means Autopilot uses its
+			// full default monitoring component set (SYSTEM_COMPONENTS +
+			// APISERVER + SCHEDULER + ... + KUBELET) with managed-Prometheus
+			// enabled and auto-monitoring off — exactly the desired posture.
+			// The unavoidable GKE-managed system pipeline (kubelet/cAdvisor +
+			// kube-state-metrics) is the cost floor. User workload metrics
+			// become opt-in via per-namespace PodMonitoring CRDs in the
+			// prod-k8s-manifests follow-up.
 			//
 			// A user-applied ClusterPodMonitoring with metric_relabeling does
 			// NOT filter the GKE-managed system scrapes — its relabel rules
@@ -491,20 +502,10 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 						channel: 'CHANNEL_STANDARD',
 					},
 
-					// GMP cost control: disable Autopilot's auto-discovery of
-					// application Pods. The managed system pipeline (kubelet,
-					// cAdvisor, kube-state-metrics) is unavoidable on Autopilot
-					// ≥ 1.25, but auto-monitoring of user workloads can be
-					// turned off here. User metrics become opt-in via explicit
-					// PodMonitoring CRDs.
-					monitoringConfig: {
-						managedPrometheus: {
-							enabled: true,
-							autoMonitoringConfig: {
-								scope: 'NONE',
-							},
-						},
-					},
+					// monitoringConfig is intentionally omitted — see leading
+					// block comment. Autopilot's default scope: NONE handles
+					// the cost-control intent without triggering the provider's
+					// "monitoring must be enabled" validation.
 				},
 				{ parent: this, dependsOn: enabledApis },
 			)


### PR DESCRIPTION
## Summary

Hotfix for the first `pulumi up --stack prod` attempt on `migrate-prod-to-autopilot`, which failed at the create phase with:

```
Error 400: Autopilot clusters must have monitoring enabled
```

The partial `monitoringConfig` block (only `managedPrometheus`, no `enableComponents`) on the new `autopilot-cluster-osaka` was serialized by the Pulumi/Terraform provider as a full replacement of the default with an empty `enableComponents`, which Autopilot validates against and rejects.

## Fix

Drop the entire `monitoringConfig` block from the prod Autopilot cluster definition. Autopilot now uses its defaults:

- Full system component set enabled (`SYSTEM_COMPONENTS, APISERVER, SCHEDULER, ..., KUBELET`)
- `managedPrometheus.enabled: true` (cannot be disabled on Autopilot ≥1.25)
- `managedPrometheus.autoMonitoringConfig.scope: NONE` ← the cost-control intent

Per [GMP auto-monitoring docs](https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/auto-monitoring): *"Automatic application monitoring is OFF by default for both Autopilot and Standard clusters."* So the default already matches the cost-control posture we wanted; making it explicit was the cause of the validation failure.

The spec scenario in `migrate-prod-to-autopilot/specs/.../spec.md` already accommodates both: `monitoringConfig.managedPrometheusConfig.autoMonitoringConfig.scope SHALL be NONE (or unset / absent)`. So dropping the explicit field stays consistent with the spec.

## State after the failed up

- Old `standard-cluster-osaka` is **untouched** — create failed at t+4s before destroy was attempted.
- Pulumi state still contains the old cluster with `deletionProtection: false` (from the manual state edit prior to the first attempt).
- No partial resources to clean up.

## Verification

`pulumi preview --stack prod` after the fix:

```
+ gcp:container:Cluster autopilot-cluster-osaka  create
- gcp:container:NodePool spot-pool-osaka         delete
- gcp:container:Cluster standard-cluster-osaka   delete

Resources: + 1 to create, - 2 to delete, 193 unchanged
```

No `monitoringConfig` block on the create — passes Autopilot validation now.

## Test plan

- [x] `make lint-ts` passes
- [x] Local `pulumi preview --stack prod` shows the expected +1/-2 plan
- [ ] CI green
- [ ] Pulumi Cloud auto-preview matches local
- [ ] After merge: manual `pulumi up --stack prod` retry from Pulumi Cloud console
- [ ] Post-cutover: `gcloud container clusters describe autopilot-cluster-osaka ... --format='value(monitoringConfig.managedPrometheusConfig.enabled,monitoringConfig.managedPrometheusConfig.autoMonitoringConfig.scope)'` returns `True NONE` (or `True ` empty)

## Follow-up

The OpenSpec tasks.md §7.1a/b for the migrate change documented a wrong gcloud command (`--no-deletion-protection` doesn't exist; `deletionProtection` is a Pulumi/TF-provider-only attribute). The actual fix used was a Pulumi state edit. This will be captured in the §10.1 incident notes during archive, alongside this monitoringConfig correction.
