### PR TITLE
fix(infra): drop advancedDatapathObservabilityConfig to eliminate Pulumi drift on prod

### DIFF
--- a/src/gcp/components/kubernetes.ts
+++ b/src/gcp/components/kubernetes.ts
@@ -416,36 +416,40 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 			//     mandatory floor per
 			//     [configure-metrics docs](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/configure-metrics):
 			//     *"For GKE Autopilot clusters, you cannot disable the
-			//     collection of system metrics."*
+			//     collection of system metrics."* Reducing this list also
+			//     causes GKE to remove the corresponding addon workloads
+			//     (e.g., the `kube-state-metrics` StatefulSet in
+			//     `gke-managed-cim` is uninstalled when these components
+			//     drop out — confirmed empirically post-PR #252).
 			//   • `managedPrometheus.enabled: true` — mandatory on Autopilot
 			//     ≥ 1.25 per
 			//     [GMP setup-managed docs](https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed):
 			//     *"You can't turn off managed collection in GKE Autopilot
 			//     clusters running GKE version 1.25 or greater."*
-			//   • `advancedDatapathObservabilityConfig.enableMetrics: false`
-			//     — disables Cilium/Hubble per-node network-flow metrics,
-			//     the biggest variable cost driver as nodes scale up.
 			//   • `autoMonitoringConfig.scope` is left unset — Autopilot's
 			//     default per
 			//     [GMP auto-monitoring docs](https://docs.cloud.google.com/stackdriver/docs/managed-prometheus/auto-monitoring)
 			//     is OFF for both Autopilot and Standard, so unset == NONE
 			//     and no application Pods are auto-discovered.
-			//
-			// The unavoidable cost floor is the GKE-managed system pipeline:
-			// the `kube-state-metrics` and `gke-managed-dcgm-exporter` CRs
-			// in `gke-managed-cim` / `gke-gmp-system` namespaces (both
-			// addon-managed with `addonmanager.kubernetes.io/mode: Reconcile`,
-			// so user edits are reverted). At idle (zero workloads → zero
-			// nodes) the kube-state-metrics Pod stays Pending and the
-			// empirical GMP cost is ~$0. When workloads land, per-node
-			// kubelet/cAdvisor + kube-state-metrics emission begins.
+			//   • `advancedDatapathObservabilityConfig` is left unmanaged —
+			//     PR #252 tried setting `enableMetrics: false` to silence
+			//     DPv2/Cilium per-node network-flow metrics, but Autopilot
+			//     silently enforces `true` regardless of the input. Pulumi
+			//     reported `update: succeeded` but the field reverted on the
+			//     live API, producing a perpetual phantom diff on every
+			//     subsequent preview. Omitting the field lets Pulumi accept
+			//     whatever Autopilot returns; cost stays at Autopilot's
+			//     floor (per-node Hubble metrics) and cannot be reduced
+			//     further via cluster config.
 			//
 			// **Pulumi serializer gotcha (resolved)**: an earlier draft set
 			// `monitoringConfig` with ONLY `managedPrometheus` — Pulumi/TF
 			// serialized the missing `enableComponents` as `[]`, which
 			// Autopilot rejected with `Error 400: Autopilot clusters must
 			// have monitoring enabled`. Setting `enableComponents` explicitly
-			// avoids the trap (PR #250 hotfix, then this PR's tightening).
+			// avoids the trap (PR #250 hotfix, then PR #252 tightening,
+			// then PR drop-dpv2-observability-pulumi-drift removing the
+			// non-converging DPv2 field).
 			//
 			// User workload metrics become opt-in via per-namespace
 			// `PodMonitoring` CRDs in the `prod-k8s-manifests` follow-up.
@@ -521,15 +525,18 @@ export class KubernetesComponent extends pulumi.ComponentResource {
 					},
 
 					// Minimum monitoring config — see leading block comment
