### PR TITLE
feat(zitadel): provision password-based E2E test user (dev only)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ const postmarkConfig = config.requireObject(
 const zitadelConfig = config.requireSecretObject<{
 	googleAdminIdp: { clientId: string; clientSecret: string }
 	adminGoogleSubs: { pannpers: string }
+	e2eTestUser: { password: string }
 }>('zitadel')
 
 const env = pulumi.getStack() as Environment
@@ -87,6 +88,7 @@ if (env === 'dev') {
 		pannpersGoogleSub: zitadelConfig.apply(
 			(z) => z.adminGoogleSubs.pannpers,
 		),
+		e2eTestUserPassword: zitadelConfig.apply((z) => z.e2eTestUser.password),
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails
 	zitadelLoginPat = zitadel.loginClientToken

--- a/src/zitadel/components/e2e-test-user.ts
+++ b/src/zitadel/components/e2e-test-user.ts
@@ -1,0 +1,136 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+import type { Environment } from '../../config.js'
+
+export interface E2eTestUserComponentArgs {
+	/** Pulumi stack environment. The component throws synchronously if
+	 *  `env !== 'dev'` — the E2E test user is dev-only and the parent
+	 *  `Zitadel` class also gates self-hosted topology to dev, so this
+	 *  guard is defensive depth in case the component is ever lifted
+	 *  out of the dev-only constructor. */
+	env: Environment
+	/** ID of the `liverty-music` product org. The E2E test user lives
+	 *  alongside end-user identities; the product org's `LoginPolicy`
+	 *  (see `components/frontend.ts`) currently has `userLogin = true`
+	 *  which permits username + password sign-in. */
+	orgId: pulumi.Input<string>
+	/** Initial password for the test user. Source: ESC
+	 *  `pulumiConfig.zitadel.e2eTestUser.password`. The caller wraps it
+	 *  with `pulumi.secret()` when extracting from the parent
+	 *  `requireSecretObject<>` so Pulumi marks it `[secret]` in state. */
+	initialPassword: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * E2eTestUserComponent provisions a single password-based HumanUser
+ * in the `liverty-music` product org for use by Playwright headless
+ * E2E tests.
+ *
+ * ## Why a separate user
+ *
+ * The existing dev test user is passkey-only. Passkey credentials
+ * require a biometric/PIN gesture from the registered device and
+ * cannot be replayed by headless Playwright. On WSL2 + WSLg the
+ * headed-Chromium fallback (`capture-auth-state.ts`) cannot reliably
+ * render the OS-level passkey UI either — Chromium opens but the
+ * page stays at `about:blank` past the 5-minute polling timeout.
+ *
+ * A second user, authenticated by username + password, gives
+ * headless Playwright a credential path it can drive end-to-end.
+ * The passkey user is retained unchanged for device-bound manual
+ * testing on display-capable hosts.
+ *
+ * See OpenSpec change `playwright-password-test-user` for the full
+ * decision record (D1–D5) and risk table.
+ *
+ * ## Dependency on `LoginPolicy.userLogin = true`
+ *
+ * Password sign-in for this user depends on the product org's
+ * `LoginPolicy.userLogin` flag being `true`. Today it IS true, but
+ * only as a workaround for Zitadel upstream issue
+ * https://github.com/zitadel/zitadel/issues/11682 (Login V2 Register
+ * page does not render form fields when `userLogin = false`, even
+ * with `passwordlessType = ALLOWED`). When that upstream fix lands
+ * and the workaround is reverted, the e2e-test-user can no longer
+ * authenticate with this approach. See the design.md risk row for
+ * the three mitigation options at revert time.
+ *
+ * ## isEmailVerified + initialPassword
+ *
+ * The `@pulumiverse/zitadel.HumanUser` provider requires an
+ * `initialPassword` to be present when `isEmailVerified = true`:
+ *
+ *   > Caution: Email can only be set verified if a password is set
+ *   > for the user, either with initialPassword or during runtime.
+ *
+ * E2E demands a pre-verified email (no OTP step in headless flow),
+ * and the password is the user's actual sign-in credential — so the
+ * dual constraint is satisfied naturally here (unlike `human-admin`,
+ * which sets a never-used random password).
+ *
+ * ## ignoreChanges on initialPassword
+ *
+ * `initialPassword` is marked `ignoreChanges` so a casual ESC-secret
+ * edit does not silently trigger resource replacement, which would
+ * (a) re-mint the password, (b) invalidate the captured Playwright
+ * storage state without telling anyone, and (c) require a manual
+ * `.auth/password.md` + `.auth/storageState.json` refresh dance.
+ *
+ * Intentional rotation requires:
+ *   1. `pulumi up --replace` against this resource explicitly, AND
+ *   2. update `.auth/password.md` (read fresh from ESC), AND
+ *   3. regenerate `.auth/storageState.json` via the capture script.
+ */
+export class E2eTestUserComponent extends pulumi.ComponentResource {
+	public readonly humanUser: zitadel.HumanUser
+
+	constructor(
+		name: string,
+		args: E2eTestUserComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:E2eTestUser', name, {}, opts)
+
+		const { env, orgId, initialPassword, provider } = args
+
+		// Defensive depth — the parent Zitadel class already throws on
+		// non-dev, but this catches accidental refactors that lift the
+		// component out of the dev-only constructor branch.
+		if (env !== 'dev') {
+			throw new Error(
+				`E2eTestUserComponent: E2E test user is dev-only; got env=${env}. ` +
+					'See OpenSpec change "playwright-password-test-user" for the rationale.',
+			)
+		}
+
+		this.humanUser = new zitadel.HumanUser(
+			'e2e-test-password',
+			{
+				orgId,
+				// userName + email aligned so Login V2's username field accepts
+				// the email directly. The `e2e-test-password@` local-part makes
+				// the user immediately recognizable in the admin console list.
+				userName: 'e2e-test-password@dev.liverty-music.app',
+				email: 'e2e-test-password@dev.liverty-music.app',
+				firstName: 'E2E',
+				lastName: 'Password Test User',
+				preferredLanguage: 'en',
+				// Pre-verified so the headless OIDC flow does not hit the
+				// Self-Registration OTP step. Paired with `initialPassword`
+				// per the @pulumiverse/zitadel HumanUser constraint.
+				isEmailVerified: true,
+				initialPassword: pulumi.secret(initialPassword),
+			},
+			{
+				provider,
+				parent: this,
+				// See header comment "ignoreChanges on initialPassword" for
+				// the rotation protocol.
+				ignoreChanges: ['initialPassword'],
+			},
+		)
+
+		this.registerOutputs({ humanUser: this.humanUser })
+	}
+}

--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -75,6 +75,22 @@ export class FrontendComponent extends pulumi.ComponentResource {
 				// TODO: Revert to false once upstream fix is released.
 				// Login V2 Register page does not render form fields when userLogin=false,
 				// even with passwordlessType=ALLOWED. See: https://github.com/zitadel/zitadel/issues/11682
+				//
+				// LOAD-BEARING for E2E: the dev password-based test user provisioned
+				// by `E2eTestUserComponent` (see ../index.ts and OpenSpec change
+				// `playwright-password-test-user`) signs in via username + password
+				// against THIS productOrg LoginPolicy. Password sign-in only works
+				// while `userLogin: true`. When the upstream fix lands and this flag
+				// is reverted to `false`, the reverting PR MUST EITHER:
+				//   (a) remove `E2eTestUserComponent` and switch the headless E2E
+				//       capture path back to passkey (currently no working option
+				//       for WSL2), OR
+				//   (b) move the e2e-test-user into a separate org whose own
+				//       LoginPolicy has `userLogin: true`, OR
+				//   (c) defer the revert until per-user passwordless-override
+				//       support exists in Zitadel.
+				// See the design.md Risks table in the `playwright-password-test-user`
+				// OpenSpec change for the full mitigation record.
 				userLogin: true,
 				allowRegister: true,
 				// Disable external IDPs (Google etc.) to enforce passkey-only authentication

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -4,6 +4,7 @@ import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../config.js'
 import { ActionsV2Component } from './components/actions-v2.js'
 import { AdminOrgConfigComponent } from './components/admin-org-config.js'
+import { E2eTestUserComponent } from './components/e2e-test-user.js'
 import { FrontendComponent } from './components/frontend.js'
 import { GoogleAdminIdpComponent } from './components/google-admin-idp.js'
 import { HumanAdminComponent } from './components/human-admin.js'
@@ -18,6 +19,7 @@ import {
 
 export * from './components/actions-v2.js'
 export * from './components/admin-org-config.js'
+export * from './components/e2e-test-user.js'
 export * from './components/frontend.js'
 export * from './components/google-admin-idp.js'
 export * from './components/human-admin.js'
@@ -55,6 +57,13 @@ export interface ZitadelArgs {
 	 * userLogin or auto-creation.
 	 */
 	pannpersGoogleSub: pulumi.Input<string>
+	/**
+	 * Initial password for the dev-only Playwright E2E test user.
+	 * Sourced from ESC `pulumiConfig.zitadel.e2eTestUser.password`
+	 * (secret). Consumed by `E2eTestUserComponent`. See OpenSpec
+	 * change `playwright-password-test-user` for rationale.
+	 */
+	e2eTestUserPassword: pulumi.Input<string>
 }
 
 /**
@@ -107,6 +116,7 @@ export class Zitadel {
 	public readonly googleAdminIdp: GoogleAdminIdpComponent
 	public readonly adminOrgConfig: AdminOrgConfigComponent
 	public readonly humanAdmin: HumanAdminComponent
+	public readonly e2eTestUser: E2eTestUserComponent
 
 	/** JWT profile JSON for the backend-app machine user. Store in Secret Manager. */
 	public readonly machineKeyDetails: pulumi.Output<string>
@@ -124,6 +134,7 @@ export class Zitadel {
 			googleAdminIdpClientId,
 			googleAdminIdpClientSecret,
 			pannpersGoogleSub,
+			e2eTestUserPassword,
 		} = args
 
 		if (env !== 'dev') {
@@ -306,6 +317,20 @@ export class Zitadel {
 			googleSub: pannpersGoogleSub,
 			domain,
 			jwtProfileJson,
+			provider: this.provider,
+		})
+
+		// E2E test user — password-based HumanUser for Playwright headless
+		// capture. Lives in `productOrg` to ride on the same end-user
+		// LoginPolicy that real users hit; password sign-in only works
+		// because `productOrg.loginPolicy.userLogin = true` (see
+		// `components/frontend.ts` and the upstream Zitadel issue cited
+		// there). See OpenSpec change `playwright-password-test-user`
+		// for the full design + risk record.
+		this.e2eTestUser = new E2eTestUserComponent(name, {
+			env,
+			orgId: this.productOrg.id,
+			initialPassword: e2eTestUserPassword,
 			provider: this.provider,
 		})
 	}


### PR DESCRIPTION
## 🔗 Related Issue

Spec: liverty-music/specification#456 (`playwright-password-test-user`) — MUST merge first. This PR is the cloud-provisioning side of §1.2–§1.6.

## 📝 Summary of Changes

Add `E2eTestUserComponent` — a Pulumi-provisioned password-based `zitadel.HumanUser` in the `liverty-music` product org for use by Playwright headless E2E tests.

The existing dev test user is passkey-only and incompatible with headless automation (passkey requires a device gesture). On WSL2 + WSLg the headed-Chromium fallback `capture-auth-state.ts` also cannot regenerate `.auth/storageState.json`. This component provides a password-based credential path that headless Playwright can drive end-to-end.

**Tasks covered (from `playwright-password-test-user/tasks.md`):**

- §1.2 New component `src/zitadel/components/e2e-test-user.ts` with `zitadel.HumanUser` (userName, email, firstName, lastName, isEmailVerified, initialPassword)
- §1.3 Synthesis-time dev-only guard inside the component (parent `Zitadel` class also gates; this is defensive depth)
- §1.4 `ignoreChanges: ['initialPassword']` on the resource — rotation requires explicit `pulumi up --replace`
- §1.6 Wired into `Zitadel` constructor (after `humanAdmin`), exported from `src/zitadel/index.ts`

**Task §1.5 — no-op:** the spec mentions "grant the new user the same OIDC Application role as the existing passkey user". In practice the productOrg's existing passkey users have no `UserGrant` records — the project's `projectRoleCheck` is `false`, so authentication against the `web-frontend` OIDC application succeeds without any role grant. No `UserGrant` is added here.

**Tasks NOT in this PR (live ops — operator responsibility):**

- §1.1 — set ESC secret BEFORE merging (see §1.1 prerequisite below)
- §1.7 — auto-deploy on merge creates the user (per `cloud-provisioning/CLAUDE.md`, dev `pulumi up` is automated on src/** merges)
- §1.8 — `pulumi preview --stack staging` to verify the guard

## ⚠️ §1.1 Prerequisite — MUST run BEFORE merging

This PR's auto-deploy will FAIL at config load if the ESC secret is missing — `config.requireSecretObject` throws on missing keys.

```bash
esc env set liverty-music/dev \
  pulumiConfig.zitadel.e2eTestUser.password \
  <generated-strong-password> --secret
```

Do NOT set on `liverty-music/staging` or `liverty-music/prod` — the component's runtime guard throws on non-dev (defensive depth; the parent `Zitadel` class already throws for non-dev).

## 🌍 Affected Stacks

- [x] Dev
- [ ] Prod (intentionally excluded — runtime guard throws)

## 🔮 Pulumi Preview

To be verified by Pulumi Cloud PR preview. Expected diff: single `zitadel.HumanUser` create at `urn:pulumi:dev::liverty-music::zitadel:liverty-music:E2eTestUser$zitadel:index/humanUser:HumanUser::e2e-test-password`. No deletions, no replacements.

## 📦 State Changes

None — additive resource only. No `state mv`, `import`, or destructive changes.

## ✅ Checklist

- [x] `make lint-ts` passes locally (biome + tsc).
- [x] No unintended destructive changes (additive resource only).
- [x] Secrets are managed via ESC (`liverty-music/dev pulumiConfig.zitadel.e2eTestUser.password`), NOT Pulumi config / not GSM / not committed.
- [ ] **Operator: set the ESC secret before merging** (see §1.1 Prerequisite above).
- [ ] **Operator: verify the synthesis guard** via `pulumi preview --stack staging` after merge (§1.8).
