### PR TITLE
feat(infra): bootstrap prod cluster — ArgoCD Apps + namespace overlays + Gateway + PodMonitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,20 @@ lint-ts:
 	npx tsc --noEmit
 
 ## lint-k8s: render + kube-linter + spot nodeSelector check for K8s manifests
+## Renders all four overlay groups (11 namespaces × 2 envs + 1 cluster × 2 envs = 24 overlays).
+## NOTE: explicit listing of the four globs rather than `{dev,prod}` brace expansion.
+## Make's default SHELL=/bin/sh is `dash` on Debian-family runners; dash does not
+## expand `{dev,prod}`, the literal token would iterate once over a non-existent
+## path and the loop would silently lint nothing.
+## The output filename includes both namespace and env (`<ns>-<env>.yaml`) so that
+## dev and prod rendered files don't collide.
 lint-k8s:
 	mkdir -p /tmp/rendered
-	@for overlay in k8s/namespaces/*/overlays/dev; do \
+	@for overlay in k8s/namespaces/*/overlays/dev k8s/namespaces/*/overlays/prod k8s/cluster/overlays/dev k8s/cluster/overlays/prod; do \
 		namespace=$$(echo "$$overlay" | cut -d'/' -f3); \
-		echo "==> Rendering $$namespace"; \
-		kustomize build --enable-helm "$$overlay" > "/tmp/rendered/$${namespace}.yaml" || exit 1; \
+		env=$$(basename "$$overlay"); \
+		echo "==> Rendering $$namespace ($$env)"; \
+		kustomize build --enable-helm "$$overlay" > "/tmp/rendered/$${namespace}-$${env}.yaml" || exit 1; \
 	done
 	kube-linter lint /tmp/rendered --config .kube-linter.yaml
 	./scripts/check-spot-nodeselector.sh /tmp/rendered

--- a/k8s/argocd-apps/prod/argocd.yaml
+++ b/k8s/argocd-apps/prod/argocd.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/argocd/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/atlas-operator.yaml
+++ b/k8s/argocd-apps/prod/atlas-operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: atlas-operator
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/atlas-operator/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: atlas-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/backend-migrations.yaml
+++ b/k8s/argocd-apps/prod/backend-migrations.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backend-migrations
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/backend.git
+    targetRevision: main
+    path: k8s/atlas/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: atlas-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/backend.yaml
+++ b/k8s/argocd-apps/prod/backend.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: backend
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    name: consumer-app
+    jsonPointers:
+    - /spec/replicas
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/backend/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: backend
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/cluster.yaml
+++ b/k8s/argocd-apps/prod/cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: core
+  namespace: argocd
+  # Wave 1: apply ClusterSecretStore after ESO CRDs are installed (wave 0)
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/cluster/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd # Application resource lives here, but it manages cluster-wide/other-ns resources
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/external-secrets.yaml
+++ b/k8s/argocd-apps/prod/external-secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+  # Wave 0: install ESO CRDs and controller before the core app applies ClusterSecretStore
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/external-secrets/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/frontend.yaml
+++ b/k8s/argocd-apps/prod/frontend.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: frontend
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/frontend/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: frontend
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/gateway.yaml
+++ b/k8s/argocd-apps/prod/gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gateway
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/gateway/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gateway
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/keda.yaml
+++ b/k8s/argocd-apps/prod/keda.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda
+  namespace: argocd
+  # Wave 0: install KEDA operator before ScaledObject resources are applied
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/keda/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keda
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/namespaces.yaml
+++ b/k8s/argocd-apps/prod/namespaces.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: namespaces
+  namespace: argocd
+  # Wave -1: create all namespaces before Wave 0 operators (ESO, Reloader) are deployed
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/init
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/nats.yaml
+++ b/k8s/argocd-apps/prod/nats.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nats
+  namespace: argocd
+  # Wave 0: install NATS before consumer apps that depend on it
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/nats/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: nats
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/k8s/argocd-apps/prod/otel-collector.yaml
+++ b/k8s/argocd-apps/prod/otel-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: otel-collector
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/otel-collector/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: otel-collector
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/k8s/argocd-apps/prod/reloader.yaml
+++ b/k8s/argocd-apps/prod/reloader.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+  namespace: argocd
+  # Wave 0: install operator before apps that depend on it
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/liverty-music/cloud-provisioning.git
+    targetRevision: main
+    path: k8s/namespaces/reloader/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: reloader
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - ServerSideApply=true

--- a/k8s/cluster/overlays/prod/cluster-secret-store-argocd-patch.yaml
+++ b/k8s/cluster/overlays/prod/cluster-secret-store-argocd-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: google-secret-manager-argocd
+spec:
+  provider:
+    gcpsm:
+      projectID: liverty-music-prod

--- a/k8s/cluster/overlays/prod/cluster-secret-store-patch.yaml
+++ b/k8s/cluster/overlays/prod/cluster-secret-store-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: google-secret-manager
+spec:
+  provider:
+    gcpsm:
+      projectID: liverty-music-prod

--- a/k8s/cluster/overlays/prod/kustomization.yaml
+++ b/k8s/cluster/overlays/prod/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod cluster-scope overlay.
+# Mirrors dev's structure but:
+#   - Patches both ClusterSecretStores' gcpsm projectID to liverty-music-prod.
+#   - Omits the kube-dns-autoscaler ConfigMap override: on Autopilot the
+#     kube-dns autoscaler is GKE-managed and not user-modifiable, so we cannot
+#     and should not override its `linear` policy here. Prod accepts GKE's
+#     default `preventSinglePointFailure: true` (≥2 kube-dns replicas) for
+#     reliability — opposite trade-off from dev's single-replica cost-cut.
+
+resources:
+- ../../base
+
+patches:
+- path: cluster-secret-store-patch.yaml
+  target:
+    kind: ClusterSecretStore
+    name: google-secret-manager
+- path: cluster-secret-store-argocd-patch.yaml
+  target:
+    kind: ClusterSecretStore
+    name: google-secret-manager-argocd

--- a/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
@@ -27,3 +27,19 @@ patches:
   target:
     kind: Deployment
     name: argocd-server
+# Spot VM nodeSelector — required by `check-spot-nodeselector.sh` on every
+# Pod template in prod overlays (per spec Requirement 4 of the
+# prod-k8s-manifests change). Matches dev's pattern; needed because the
+# ArgoCD Helm-rendered base lacks a Spot nodeSelector that would otherwise
+# survive to the prod overlay. Targets ALL Deployments / StatefulSets /
+# Jobs so child resources (argocd-image-updater-controller, redis-secret-init,
+# application-controller, etc.) are covered without per-resource patches.
+- path: spot-vm_patch_deployment.yaml
+  target:
+    kind: Deployment
+- path: spot-vm_patch_statefulset.yaml
+  target:
+    kind: StatefulSet
+- path: spot-vm_patch_job.yaml
+  target:
+    kind: Job

--- a/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_deployment.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_deployment.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/template/spec/nodeSelector
+  value:
+    cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_job.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_job.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/template/spec/nodeSelector
+  value:
+    cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_statefulset.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/spot-vm_patch_statefulset.yaml
@@ -1,0 +1,4 @@
+- op: replace
+  path: /spec/template/spec/nodeSelector
+  value:
+    cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/atlas-operator/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/atlas-operator/overlays/prod/kustomization.yaml
@@ -1,0 +1,47 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Atlas Operator is a singleton controller with no env-divergent state (no
+# ESC secrets mounted, no hostnames, no per-env config). The dev overlay's
+# spot-nodeSelector and right-sized resource requests are the right baseline
+# for prod too — per design D2 / spec Requirement 3, resource sizing matches
+# dev exactly until real prod load justifies a `right-size-prod` follow-up.
+
+resources:
+- ../../base
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: atlas-operator
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+
+# Match dev's resource requests/limits exactly (design D2).
+- target:
+    kind: Deployment
+    name: atlas-operator
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: atlas-operator
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi

--- a/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
@@ -1,0 +1,19 @@
+# Environment
+ENVIRONMENT=production
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog.
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# OIDC (Zitadel domain for API calls)
+OIDC_ISSUER_URL=https://auth.liverty-music.app
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
+# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
+VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo

--- a/k8s/namespaces/backend/overlays/prod/cronjob/artist-image-sync/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/artist-image-sync/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=production
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
@@ -1,0 +1,20 @@
+# Environment
+ENVIRONMENT=production
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
+
+# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
+VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -1,0 +1,138 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod backend overlay. Env-divergent fields per design D2 / spec Requirement 3:
+#   - GSA: backend-app@liverty-music-prod (vs liverty-music-dev)
+#   - Cloud SQL: liverty-music-prod:asia-northeast2:postgres-osaka
+#     (sql-proxy/deployment.yaml + ConfigMap DATABASE_HOST / DATABASE_INSTANCE_CONNECTION_NAME)
+#   - PSC DNS: 298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+#   - DATABASE_USER: backend-app@liverty-music-prod.iam
+#   - CORS_ALLOWED_ORIGINS: https://liverty-music.app (apex)
+#   - OIDC_ISSUER_URL: https://auth.liverty-music.app
+#   - HTTPRoute hostname: api.liverty-music.app
+#   - GCP_PROJECT_ID, ENVIRONMENT=production
+#
+# Replicas: 1 (per design D8). Resource sizing matches dev exactly.
+#
+# IMPORTANT placeholders (replace before launch):
+#   - TICKET_SBT_ADDRESS (mainnet contract address)
+#   - VAPID_PUBLIC_KEY (prod keypair public key)
+# The concert-discovery CronJob runs on the base daily schedule (no
+# Fridays-only patch), because prod's concert ingestion should be regular.
+
+resources:
+- ../../base
+- sql-proxy/deployment.yaml
+- podmonitoring.yaml
+
+namespace: backend
+
+patches:
+- path: serviceaccount_patch.yaml
+  target:
+    kind: ServiceAccount
+    name: backend-app
+
+# Global Spot VM patch for all Deployments
+- path: spot-vm_patch.yaml
+  target:
+    kind: Deployment
+
+- path: spot-vm_patch_cronjob.yaml
+  target:
+    kind: CronJob
+
+# Replicas: 1 (per design D8 — single replica during bootstrap)
+- target:
+    kind: Deployment
+    name: server-app
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: server-app
+    spec:
+      replicas: 1
+
+# Match dev's resource sizing exactly (design D2)
+- target:
+    kind: Deployment
+    name: server-app
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: server-app
+    spec:
+      template:
+        spec:
+          containers:
+          - name: server
+            resources:
+              requests:
+                cpu: 10m
+                memory: 60Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
+
+# Prod HTTPRoute hostname.
+- target:
+    kind: HTTPRoute
+    name: server-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["api.liverty-music.app"]
+
+# Match dev's consumer resource sizing.
+- target:
+    kind: Deployment
+    name: consumer-app
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: consumer-app
+    spec:
+      template:
+        spec:
+          containers:
+          - name: consumer
+            resources:
+              requests:
+                cpu: 10m
+                memory: 20Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi
+
+# Consumer ScaledObject — start with maxReplicas: 1 (per design D8). KEDA can scale up via Pulumi tweak.
+- target:
+    kind: ScaledObject
+    name: consumer-app
+  patch: |-
+    apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    metadata:
+      name: consumer-app
+    spec:
+      maxReplicaCount: 1
+
+configMapGenerator:
+- name: server-config
+  behavior: merge
+  envs:
+  - server/configmap.env
+- name: concert-discovery-job-config
+  behavior: merge
+  envs:
+  - cronjob/concert-discovery/configmap.env
+- name: artist-image-sync-job-config
+  behavior: merge
+  envs:
+  - cronjob/artist-image-sync/configmap.env
+- name: consumer-consumer-config
+  behavior: merge
+  envs:
+  - consumer/configmap.env

--- a/k8s/namespaces/backend/overlays/prod/podmonitoring.yaml
+++ b/k8s/namespaces/backend/overlays/prod/podmonitoring.yaml
@@ -1,0 +1,29 @@
+# PodMonitoring CRD — opts the backend server pods into Google Managed
+# Service for Prometheus (GMP) ingestion. Per design D5: opt-in only for
+# workloads with active alerts; metricRelabeling keep-rule bounds the
+# ingested series so we never accidentally enable a high-cardinality scrape.
+#
+# Keep-rule scope:
+#   - connect_server_*   : Connect-RPC core (request count, latency, errors)
+#   - go_goroutines      : Go runtime health
+#   - go_memstats_*      : Go memory profile (heap, gc pauses)
+#   - process_*          : Process-level (CPU, RSS, fd count)
+#
+# Interval: 60s (4× reduction vs the default 15s) keeps ingestion rate
+# bounded per design D5 / spec Requirement 6.
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: backend-server
+  namespace: backend
+spec:
+  selector:
+    matchLabels:
+      app: server-app
+  endpoints:
+  - port: metrics
+    interval: 60s
+    metricRelabeling:
+    - sourceLabels: [__name__]
+      regex: connect_server_.+|go_goroutines|go_memstats_.+|process_.+
+      action: keep

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -1,0 +1,27 @@
+# Environment
+ENVIRONMENT=production
+# CORS
+CORS_ALLOWED_ORIGINS=https://liverty-music.app
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog.
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# OIDC
+OIDC_ISSUER_URL=https://auth.liverty-music.app
+
+# Blockchain (prod ticket SBT — placeholder; replace with mainnet contract address before launch)
+TICKET_SBT_ADDRESS=0x0000000000000000000000000000000000000000
+
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
+
+# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
+VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo

--- a/k8s/namespaces/backend/overlays/prod/serviceaccount_patch.yaml
+++ b/k8s/namespaces/backend/overlays/prod/serviceaccount_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app # Base name matched before namePrefix
+  annotations:
+    iam.gke.io/gcp-service-account: backend-app@liverty-music-prod.iam.gserviceaccount.com

--- a/k8s/namespaces/backend/overlays/prod/spot-vm_patch.yaml
+++ b/k8s/namespaces/backend/overlays/prod/spot-vm_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: any
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/backend/overlays/prod/spot-vm_patch_cronjob.yaml
+++ b/k8s/namespaces/backend/overlays/prod/spot-vm_patch_cronjob.yaml
@@ -1,0 +1,11 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: any
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/backend/overlays/prod/sql-proxy/deployment.yaml
+++ b/k8s/namespaces/backend/overlays/prod/sql-proxy/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-sql-proxy
+  labels:
+    app: cloud-sql-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud-sql-proxy
+  template:
+    metadata:
+      labels:
+        app: cloud-sql-proxy
+    spec:
+      serviceAccountName: backend-app
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"
+      containers:
+      - name: cloud-sql-proxy
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+        args:
+        - --psc
+        - --auto-iam-authn
+        - --port=5432
+        - --address=127.0.0.1
+        - liverty-music-prod:asia-northeast2:postgres-osaka
+        ports:
+        - containerPort: 5432
+          name: postgres
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+          allowPrivilegeEscalation: false
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi

--- a/k8s/namespaces/external-secrets/overlays/prod/eso-sa-patch.yaml
+++ b/k8s/namespaces/external-secrets/overlays/prod/eso-sa-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: external-secrets
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-external-secrets@liverty-music-prod.iam.gserviceaccount.com

--- a/k8s/namespaces/external-secrets/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/external-secrets/overlays/prod/kustomization.yaml
@@ -1,0 +1,104 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod ESO overlay. Env-divergent fields per design D2 / spec Requirement 3:
+#   - eso-sa-patch.yaml swaps the GSA email to the prod project's
+#     k8s-external-secrets SA (Workload Identity binding).
+# Resource sizing / replica counts match dev exactly.
+
+resources:
+- ../../base
+
+patches:
+- path: eso-sa-patch.yaml
+  target:
+    kind: ServiceAccount
+    name: external-secrets
+
+# Spot VM patch for prod: apply to all ESO Deployments
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: external-secrets
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+
+# Replicas=1 per design D8 (matches dev)
+- target:
+    kind: Deployment
+    name: external-secrets
+    namespace: external-secrets
+  patch: |-
+    - op: replace
+      path: /spec/replicas
+      value: 1
+
+# Right-sized CPU requests (match dev — design D2)
+- target:
+    kind: Deployment
+    name: external-secrets
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: external-secrets
+    spec:
+      template:
+        spec:
+          containers:
+          - name: external-secrets
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 256Mi
+
+- target:
+    kind: Deployment
+    name: external-secrets-cert-controller
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: external-secrets-cert-controller
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cert-controller
+            resources:
+              requests:
+                cpu: 10m
+                memory: 52Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+
+- target:
+    kind: Deployment
+    name: external-secrets-webhook
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: external-secrets-webhook
+    spec:
+      template:
+        spec:
+          containers:
+          - name: webhook
+            resources:
+              requests:
+                cpu: 10m
+                memory: 52Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod frontend overlay. Env-divergent fields per design D2 / spec Requirement 3:
+#   - HTTPRoute hostname: liverty-music.app (apex) vs dev's dev.liverty-music.app
+# Resource sizing matches dev exactly; spot label matches.
+
+resources:
+- ../../base
+
+namespace: frontend
+
+patches:
+- path: spot-vm_patch.yaml
+  target:
+    kind: Deployment
+
+# Match dev's resource sizing exactly (design D2).
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: web-app
+    spec:
+      template:
+        spec:
+          containers:
+          - name: caddy
+            resources:
+              requests:
+                cpu: 10m
+                memory: 52Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+
+# Prod HTTPRoute hostname (apex).
+- target:
+    kind: HTTPRoute
+    name: web-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["liverty-music.app"]

--- a/k8s/namespaces/frontend/overlays/prod/spot-vm_patch.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/spot-vm_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: any
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/gateway/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/gateway/overlays/prod/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod gateway overlay. The Gateway base references `api-gateway-static-ip`
+# (the NamedAddress) and `api-gateway-cert-map` — both are project-scoped GCP
+# resources with the same name in dev and prod, so the base manifest works
+# unchanged for prod. The Gateway in this overlay claims the prod project's
+# `api-gateway-static-ip` global address (34.110.151.208), transitioning it
+# from RESERVED to IN_USE.
+#
+# Per-route hostname configuration (api.liverty-music.app, auth.liverty-music.app)
+# is in the backend and zitadel overlays' HTTPRoute patches, not here.
+
+resources:
+- ../../base

--- a/k8s/namespaces/keda/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/keda/overlays/prod/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod KEDA overlay. KEDA is a singleton controller with no env-divergent
+# state. Resource sizing + spot label match dev exactly (design D2 / spec
+# Requirement 3).
+
+namespace: keda
+
+helmCharts:
+- name: keda
+  repo: https://kedacore.github.io/charts
+  version: 2.19.0
+  releaseName: keda
+  namespace: keda
+  valuesFile: values.yaml
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: keda
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"

--- a/k8s/namespaces/keda/overlays/prod/values.yaml
+++ b/k8s/namespaces/keda/overlays/prod/values.yaml
@@ -1,0 +1,22 @@
+resources:
+  operator:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  metricServer:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  webhooks:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/k8s/namespaces/nats/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/nats/overlays/prod/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod NATS overlay. Single-replica StatefulSet (per design D8) — matches
+# dev's pattern. Cluster-mode + multi-replica is a follow-up change when
+# traffic justifies it; for greenfield prod, 1 replica minimizes idle nodes.
+
+namespace: nats
+
+helmCharts:
+- name: nats
+  repo: https://nats-io.github.io/k8s/helm/charts/
+  version: 1.3.16
+  releaseName: nats
+  namespace: nats
+  valuesFile: values.yaml
+
+patches:
+- target:
+    kind: StatefulSet
+  patch: |-
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: nats
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+          # GKE Autopilot injects seccompProfile on all pods
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault

--- a/k8s/namespaces/nats/overlays/prod/values.yaml
+++ b/k8s/namespaces/nats/overlays/prod/values.yaml
@@ -1,0 +1,51 @@
+config:
+  cluster:
+    enabled: false
+    replicas: 1
+
+  jetstream:
+    enabled: true
+    fileStore:
+      dir: /data
+      pvc:
+        enabled: true
+        size: 10Gi
+        storageClassName: premium-rwo
+
+container:
+  merge:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    # GKE Autopilot injects these security defaults
+    securityContext:
+      capabilities:
+        drop:
+        - NET_RAW
+
+reloader:
+  merge:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
+    # GKE Autopilot injects these security defaults
+    securityContext:
+      capabilities:
+        drop:
+        - NET_RAW
+
+natsBox:
+  enabled: false
+
+service:
+  ports:
+    monitor:
+      enabled: true

--- a/k8s/namespaces/otel-collector/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/otel-collector/overlays/prod/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod otel-collector overlay. Env-divergent fields:
+#   - ServiceAccount GSA email: otel-collector@liverty-music-prod (vs dev).
+# Resource sizing + spot label match dev exactly.
+
+resources:
+- ../../base
+
+namespace: otel-collector
+
+patches:
+- path: serviceaccount_patch.yaml
+  target:
+    kind: ServiceAccount
+    name: otel-collector
+
+# Spot VM nodeSelector for prod
+- target:
+    kind: Deployment
+    name: otel-collector
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: otel-collector
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+
+- target:
+    kind: Deployment
+    name: otel-collector
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: otel-collector
+    spec:
+      template:
+        spec:
+          containers:
+          - name: otel-collector
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi

--- a/k8s/namespaces/otel-collector/overlays/prod/serviceaccount_patch.yaml
+++ b/k8s/namespaces/otel-collector/overlays/prod/serviceaccount_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  annotations:
+    iam.gke.io/gcp-service-account: otel-collector@liverty-music-prod.iam.gserviceaccount.com

--- a/k8s/namespaces/reloader/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/reloader/overlays/prod/kustomization.yaml
@@ -1,0 +1,43 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod Reloader overlay. Reloader is a singleton controller with no
+# env-divergent state. Spot label + resource sizing match dev exactly.
+
+resources:
+- ../../base
+
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: reloader
+    spec:
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+
+- target:
+    kind: Deployment
+    name: reloader-reloader
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: reloader-reloader
+    spec:
+      template:
+        spec:
+          containers:
+          - name: reloader-reloader
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi

--- a/k8s/namespaces/zitadel/overlays/prod/configmap-patch.env
+++ b/k8s/namespaces/zitadel/overlays/prod/configmap-patch.env
@@ -17,3 +17,13 @@ ZITADEL_EXTERNALDOMAIN=auth.liverty-music.app
 # Pulumi resources land.
 ZITADEL_DATABASE_POSTGRES_USER_USERNAME=zitadel@liverty-music-prod.iam
 ZITADEL_DATABASE_POSTGRES_ADMIN_USERNAME=zitadel@liverty-music-prod.iam
+
+# Connection pool tuning. Prod Cloud SQL is the same db-f1-micro tier as
+# dev (25 connection cap); backend already consumes ~12. With Zitadel at
+# replicas=1 (design D8), MaxOpen=3 leaves headroom for Atlas + manual
+# psql. Matches dev's tuning per design D2 (resource sizing match-dev-
+# exactly until SLO-driven re-tune).
+ZITADEL_DATABASE_POSTGRES_MAXOPENCONNS=3
+ZITADEL_DATABASE_POSTGRES_MAXIDLECONNS=1
+ZITADEL_DATABASE_POSTGRES_MAXCONNLIFETIME=30m
+ZITADEL_DATABASE_POSTGRES_MAXCONNIDLETIME=5m

--- a/k8s/namespaces/zitadel/overlays/prod/deployment-api-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/deployment-api-patch.yaml
@@ -1,9 +1,9 @@
 # Prod overlay for the Zitadel API Deployment.
-# Inherits base `replicas: 2` and `PodDisruptionBudget minAvailable: 1`.
-# Applies the Spot-pool nodeSelector for pre-launch cost — safe because the
-# base `podAntiAffinity` (hostname topology) ensures the two replicas land
-# on different nodes, so a single Spot preemption cannot take the entire
-# API plane down.
+# Per design D8 of the prod-k8s-manifests change: replicas=1 during initial
+# prod bootstrap (no users yet — second-replica HA is over-provisioning at
+# idle); HA replicas are a follow-up `right-size-prod` change. The base PDB
+# minAvailable=1 must be relaxed in pdb-patch.yaml so the single replica can
+# be voluntarily evicted (Spot preemption, node drain).
 #
 # Also overrides the cloud-sql-proxy `args` to point at the prod Cloud SQL
 # instance. Base hardcodes the dev instance connection name
@@ -17,6 +17,7 @@ kind: Deployment
 metadata:
   name: zitadel-api
 spec:
+  replicas: 1
   template:
     spec:
       nodeSelector:

--- a/k8s/namespaces/zitadel/overlays/prod/deployment-web-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/deployment-web-patch.yaml
@@ -1,6 +1,7 @@
 # Prod overlay for the Zitadel Web (Login V2 UI) Deployment — same posture
-# as the API deployment: inherit base replicas: 2 + PDB minAvailable: 1,
-# apply Spot-pool nodeSelector.
+# as the API deployment per design D8: replicas=1 during prod bootstrap +
+# spot-pool nodeSelector. PDB minAvailable=1 from base is relaxed in
+# pdb-patch.yaml.
 #
 # Also overrides ZITADEL_API_URL to the prod public URL. Base hardcodes the
 # dev URL; without this patch, prod's Login UI would call the dev domain,
@@ -12,6 +13,7 @@ kind: Deployment
 metadata:
   name: zitadel-web
 spec:
+  replicas: 1
   template:
     spec:
       nodeSelector:

--- a/k8s/namespaces/zitadel/overlays/prod/job-grant-db.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/job-grant-db.yaml
@@ -1,0 +1,104 @@
+# Prod one-shot Job that grants database ownership to the prod IAM user
+# Zitadel connects as. Mirrors the dev Job (same idempotent GRANT/ALTER
+# pattern, same K8s 1.28+ native sidecar shape). Hardcodes prod Cloud SQL
+# instance + prod IAM SA username.
+#
+# Why this is needed: Cloud SQL's CREATE DATABASE API runs as
+# `cloudsqlsuperuser`, so the pre-existing `zitadel` database is owned by
+# `postgres`. The prod IAM user `zitadel@liverty-music-prod.iam` (created
+# by Pulumi) has the `cloudsqliamuser` role but no ownership or CREATE on
+# `zitadel`. Without this Job, Zitadel's `start-from-init` routine fails
+# with `permission denied for database zitadel (SQLSTATE 42501)` when
+# attempting to CREATE SCHEMA.
+#
+# Why not Pulumi: Cloud SQL is PSC-only. Pulumi Cloud Deployments runs
+# outside the VPC, so the `postgresql` provider can't reach the instance.
+# Running grants from inside the cluster (this Job) mirrors the pattern
+# backend/atlas-operator already uses.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: zitadel-db-grant
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/sync-options: Replace=true
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: zitadel-db-grant
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: zitadel
+      nodeSelector:
+        cloud.google.com/gke-spot: "true"
+      initContainers:
+      - name: cloud-sql-proxy
+        restartPolicy: Always
+        image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+        args:
+        - --psc
+        - --port=5432
+        - --address=127.0.0.1
+        - liverty-music-prod:asia-northeast2:postgres-osaka
+        ports:
+        - containerPort: 5432
+          name: postgres
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65532
+      containers:
+      - name: psql
+        image: postgres:17-alpine
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          export PGPASSWORD="$POSTGRES_ADMIN_PASSWORD"
+
+          echo "db-grant: waiting for cloud-sql-proxy tunnel..."
+          for i in $(seq 1 30); do
+            if psql -h 127.0.0.1 -p 5432 -U postgres -d postgres \
+                 -c 'SELECT 1' >/dev/null 2>&1; then
+              echo "db-grant: tunnel ready"
+              break
+            fi
+            sleep 2
+          done
+
+          echo "db-grant: applying grants to 'zitadel' database..."
+          psql -h 127.0.0.1 -p 5432 -U postgres -d zitadel \
+               -v ON_ERROR_STOP=1 <<'SQL'
+          GRANT "zitadel@liverty-music-prod.iam" TO postgres;
+          ALTER DATABASE zitadel OWNER TO "zitadel@liverty-music-prod.iam";
+          GRANT ALL ON SCHEMA public TO "zitadel@liverty-music-prod.iam";
+          SQL
+
+          echo "db-grant: done"
+        env:
+        - name: POSTGRES_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-admin-credentials
+              key: postgres-admin-password
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -5,6 +5,15 @@ namespace: zitadel
 
 resources:
 - ../../base
+# Prod DB grant Job — idempotent ALTER DATABASE OWNER + GRANT scoped to the
+# prod Cloud SQL `zitadel` DB. Mirrors the dev pattern at
+# `../dev/job-grant-db.yaml` but targets the prod connection name and the
+# prod IAM user `zitadel@liverty-music-prod.iam`.
+- job-grant-db.yaml
+# Per design D5 + spec Requirement 6: opt-in PodMonitoring CRD for prod-only
+# GMP scrape of zitadel-api `/debug/metrics`, keep-rule bounded to
+# `zitadel_command_*` + `http_server_request_duration_*` series.
+- podmonitoring.yaml
 # NOTE: `cronjob-restart-zitadel.yaml` is intentionally NOT imported here.
 # That resource is a dev-only band-aid for the `self-hosted-zitadel` §18.6
 # hang (search the `liverty-music.app/temporary` annotation in the dev
@@ -12,20 +21,19 @@ resources:
 
 configMapGenerator:
 # Merge prod env-specific overrides into the base `zitadel-config` ConfigMap.
-# Currently overrides ZITADEL_EXTERNALDOMAIN and the Cloud SQL IAM SA
-# usernames — see `configmap-patch.env` for the full set + rationale.
+# Currently overrides ZITADEL_EXTERNALDOMAIN, Cloud SQL IAM SA usernames,
+# and connection pool tuning — see `configmap-patch.env` for the full set +
+# rationale.
 - name: zitadel-config
   behavior: merge
   envs:
   - configmap-patch.env
 
 patches:
-# Apply Spot-pool nodeSelector to both Deployments + override cloud-sql-proxy
-# args (deployment-api) and ZITADEL_API_URL env (deployment-web). Replica
-# count and PDB minAvailable inherit from base (replicas: 2,
-# minAvailable: 1) — spot is acceptable pre-launch because base
-# podAntiAffinity ensures different-host placement; revisit non-spot when
-# SLO/traffic justifies.
+# Per design D8 of the prod-k8s-manifests change: both Deployments patched
+# to replicas=1 + spot-pool nodeSelector. `deployment-api-patch.yaml` also
+# overrides cloud-sql-proxy args to the prod instance; `deployment-web-patch.yaml`
+# also sets ZITADEL_API_URL to the prod public URL.
 - path: deployment-api-patch.yaml
   target:
     kind: Deployment
@@ -34,6 +42,9 @@ patches:
   target:
     kind: Deployment
     name: zitadel-web
+# Relax both PDBs to minAvailable=0 so the single replicas can be voluntarily
+# evicted (Spot preemption, drain). Required after replicas=1 patches above.
+- path: pdb-patch.yaml
 # Override the Workload Identity GCP SA on the `zitadel` ServiceAccount
 # (base annotates the dev project's SA; prod pods need the prod SA).
 - path: serviceaccount-patch.yaml

--- a/k8s/namespaces/zitadel/overlays/prod/pdb-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/pdb-patch.yaml
@@ -1,0 +1,23 @@
+# Prod overlay relaxes both Zitadel PDBs to minAvailable=0 because design D8
+# patches both Deployments to replicas=1 during initial prod bootstrap. The
+# base minAvailable=1 would permanently block voluntary disruption — Spot
+# preemption graceful drain, node auto-upgrade, and rolling updates would
+# all stall waiting for a second pod that never exists.
+#
+# Setting minAvailable=0 keeps the PDB resource present (so future
+# right-size-prod overlays can re-tighten it once replicas are scaled up)
+# while letting prod evict its single pod cleanly. Brief downtime per
+# disruption is acceptable during pre-launch bootstrap.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zitadel-api
+spec:
+  minAvailable: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: zitadel-web
+spec:
+  minAvailable: 0

--- a/k8s/namespaces/zitadel/overlays/prod/podmonitoring.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/podmonitoring.yaml
@@ -1,0 +1,27 @@
+# PodMonitoring CRD — opts the zitadel-api pods into GMP ingestion at
+# Zitadel's `/debug/metrics` endpoint. Per design D5: opt-in only for
+# workloads with active alerts; metricRelabeling keep-rule bounds the
+# ingested series.
+#
+# Keep-rule scope:
+#   - zitadel_command_*               : auth command latency / error rate
+#   - http_server_request_duration_*  : auth endpoint latency histograms
+#
+# Interval: 60s per design D5 / spec Requirement 6.
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: zitadel-api
+  namespace: zitadel
+spec:
+  selector:
+    matchLabels:
+      app: zitadel-api
+  endpoints:
+  - port: debug
+    path: /debug/metrics
+    interval: 60s
+    metricRelabeling:
+    - sourceLabels: [__name__]
+      regex: zitadel_command_.+|http_server_request_duration_.+
+      action: keep

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -234,14 +259,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.5.3",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -369,18 +394,18 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.4.3.tgz",
-      "integrity": "sha512-YhkR7XFdO7OBr8U1qs7DA7PmhSJXg59rLqd53jmeJ4pYe8WTCAsUZsKqxX7KKPEgAO5K7D/SjbyPUrBes9aP6Q==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.5.0.tgz",
+      "integrity": "sha512-qS+TtKWC58sjBjD+szLrhEj2TCLnwzUA9vlMyCnU9ztw01ZjQSu25iQPxeBa0sk9sS9/Hzs/xJMWl7J/vRCjGQ==",
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
@@ -531,9 +556,9 @@
       }
     },
     "node_modules/@npmcli/arborist/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -772,9 +797,9 @@
       }
     },
     "node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1070,9 +1095,9 @@
       }
     },
     "node_modules/@npmcli/run-script/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1448,9 +1473,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1541,9 +1566,9 @@
       }
     },
     "node_modules/@pulumi/gcp": {
-      "version": "9.22.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-9.22.0.tgz",
-      "integrity": "sha512-uiQlH0MkT8LwLOiVfPOXGI3I0GIen/j8aL/FIhc379+RUVDd+5153xkd6hgQEwZikRrWKMUn1K0uyM4iTlPCqw==",
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-9.23.0.tgz",
+      "integrity": "sha512-4ASG24GmMKzz4FTA7mv4tC2yuHDPuM4UPB1NBi/8aQrwwdoGF39FGbHWYCtOVfAYyiDkQguV9s0a3aHszphdWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/package-json": "^6.2.0",
@@ -1561,9 +1586,9 @@
       }
     },
     "node_modules/@pulumi/pulumi": {
-      "version": "3.234.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.234.0.tgz",
-      "integrity": "sha512-g9tXFsk0gGkZUV1fjy45b+yRRr2ydSzyt0ZcnUjOzG8K4A0d/gzP82Og6IAcifU5Lv6InyDdONw4nRrJrTj+5Q==",
+      "version": "3.238.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.238.0.tgz",
+      "integrity": "sha512-Lc+TmJTajbLsVBjUBCDcMlzuC4pLsnTyN9gOrTcvAp7otZ9j2b+ttOQZXlB70gDLr+ylDdPIVEy6Ghs28VfMRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.1",
@@ -1620,9 +1645,9 @@
       }
     },
     "node_modules/@pulumi/random": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@pulumi/random/-/random-4.19.2.tgz",
-      "integrity": "sha512-ee77eUIfPMekYi9x7/3iDVIhqUcZrvXQpC8YNTRN8XKfRDuuWio4xu2CvoHeEBDOov84FumMafFqn+xSf+XlDQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/random/-/random-4.20.0.tgz",
+      "integrity": "sha512-2jBPt+lR6XI6p87ALtznasNKU7Da247nW2g2MPCjd1JHKJwvtjyNrD2c4Wd3jgQ+kdKyvtUfiguTPi06m8JKpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pulumi/pulumi": "^3.142.0"
@@ -1638,9 +1663,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -1655,9 +1680,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -1672,9 +1697,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -1689,9 +1714,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -1706,9 +1731,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -1723,9 +1748,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -1740,9 +1765,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -1757,9 +1782,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -1774,9 +1799,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -1791,9 +1816,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -1808,9 +1833,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -1825,9 +1850,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -1842,9 +1867,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -1861,9 +1886,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -1878,9 +1903,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -1895,9 +1920,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2042,9 +2067,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2090,9 +2115,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2139,9 +2164,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2149,9 +2174,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -2209,16 +2234,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2227,13 +2252,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2254,9 +2279,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2267,13 +2292,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2281,14 +2306,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2297,9 +2322,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2307,13 +2332,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2459,9 +2484,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2515,9 +2540,9 @@
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3189,12 +3214,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3988,9 +4013,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4308,9 +4333,9 @@
       }
     },
     "node_modules/pacote/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -4462,9 +4487,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -4553,9 +4578,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4648,14 +4673,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4664,21 +4689,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/safer-buffer": {
@@ -4689,9 +4714,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4768,9 +4793,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.1.1",
@@ -5006,9 +5031,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -5222,17 +5247,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -5249,7 +5274,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -5301,19 +5326,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5341,12 +5366,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,31 +200,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,14 +109,14 @@ const gcp = new Gcp({
 	zitadelLoginPat,
 })
 
-// 5. Self-hosted Zitadel infra phase (dev only).
+// 5. Self-hosted Zitadel infra phase (dev + prod).
 // Provisions GSM secret shells (masterkey, empty admin-sa-key) that the
 // in-cluster Zitadel pod's bootstrap sidecar will populate on first boot.
 // The cutover PR reads `zitadel-machine-key-for-pulumi-admin` from GSM to reconfigure the
 // Zitadel Pulumi provider at the self-hosted hostname. Always running this
 // phase (even before cutover) is safe: the secret shells don't affect the
 // Cloud-tenant Zitadel resources above.
-if (env === 'dev') {
+if (env === 'dev' || env === 'prod') {
 	new SecretsComponent('zitadel-secrets', {
 		project: gcp.project,
 		zitadelServiceAccountEmail: gcp.zitadelServiceAccountEmail,


### PR DESCRIPTION
## Summary

Bootstraps the prod cluster (post `migrate-prod-to-autopilot`) from
infra-only/idle to ArgoCD-managed, externally addressable, Zitadel-served
in a single PR. Implements the `prod-k8s-manifests` OpenSpec change (spec
PR liverty-music/specification#457 merged 2026-05-14 as 1dcd7b5).

- **Pulumi**: lift the `env === 'dev'` gate at [src/index.ts:119](src/index.ts#L119-L125)
  so prod also instantiates `SecretsComponent('zitadel-secrets', ...)`.
  `pulumi preview --stack prod` shows **8 resources to create** (parent
  ComponentResource + RandomString helper + 2 Secrets + 1 SecretVersion +
  3 IAM bindings); 194 unchanged; zero cluster/network/KMS churn.
- **k8s/argocd-apps/prod/**: 14 ArgoCD Applications mirroring `dev/` by
  name + sync-wave. `namespaces` wave -1, `cluster` wave 1, rest default.
- **10 new namespace prod overlays** (`atlas-operator`, `backend`,
  `external-secrets`, `frontend`, `gateway`, `keda`, `nats`,
  `otel-collector`, `reloader`, `zitadel` — argocd was pre-existing) and
  the **cluster prod overlay** at `k8s/cluster/overlays/prod/`. Each
  overlay is the minimum env-divergent patch set per design D2 (ExternalSecret/SA
  refs, hostnames, ConfigMap data, replicas=1). Resource sizing matches dev.
- **zitadel/overlays/prod** (pre-existing): adds replicas=1 to both
  deployments (was inheriting base replicas=2), `pdb-patch.yaml`
  (minAvailable=0), `job-grant-db.yaml` (prod IAM user), extends
  `configmap-patch.env` with connection-pool tuning.
- **PodMonitoring CRDs** (`backend`, `zitadel-api`): opt-in GMP scrape
  bounded by `metricRelabeling` keep-rule per design D5, 60s interval.
- **Makefile lint-k8s**: extended to render all 24 overlays (11 ns × 2 env
  + 1 cluster × 2 env); explicit listing (no `{dev,prod}` brace expansion
  since /bin/sh is dash); output filenames include env to avoid collision.

### Cross-repo dependency

`k8s/argocd-apps/prod/backend-migrations.yaml` points at the **backend
repo** at `k8s/atlas/overlays/prod` (this is consistent with dev which
points at `k8s/atlas/overlays/dev` in the backend repo). That overlay
doesn't exist yet — a follow-up backend-repo PR is required before §9.3
ArgoCD bootstrap completes; the backend-migrations Application would
otherwise be Degraded with "Could not retrieve manifests".

### Deferred from this PR

- §7.5 Atlas migrate dry-run (requires reviewer-local Docker + backend
  repo checkout)
- §7.2 / §7.3 `make lint-k8s` locally — local helm v4 vs kustomize
  `helm version -c` flag mismatch blocks rendering of helm-based overlays
  (would also affect dev). Non-helm overlays render OK. CI uses helm v3
  and will exercise the full pipeline.

### Placeholders flagged for replacement before launch

- `backend/overlays/prod/server/configmap.env`: `TICKET_SBT_ADDRESS`
  (mainnet contract address, currently 0x0)
- All backend prod configmap.env files: `VAPID_PUBLIC_KEY` (prod
  keypair public key, currently shares dev's value)

### Companion PR

- specification: https://github.com/liverty-music/specification/pull/new/apply-prod-k8s-manifests
  (task-tick PR — ticks §1-§7 of the OpenSpec change tasks list)

## Test plan

- [ ] CI green — `lint-k8s` renders all 24 overlays + kube-linter + spot-label check
- [ ] CI green — `lint-ts` passes (already verified locally)
- [ ] Pulumi Cloud auto-preview on dev shows zero changes
- [ ] Pulumi Cloud auto-preview on prod shows the expected 8 GSM-related additions
- [ ] Manual: `atlas migrate apply --dry-run` against an empty postgres:18 container with `liverty-music` (hyphen!) database
- [ ] Manual review approval before merge (this is the prod-bootstrap PR)
- [ ] Post-merge: trigger `pulumi up --stack prod` from Pulumi Cloud; verify Secret + SecretVersion + 3 IAM bindings created
- [ ] Post-merge: register the 14 prod Applications via `kubectl apply -k k8s/argocd-apps/prod/`; watch wave -1 → wave 0 → wave 1 sync
- [ ] Post-merge: trigger second `pulumi up --stack prod` after Zitadel-bootstrap-uploader has populated the pulumi-admin secret; verify `zitadel-machine-key-for-backend-app` GSM Secret exists
- [ ] Post-merge: `curl -I https://api.liverty-music.app/grpc.health.v1.Health/Check` → 200; `curl -s https://auth.liverty-music.app/.well-known/openid-configuration` → Zitadel issuer

close: https://github.com/liverty-music/specification/pull/457