-					// for rationale + GCP doc citations.
+					// for rationale + GCP doc citations. `advancedDatapath
+					// ObservabilityConfig` is intentionally NOT declared here
+					// because Autopilot silently enforces `enableMetrics: true`
+					// regardless of what Pulumi sets — declaring `false`
+					// caused perpetual phantom drift on every subsequent
+					// `pulumi up` (Pulumi inputs `false`, Autopilot outputs
+					// `true`, never converges). Leaving the field unmanaged
+					// lets Pulumi accept whatever Autopilot returns.
 					monitoringConfig: {
 						enableComponents: ['SYSTEM_COMPONENTS'],
 						managedPrometheus: {
 							enabled: true,
-						},
-						advancedDatapathObservabilityConfig: {
-							enableMetrics: false,
-							enableRelay: false,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

After PR #252 (minimize-prod-gmp-cost) merged and `pulumi up --stack prod` was applied, every subsequent `pulumi preview --stack prod` shows a perpetual phantom update:

```
~ gcp:container:Cluster autopilot-cluster-osaka  update
  ~ monitoringConfig:
      ~ advancedDatapathObservabilityConfig:
          ~ enableMetrics: true => false

Resources: ~ 1 to update, 193 unchanged
```

## Root cause

Autopilot silently enforces `advancedDatapathObservabilityConfig.enableMetrics: true` regardless of the input. Confirmed via Pulumi state inspection:

| Field | Pulumi inputs (code) | Pulumi outputs (live API) | Match? |
|---|---|---|---|
| `advancedDatapathObservabilityConfig.enableMetrics` | `false` | `true` | ❌ never converges |
| `advancedDatapathObservabilityConfig.enableRelay` | `false` | `false` | ✅ |
| `enableComponents` | `[SYSTEM_COMPONENTS]` | `[SYSTEM_COMPONENTS]` | ✅ |

Pulumi reports `update: succeeded` because the GCP API accepts the patch — but Autopilot's reconciler resets `enableMetrics` back to `true` on every apply.

DPv2/Cilium per-node network-flow metrics are non-disableable on Autopilot. PR #252's setting was ineffective; leaving it in code only generates noise for every future preview.

## Fix

Remove the `advancedDatapathObservabilityConfig` block entirely from the prod cluster's `monitoringConfig`. With the field unmanaged:
- Pulumi accepts whatever Autopilot returns
- The preview goes from `~ 1 to update` → `194 unchanged`
- No effective behavior change — DPv2 observability was already on and stays on

## What stays from PR #252

| Lever | Status | Effect |
|---|---|---|
| `enableComponents: [SYSTEM_COMPONENTS]` | ✅ kept | **Effective** — GKE uninstalled the `kube-state-metrics` StatefulSet from `gke-managed-cim` namespace after the reduction (empirically confirmed) |
| `managedPrometheus.enabled: true` | ✅ kept | Autopilot-mandatory |
| `autoMonitoringConfig.scope` | unset (= NONE) | Default-OFF on Autopilot |

## Verification

```
pulumi preview --stack prod
Resources: 194 unchanged
```

Live cluster post-PR-#252 keeps:
- `enableComponents: [SYSTEM_COMPONENTS]` (cost win locked in)
- `enableMetrics: true` (unavoidable; this PR just acknowledges that)
- `kube-state-metrics` StatefulSet: absent (the actual cost-control win)

## Test plan

- [x] `make lint-ts` passes
- [x] Local `pulumi preview --stack prod` shows `194 unchanged` (drift eliminated)
- [ ] CI green
- [ ] Pulumi Cloud auto-preview confirms no diff
- [ ] After merge: `pulumi up --stack prod` from Pulumi Cloud console is a no-op refresh (or near-no-op — refreshing state to match code)

## Follow-up

At `/opsx:archive migrate-prod-to-autopilot` time, the §10.1 incident notes will include this Autopilot enforcement quirk (`enableMetrics` cannot be user-disabled despite API acceptance).
