### PR TITLE
fix(zitadel/prod): remove podAntiAffinity to satisfy Autopilot Warden

### DIFF
--- a/k8s/namespaces/zitadel/overlays/prod/affinity-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/affinity-patch.yaml
@@ -1,0 +1,33 @@
+# Remove podAntiAffinity from both Zitadel Deployments on prod.
+#
+# Why: GKE Autopilot's `autogke-pod-limit-constraints` Warden requires
+# workloads using podAntiAffinity to have ≥500m CPU per Pod. The base
+# zitadel manifests inherit dev's right-sized CPU (zitadel-api total
+# 120m: 10m proxy + 100m api + 10m bootstrap-uploader; zitadel-web 50m).
+# Combined with podAntiAffinity, prod's Autopilot rejects the Deployment
+# admission with:
+#   "workload 'zitadel-api' cpu requests '120m' is lower than the
+#   Autopilot minimum required of '500m' for using pod anti affinity"
+#
+# Per design D8 the prod overlay sets replicas=1 anyway, so podAntiAffinity
+# (which spreads multi-replica Pods across nodes) has no effect — removing
+# it is safe. HA replicas + anti-affinity is a follow-up `right-size-prod`
+# change once real load justifies it; that change would also boost CPU
+# requests to ≥500m to satisfy Autopilot.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zitadel-api
+spec:
+  template:
+    spec:
+      affinity: null
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zitadel-web
+spec:
+  template:
+    spec:
+      affinity: null

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -45,6 +45,11 @@ patches:
 # Relax both PDBs to minAvailable=0 so the single replicas can be voluntarily
 # evicted (Spot preemption, drain). Required after replicas=1 patches above.
 - path: pdb-patch.yaml
+# Remove podAntiAffinity from both Deployments. Autopilot's Warden rejects
+# Deployments that use podAntiAffinity with CPU requests <500m per Pod, and
+# replicas=1 (above) makes anti-affinity a no-op anyway. See the file header
+# for the full Warden error message and the right-size-prod follow-up plan.
+- path: affinity-patch.yaml
 # Override the Workload Identity GCP SA on the `zitadel` ServiceAccount
 # (base annotates the dev project's SA; prod pods need the prod SA).
 - path: serviceaccount-patch.yaml


### PR DESCRIPTION
## Summary

Fix discovered during the prod bootstrap that landed in #255. Both Zitadel
Deployments were rejected by GKE Autopilot's `autogke-pod-limit-constraints`
Warden because their dev-sized CPU requests (120m total for `zitadel-api`,
50m for `zitadel-web`) are below Autopilot's 500m minimum when combined
with `podAntiAffinity`.

Per design D8 of the `prod-k8s-manifests` change, the prod overlay already
sets `replicas: 1` on both Deployments — so `podAntiAffinity` (which
spreads replicas across nodes) has no effect at runtime. Removing it via
the new `affinity-patch.yaml` strategic-merge patch unblocks Autopilot
admission without changing topology.

This has been applied directly to prod via `kubectl apply --server-side`
to unblock the in-progress §9.3-§9.4 bootstrap (zitadel was the chain root
for backend-machine-key creation). This PR upstreams the same fix to main
so ArgoCD's continuous reconcile doesn't keep trying to re-apply the
pre-fix manifest.

## Test plan

- [ ] CI green (lint-k8s + lint-ts + Pulumi previews)
- [ ] CI's render of zitadel prod overlay shows no `affinity:` block on
  either Deployment
- [ ] Post-merge ArgoCD on prod stays in sync (no drift from the
  manually-applied fix)

## Follow-ups (not in this PR)

- `right-size-prod` change: when real traffic data exists, restore HA
  replicas (2+) and boost CPU requests to ≥500m to satisfy Autopilot's
  podAntiAffinity rule; re-add the affinity spec.
