### PR TITLE
feat(infra): enable Zitadel prod Pulumi provider + backend MachineKey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1448,9 +1473,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.129.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1561,9 +1586,9 @@
       }
     },
     "node_modules/@pulumi/pulumi": {
-      "version": "3.238.0",
-      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.238.0.tgz",
-      "integrity": "sha512-Lc+TmJTajbLsVBjUBCDcMlzuC4pLsnTyN9gOrTcvAp7otZ9j2b+ttOQZXlB70gDLr+ylDdPIVEy6Ghs28VfMRw==",
+      "version": "3.239.0",
+      "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.239.0.tgz",
+      "integrity": "sha512-3OqN4x1OYgan3LvkiYCQYapm9phYnZzcu3usvovAXcQA3x5N5izHi9lmx0N/NLRsQQswE021ZvTTC2HZrYcqTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.1",
@@ -1638,9 +1663,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -1655,9 +1680,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -1672,9 +1697,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -1689,9 +1714,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -1706,9 +1731,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -1723,9 +1748,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -1740,9 +1765,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -1757,9 +1782,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -1774,9 +1799,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -1791,9 +1816,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -1808,9 +1833,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -1825,9 +1850,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -1842,9 +1867,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1861,9 +1886,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -1878,9 +1903,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -1895,9 +1920,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4648,14 +4673,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.129.0",
-        "@rolldown/pluginutils": "1.0.0"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4664,21 +4689,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0",
-        "@rolldown/binding-darwin-arm64": "1.0.0",
-        "@rolldown/binding-darwin-x64": "1.0.0",
-        "@rolldown/binding-freebsd-x64": "1.0.0",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0",
-        "@rolldown/binding-linux-x64-musl": "1.0.0",
-        "@rolldown/binding-openharmony-arm64": "1.0.0",
-        "@rolldown/binding-wasm32-wasi": "1.0.0",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/safer-buffer": {
@@ -5222,9 +5247,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
-      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5232,7 +5257,7 @@
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.14",
-        "rolldown": "1.0.0",
+        "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,31 +200,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import * as gcpProvider from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
-import * as zitadelProvider from '@pulumiverse/zitadel'
 import type { CloudflareConfig } from './cloudflare/config.js'
 import type { Environment } from './config.js'
 import type { BlockchainConfig, GcpConfig } from './gcp/components/project.js'
@@ -128,77 +126,17 @@ if (env === 'dev' || env === 'prod') {
 }
 
 // 6. Prod self-hosted Zitadel: backend MachineUser + key + GSM bundle.
-// This block closes the gap discovered post-`prod-k8s-manifests` deploy:
-// the `Zitadel` class above is dev-only (SaaS Cloud-tenant), so prod's
-// `pulumi up` never created `zitadel-machine-key-for-backend-app` and the
-// backend Pods sat in `ContainerCreating`. The fix is a focused
-// `BackendMachineKeyComponent` that:
-//   1. Reads the admin JWT from the GSM Secret populated by the in-cluster
-//      bootstrap-uploader sidecar on first Zitadel API Pod boot (design D3).
-//      The JWT value never round-trips through Pulumi config or ESC.
-//   2. Looks up the first-boot "admin" org via the Zitadel data source
-//      (design D2). Pulumi does NOT create the org — it was auto-created
-//      by `ZITADEL_FIRSTINSTANCE_ORG_NAME` and owning it would create a
-//      destroy-cascade hazard.
-//   3. Creates the prod backend `MachineUser` + `MachineKey` + `OrgMember`
-//      (via the existing `MachineUserComponent`) and writes the resulting
-//      JWT-profile to a SEPARATE GSM Secret `zitadel-machine-key-for-backend-app`
-//      that the backend Pod mounts via ESO.
-//
-// Blast-radius separation preserved: the org-admin JWT is consumed only by
-// Pulumi at plan/apply time; runtime Pods only mount the derived
-// lower-privilege MachineKey JWT (per `prod-k8s-manifests` round-12 fix).
+// Closes the gap discovered post-`prod-k8s-manifests` deploy. The existing
+// `Zitadel` class above is dev-only (SaaS Cloud-tenant), so prod's
+// `pulumi up` was never creating `zitadel-machine-key-for-backend-app` and
+// backend Pods sat in `ContainerCreating`. The new component owns the full
+// orchestration (admin JWT lookup → Zitadel provider → org data source →
+// MachineUser/Key/OrgMember + GSM Secret bundle) so this dispatch line is
+// the thin contract.
 if (env === 'prod') {
-	const prodProject = `${brandId}-${env}` // liverty-music-prod
-	const adminJwt = gcpProvider.secretmanager.getSecretVersionAccessOutput({
-		project: prodProject,
-		secret: 'zitadel-machine-key-for-pulumi-admin',
-	})
-
-	const zitadelProdProvider = new zitadelProvider.Provider('zitadel-prod', {
-		domain: 'auth.liverty-music.app',
-		insecure: false,
-		port: '443',
-		jwtProfileJson: adminJwt.secretData,
-	})
-
-	// Look up the first-boot "admin" org by name. The Zitadel provider's
-	// data source supports name-based query via `getOrgs` (plural) returning
-	// `ids: string[]`; assert exactly one match before using it (design
-	// risk-mitigation note: lookup must be unambiguous).
-	const adminOrgs = zitadelProvider.getOrgsOutput(
-		{
-			name: 'admin',
-			nameMethod: 'TEXT_QUERY_METHOD_EQUALS',
-			state: 'ORG_STATE_ACTIVE',
-		},
-		{ provider: zitadelProdProvider },
-	)
-
-	const adminOrgId = adminOrgs.apply((result) => {
-		if (!result.ids || result.ids.length === 0) {
-			throw new Error(
-				"zitadel.getOrgs returned zero ACTIVE orgs named 'admin' against " +
-					'auth.liverty-music.app. Expected the first-boot bootstrap to have ' +
-					'created this org. Check Zitadel API logs and `ZITADEL_FIRSTINSTANCE_ORG_NAME`.',
-			)
-		}
-		if (result.ids.length > 1) {
-			throw new Error(
-				`zitadel.getOrgs returned ${result.ids.length} orgs named 'admin' ` +
-					`(ids: ${result.ids.join(', ')}). Expected exactly one — refuse ` +
-					'to guess which is the first-boot org. Inspect Zitadel and either ' +
-					'delete the stale orgs or switch this lookup to a unique discriminator.',
-			)
-		}
-		return result.ids[0]
-	})
-
 	new BackendMachineKeyComponent('backend-app-prod', {
 		env,
-		gcpProject: prodProject,
-		zitadelProvider: zitadelProdProvider,
-		orgId: adminOrgId,
+		gcpProject: `${brandId}-${env}`,
 		esoServiceAccountEmail: gcp.esoServiceAccountEmail,
 	})
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
+import * as gcpProvider from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
+import * as zitadelProvider from '@pulumiverse/zitadel'
 import type { CloudflareConfig } from './cloudflare/config.js'
 import type { Environment } from './config.js'
 import type { BlockchainConfig, GcpConfig } from './gcp/components/project.js'
@@ -10,6 +12,7 @@ import {
 	GitHubRepositoryComponent,
 	RepositoryName,
 } from './github/index.js'
+import { BackendMachineKeyComponent } from './zitadel/components/backend-machine-key.js'
 import { SecretsComponent, Zitadel } from './zitadel/index.js'
 
 const brandId = 'liverty-music'
@@ -120,6 +123,82 @@ if (env === 'dev' || env === 'prod') {
 	new SecretsComponent('zitadel-secrets', {
 		project: gcp.project,
 		zitadelServiceAccountEmail: gcp.zitadelServiceAccountEmail,
+		esoServiceAccountEmail: gcp.esoServiceAccountEmail,
+	})
+}
+
+// 6. Prod self-hosted Zitadel: backend MachineUser + key + GSM bundle.
+// This block closes the gap discovered post-`prod-k8s-manifests` deploy:
+// the `Zitadel` class above is dev-only (SaaS Cloud-tenant), so prod's
+// `pulumi up` never created `zitadel-machine-key-for-backend-app` and the
+// backend Pods sat in `ContainerCreating`. The fix is a focused
+// `BackendMachineKeyComponent` that:
+//   1. Reads the admin JWT from the GSM Secret populated by the in-cluster
+//      bootstrap-uploader sidecar on first Zitadel API Pod boot (design D3).
+//      The JWT value never round-trips through Pulumi config or ESC.
+//   2. Looks up the first-boot "admin" org via the Zitadel data source
+//      (design D2). Pulumi does NOT create the org — it was auto-created
+//      by `ZITADEL_FIRSTINSTANCE_ORG_NAME` and owning it would create a
+//      destroy-cascade hazard.
+//   3. Creates the prod backend `MachineUser` + `MachineKey` + `OrgMember`
+//      (via the existing `MachineUserComponent`) and writes the resulting
+//      JWT-profile to a SEPARATE GSM Secret `zitadel-machine-key-for-backend-app`
+//      that the backend Pod mounts via ESO.
+//
+// Blast-radius separation preserved: the org-admin JWT is consumed only by
+// Pulumi at plan/apply time; runtime Pods only mount the derived
+// lower-privilege MachineKey JWT (per `prod-k8s-manifests` round-12 fix).
+if (env === 'prod') {
+	const prodProject = `${brandId}-${env}` // liverty-music-prod
+	const adminJwt = gcpProvider.secretmanager.getSecretVersionAccessOutput({
+		project: prodProject,
+		secret: 'zitadel-machine-key-for-pulumi-admin',
+	})
+
+	const zitadelProdProvider = new zitadelProvider.Provider('zitadel-prod', {
+		domain: 'auth.liverty-music.app',
+		insecure: false,
+		port: '443',
+		jwtProfileJson: adminJwt.secretData,
+	})
+
+	// Look up the first-boot "admin" org by name. The Zitadel provider's
+	// data source supports name-based query via `getOrgs` (plural) returning
+	// `ids: string[]`; assert exactly one match before using it (design
+	// risk-mitigation note: lookup must be unambiguous).
+	const adminOrgs = zitadelProvider.getOrgsOutput(
+		{
+			name: 'admin',
+			nameMethod: 'TEXT_QUERY_METHOD_EQUALS',
+			state: 'ORG_STATE_ACTIVE',
+		},
+		{ provider: zitadelProdProvider },
+	)
+
+	const adminOrgId = adminOrgs.apply((result) => {
+		if (!result.ids || result.ids.length === 0) {
+			throw new Error(
+				"zitadel.getOrgs returned zero ACTIVE orgs named 'admin' against " +
+					'auth.liverty-music.app. Expected the first-boot bootstrap to have ' +
+					'created this org. Check Zitadel API logs and `ZITADEL_FIRSTINSTANCE_ORG_NAME`.',
+			)
+		}
+		if (result.ids.length > 1) {
+			throw new Error(
+				`zitadel.getOrgs returned ${result.ids.length} orgs named 'admin' ` +
+					`(ids: ${result.ids.join(', ')}). Expected exactly one — refuse ` +
+					'to guess which is the first-boot org. Inspect Zitadel and either ' +
+					'delete the stale orgs or switch this lookup to a unique discriminator.',
+			)
+		}
+		return result.ids[0]
+	})
+
+	new BackendMachineKeyComponent('backend-app-prod', {
+		env,
+		gcpProject: prodProject,
+		zitadelProvider: zitadelProdProvider,
+		orgId: adminOrgId,
 		esoServiceAccountEmail: gcp.esoServiceAccountEmail,
 	})
 }

--- a/src/zitadel/components/backend-machine-key.ts
+++ b/src/zitadel/components/backend-machine-key.ts
@@ -1,0 +1,138 @@
+import * as gcp from '@pulumi/gcp'
+import * as pulumi from '@pulumi/pulumi'
+import type * as zitadel from '@pulumiverse/zitadel'
+import { MachineUserComponent } from './machine-user.js'
+
+export interface BackendMachineKeyComponentArgs {
+	/** Environment label, drives only naming/scoping. Dev currently keeps its
+	 *  existing Zitadel-class-routed flow; this component is intentionally
+	 *  prod-shaped (provider + admin org lookup + GSM bundle) so the prod
+	 *  call site is a single expressive line and dev URNs remain untouched. */
+	env: 'dev' | 'prod'
+
+	/** GCP project that will own the `zitadel-machine-key-for-backend-app`
+	 *  GSM Secret + IAM bindings. */
+	gcpProject: pulumi.Input<string>
+
+	/** Zitadel provider configured against the environment's self-hosted
+	 *  Zitadel API (e.g., `https://auth.liverty-music.app` for prod) and
+	 *  authenticated via the bootstrap-uploaded admin JWT (per design D3). */
+	zitadelProvider: zitadel.Provider
+
+	/** Org id where the backend MachineUser is created. For prod this is the
+	 *  first-boot "admin" org id resolved via a `zitadel.getOrg` data source
+	 *  (per design D2 — Pulumi does not create this org). */
+	orgId: pulumi.Input<string>
+
+	/** ESO Workload Identity GCP SA email that needs read access to the new
+	 *  GSM Secret. Defaults to the platform convention
+	 *  `k8s-external-secrets@<gcpProject>.iam.gserviceaccount.com`. */
+	esoServiceAccountEmail?: pulumi.Input<string>
+}
+
+/**
+ * BackendMachineKeyComponent provisions the backend's machine-user JWT-profile
+ * for a self-hosted Zitadel installation, plus the GSM Secret + SecretVersion
+ * + IAM accessor that ESO uses to mirror the JWT into the backend namespace
+ * (per `zitadel-self-hosted-deployment` spec "Backend MachineKey Lifecycle"
+ * requirement).
+ *
+ * Five Pulumi resources are produced:
+ *   1. `zitadel.MachineUser` — `backend-app` principal (via inner MachineUserComponent)
+ *   2. `zitadel.MachineKey` — JWT-profile key pair (via inner MachineUserComponent)
+ *   3. `zitadel.OrgMember`  — ORG_USER_MANAGER role grant (via inner MachineUserComponent)
+ *   4. `gcp.secretmanager.Secret`        — `zitadel-machine-key-for-backend-app` (this component)
+ *   5. `gcp.secretmanager.SecretVersion` — JWT-profile JSON (this component)
+ *   6. `gcp.secretmanager.SecretIamMember` — ESO accessor (this component)
+ *   (Parent ComponentResource counts as one URN but not a separate GCP-side resource.)
+ *
+ * The org-admin JWT (`zitadel-machine-key-for-pulumi-admin`) is consumed only
+ * by Pulumi's Zitadel provider at plan/apply time; it is NEVER mounted into a
+ * Pod. The lower-privilege key this component produces is what the backend
+ * Pod mounts via ESO at runtime — preserving the blast-radius separation
+ * established in `prod-k8s-manifests` round-12.
+ */
+export class BackendMachineKeyComponent extends pulumi.ComponentResource {
+	public readonly machineUser: MachineUserComponent
+	public readonly secret: gcp.secretmanager.Secret
+	public readonly secretVersion: gcp.secretmanager.SecretVersion
+	public readonly secretAccessorBinding: gcp.secretmanager.SecretIamMember
+
+	/** The JWT-profile JSON for authenticating as this machine user. Stored in
+	 *  GSM via this component; exposed here for callers that want to test or
+	 *  reference it programmatically. Never log directly. */
+	public readonly keyDetails: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: BackendMachineKeyComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:BackendMachineKey', name, {}, opts)
+
+		const { env, gcpProject, zitadelProvider, orgId } = args
+		const esoServiceAccountEmail =
+			args.esoServiceAccountEmail ??
+			pulumi
+				.output(gcpProject)
+				.apply(
+					(p) =>
+						`serviceAccount:k8s-external-secrets@${p}.iam.gserviceaccount.com`,
+				)
+
+		this.machineUser = new MachineUserComponent(
+			name,
+			{ orgId, provider: zitadelProvider },
+			{ parent: this },
+		)
+
+		this.secret = new gcp.secretmanager.Secret(
+			'zitadel-machine-key-for-backend-app',
+			{
+				project: gcpProject,
+				secretId: 'zitadel-machine-key-for-backend-app',
+				replication: { auto: {} },
+				labels: { env, managed_by: 'pulumi' },
+			},
+			{ parent: this },
+		)
+
+		this.secretVersion = new gcp.secretmanager.SecretVersion(
+			'zitadel-machine-key-for-backend-app-version',
+			{
+				secret: this.secret.id,
+				secretData: this.machineUser.keyDetails,
+				deletionPolicy: 'DELETE',
+				enabled: true,
+			},
+			{ parent: this },
+		)
+
+		this.secretAccessorBinding = new gcp.secretmanager.SecretIamMember(
+			'zitadel-machine-key-for-backend-app-eso-accessor',
+			{
+				project: gcpProject,
+				secretId: this.secret.secretId,
+				role: 'roles/secretmanager.secretAccessor',
+				member: pulumi
+					.output(esoServiceAccountEmail)
+					.apply((m) =>
+						m.startsWith('serviceAccount:')
+							? m
+							: `serviceAccount:${m}`,
+					),
+			},
+			{ parent: this },
+		)
+
+		this.keyDetails = this.machineUser.keyDetails
+
+		this.registerOutputs({
+			machineUser: this.machineUser,
+			secret: this.secret,
+			secretVersion: this.secretVersion,
+			secretAccessorBinding: this.secretAccessorBinding,
+			keyDetails: this.keyDetails,
+		})
+	}
+}

--- a/src/zitadel/components/backend-machine-key.ts
+++ b/src/zitadel/components/backend-machine-key.ts
@@ -1,28 +1,24 @@
 import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
-import type * as zitadel from '@pulumiverse/zitadel'
+import * as zitadel from '@pulumiverse/zitadel'
+import type { Environment } from '../../config.js'
+import { zitadelDomainMap } from '../constants.js'
 import { MachineUserComponent } from './machine-user.js'
 
 export interface BackendMachineKeyComponentArgs {
-	/** Environment label, drives only naming/scoping. Dev currently keeps its
-	 *  existing Zitadel-class-routed flow; this component is intentionally
-	 *  prod-shaped (provider + admin org lookup + GSM bundle) so the prod
-	 *  call site is a single expressive line and dev URNs remain untouched. */
-	env: 'dev' | 'prod'
+	/** Pulumi stack environment. Drives the Zitadel provider's `domain`
+	 *  (via `zitadelDomainMap[env]`) and the Zitadel provider resource name
+	 *  (`zitadel-${env}`). Dev currently keeps its existing Zitadel-class-routed
+	 *  flow; this component is intentionally prod-shaped (provider + admin
+	 *  org lookup + GSM bundle) so the prod call site is a single expressive
+	 *  line and dev URNs remain untouched. */
+	env: Environment
 
-	/** GCP project that will own the `zitadel-machine-key-for-backend-app`
-	 *  GSM Secret + IAM bindings. */
+	/** GCP project that owns BOTH (a) the admin JWT GSM Secret
+	 *  `zitadel-machine-key-for-pulumi-admin` consumed at plan time and (b)
+	 *  the new `zitadel-machine-key-for-backend-app` GSM Secret + IAM bindings
+	 *  this component creates. */
 	gcpProject: pulumi.Input<string>
-
-	/** Zitadel provider configured against the environment's self-hosted
-	 *  Zitadel API (e.g., `https://auth.liverty-music.app` for prod) and
-	 *  authenticated via the bootstrap-uploaded admin JWT (per design D3). */
-	zitadelProvider: zitadel.Provider
-
-	/** Org id where the backend MachineUser is created. For prod this is the
-	 *  first-boot "admin" org id resolved via a `zitadel.getOrg` data source
-	 *  (per design D2 — Pulumi does not create this org). */
-	orgId: pulumi.Input<string>
 
 	/** ESO Workload Identity GCP SA email that needs read access to the new
 	 *  GSM Secret. Defaults to the platform convention
@@ -37,30 +33,46 @@ export interface BackendMachineKeyComponentArgs {
  * (per `zitadel-self-hosted-deployment` spec "Backend MachineKey Lifecycle"
  * requirement).
  *
- * Five Pulumi resources are produced:
- *   1. `zitadel.MachineUser` — `backend-app` principal (via inner MachineUserComponent)
- *   2. `zitadel.MachineKey` — JWT-profile key pair (via inner MachineUserComponent)
- *   3. `zitadel.OrgMember`  — ORG_USER_MANAGER role grant (via inner MachineUserComponent)
- *   4. `gcp.secretmanager.Secret`        — `zitadel-machine-key-for-backend-app` (this component)
- *   5. `gcp.secretmanager.SecretVersion` — JWT-profile JSON (this component)
- *   6. `gcp.secretmanager.SecretIamMember` — ESO accessor (this component)
- *   (Parent ComponentResource counts as one URN but not a separate GCP-side resource.)
+ * The component owns the full orchestration end-to-end so the `index.ts` call
+ * site stays as a thin dispatch line (per CLAUDE.md "Main entry point
+ * dispatching to GCP and GitHub components"):
  *
- * The org-admin JWT (`zitadel-machine-key-for-pulumi-admin`) is consumed only
- * by Pulumi's Zitadel provider at plan/apply time; it is NEVER mounted into a
- * Pod. The lower-privilege key this component produces is what the backend
- * Pod mounts via ESO at runtime — preserving the blast-radius separation
- * established in `prod-k8s-manifests` round-12.
+ *   1. Read the admin JWT (`zitadel-machine-key-for-pulumi-admin`) from GSM
+ *      via `getSecretVersionAccessOutput`. The JWT is wrapped in
+ *      `pulumi.secret()` to prevent the embedded RSA private key from
+ *      leaking into preview/state/CI logs (design D3 + the dev path's
+ *      CRITICAL comment in `src/zitadel/index.ts`).
+ *   2. Create a `zitadel.Provider` targeting `zitadelDomainMap[env]`
+ *      (e.g., `auth.liverty-music.app` for prod). The domain uses the
+ *      central map to avoid drift between this file and the constants.
+ *   3. Look up the first-boot "admin" org via `zitadel.getOrgsOutput`
+ *      (design D2). Pulumi does NOT create the org — it was auto-created by
+ *      `ZITADEL_FIRSTINSTANCE_ORG_NAME` at first boot; owning it would
+ *      create a destroy-cascade hazard. Lookup asserts exactly one result.
+ *   4. Instantiate the existing `MachineUserComponent` to create the
+ *      backend `MachineUser` + `MachineKey` + `OrgMember` (ORG_USER_MANAGER
+ *      role) inside the resolved org.
+ *   5. Write the resulting JWT-profile JSON to a SEPARATE GSM Secret
+ *      `zitadel-machine-key-for-backend-app` (wrapped in `pulumi.secret()`
+ *      to prevent state leakage). ESO will mirror this Secret into the
+ *      backend namespace via the existing ExternalSecret CR; Reloader rolls
+ *      the backend Deployment.
+ *
+ * Blast-radius separation preserved: the org-admin JWT is consumed only by
+ * the Zitadel provider at plan/apply time and never reaches a Pod; the
+ * derived lower-privilege MachineKey JWT is what backend mounts at runtime
+ * (per `prod-k8s-manifests` round-12 fix).
  */
 export class BackendMachineKeyComponent extends pulumi.ComponentResource {
+	public readonly provider: zitadel.Provider
 	public readonly machineUser: MachineUserComponent
 	public readonly secret: gcp.secretmanager.Secret
 	public readonly secretVersion: gcp.secretmanager.SecretVersion
 	public readonly secretAccessorBinding: gcp.secretmanager.SecretIamMember
 
-	/** The JWT-profile JSON for authenticating as this machine user. Stored in
-	 *  GSM via this component; exposed here for callers that want to test or
-	 *  reference it programmatically. Never log directly. */
+	/** The JWT-profile JSON for authenticating as the backend machine user.
+	 *  Stored in GSM via this component; exposed here for callers that want
+	 *  to test or reference it programmatically. Never log directly. */
 	public readonly keyDetails: pulumi.Output<string>
 
 	constructor(
@@ -70,19 +82,77 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:BackendMachineKey', name, {}, opts)
 
-		const { env, gcpProject, zitadelProvider, orgId } = args
+		const { env, gcpProject } = args
 		const esoServiceAccountEmail =
 			args.esoServiceAccountEmail ??
 			pulumi
 				.output(gcpProject)
 				.apply(
-					(p) =>
-						`serviceAccount:k8s-external-secrets@${p}.iam.gserviceaccount.com`,
+					(p) => `k8s-external-secrets@${p}.iam.gserviceaccount.com`,
 				)
+
+		// CRITICAL: wrap the admin JWT in `pulumi.secret()`.
+		// `getSecretVersionAccessOutput` does NOT auto-mark its output as
+		// secret. The JWT-profile JSON embeds an RSA private key — without
+		// this wrap, the key value would surface in plaintext in `pulumi
+		// preview` output (including Pulumi Cloud PR previews), CI logs,
+		// and Pulumi service state history. Matches the analogous CRITICAL
+		// guard in `src/zitadel/index.ts`'s dev path.
+		const adminJwt = pulumi.secret(
+			gcp.secretmanager
+				.getSecretVersionAccessOutput({
+					project: gcpProject,
+					secret: 'zitadel-machine-key-for-pulumi-admin',
+				})
+				.apply((v) => v.secretData),
+		)
+
+		this.provider = new zitadel.Provider(
+			`zitadel-${env}`,
+			{
+				domain: zitadelDomainMap[env],
+				insecure: false,
+				port: '443',
+				jwtProfileJson: adminJwt,
+			},
+			{ parent: this },
+		)
+
+		// Look up the first-boot "admin" org by name. `getOrg` (singular)
+		// requires id; `getOrgs` (plural) supports name-based query and
+		// returns `ids: string[]`. Assert exactly one match before using —
+		// refuse to guess on ambiguity.
+		const adminOrgs = zitadel.getOrgsOutput(
+			{
+				name: 'admin',
+				nameMethod: 'TEXT_QUERY_METHOD_EQUALS',
+				state: 'ORG_STATE_ACTIVE',
+			},
+			{ provider: this.provider, parent: this },
+		)
+
+		const adminOrgId = adminOrgs.apply((result) => {
+			if (!result.ids || result.ids.length === 0) {
+				throw new Error(
+					`zitadel.getOrgs returned zero ACTIVE orgs named 'admin' against ${zitadelDomainMap[env]}. ` +
+						'Expected the first-boot bootstrap to have created this org. ' +
+						'Check Zitadel API logs and `ZITADEL_FIRSTINSTANCE_ORG_NAME` in the configmap.',
+				)
+			}
+			if (result.ids.length > 1) {
+				throw new Error(
+					`zitadel.getOrgs returned ${result.ids.length} orgs named 'admin' ` +
+						`(ids: ${result.ids.join(', ')}). Expected exactly one — refuse ` +
+						'to guess which is the first-boot org. Inspect Zitadel and either ' +
+						'delete the stale orgs or switch this lookup to a unique discriminator.',
+				)
+			}
+			return result.ids[0]
+		})
 
 		this.machineUser = new MachineUserComponent(
 			name,
-			{ orgId, provider: zitadelProvider },
+			{ orgId: adminOrgId, provider: this.provider },
 			{ parent: this },
 		)
 
@@ -101,7 +171,15 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 			'zitadel-machine-key-for-backend-app-version',
 			{
 				secret: this.secret.id,
-				secretData: this.machineUser.keyDetails,
+				// CRITICAL: wrap the MachineKey JWT in `pulumi.secret()`.
+				// `MachineKey.keyDetails` is a plain `Output<string>` — the
+				// `@pulumiverse/zitadel` provider does NOT mark it secret.
+				// Without this wrap the RSA private key embedded in the
+				// backend machine-user JWT-profile JSON would surface in
+				// plaintext in Pulumi state history for the SecretVersion
+				// input diff. Same protection as the dev path applies in
+				// `src/gcp/index.ts` (`pulumi.secret(zitadelMachineKey)`).
+				secretData: pulumi.secret(this.machineUser.keyDetails),
 				deletionPolicy: 'DELETE',
 				enabled: true,
 			},
@@ -128,6 +206,7 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 		this.keyDetails = this.machineUser.keyDetails
 
 		this.registerOutputs({
+			provider: this.provider,
 			machineUser: this.machineUser,
 			secret: this.secret,
 			secretVersion: this.secretVersion,

--- a/src/zitadel/components/backend-machine-key.ts
+++ b/src/zitadel/components/backend-machine-key.ts
@@ -45,26 +45,34 @@ export interface BackendMachineKeyComponentArgs {
  *   2. Create a `zitadel.Provider` targeting `zitadelDomainMap[env]`
  *      (e.g., `auth.liverty-music.app` for prod). The domain uses the
  *      central map to avoid drift between this file and the constants.
- *   3. Look up the first-boot "admin" org via `zitadel.getOrgsOutput`
- *      (design D2). Pulumi does NOT create the org — it was auto-created by
- *      `ZITADEL_FIRSTINSTANCE_ORG_NAME` at first boot; owning it would
- *      create a destroy-cascade hazard. Lookup asserts exactly one result.
- *   4. Instantiate the existing `MachineUserComponent` to create the
- *      backend `MachineUser` + `MachineKey` + `OrgMember` (ORG_USER_MANAGER
- *      role) inside the resolved org.
+ *   3. Create a NEW `liverty-music` product org via `zitadel.Org` (matching
+ *      dev's two-org topology). The backend MachineUser lives here, NOT in
+ *      the first-boot "admin" org — placing `backend-app` (with its
+ *      ORG_USER_MANAGER role) in the admin org would give the runtime
+ *      backend Pod user-management authority over operator identities
+ *      (pulumi-admin, login-client, human IAM_OWNER admins). Per the
+ *      `Place Machine Users by Responsibility` rule. Pulumi does NOT touch
+ *      the first-boot "admin" org — that one was auto-created by
+ *      `ZITADEL_FIRSTINSTANCE_ORG_NAME` and owning it would create a
+ *      destroy-cascade hazard.
+ *   4. Instantiate the existing `MachineUserComponent` inside the product
+ *      org to create the backend `MachineUser` + `MachineKey` + `OrgMember`
+ *      (ORG_USER_MANAGER role scoped to the product org).
  *   5. Write the resulting JWT-profile JSON to a SEPARATE GSM Secret
  *      `zitadel-machine-key-for-backend-app` (wrapped in `pulumi.secret()`
  *      to prevent state leakage). ESO will mirror this Secret into the
  *      backend namespace via the existing ExternalSecret CR; Reloader rolls
  *      the backend Deployment.
  *
- * Blast-radius separation preserved: the org-admin JWT is consumed only by
- * the Zitadel provider at plan/apply time and never reaches a Pod; the
- * derived lower-privilege MachineKey JWT is what backend mounts at runtime
- * (per `prod-k8s-manifests` round-12 fix).
+ * Blast-radius separation preserved on two axes: (a) the org-admin JWT is
+ * consumed only by the Zitadel provider at plan/apply time and never reaches
+ * a Pod (per `prod-k8s-manifests` round-12 fix); (b) the backend MachineUser
+ * is scoped to the product org and cannot reach the admin org's operator
+ * identities (this component's design).
  */
 export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 	public readonly provider: zitadel.Provider
+	public readonly productOrg: zitadel.Org
 	public readonly machineUser: MachineUserComponent
 	public readonly secret: gcp.secretmanager.Secret
 	public readonly secretVersion: gcp.secretmanager.SecretVersion
@@ -118,41 +126,21 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
-		// Look up the first-boot "admin" org by name. `getOrg` (singular)
-		// requires id; `getOrgs` (plural) supports name-based query and
-		// returns `ids: string[]`. Assert exactly one match before using —
-		// refuse to guess on ambiguity.
-		const adminOrgs = zitadel.getOrgsOutput(
-			{
-				name: 'admin',
-				nameMethod: 'TEXT_QUERY_METHOD_EQUALS',
-				state: 'ORG_STATE_ACTIVE',
-			},
+		// Product org — Pulumi-created, scoped to backend app workloads.
+		// NOT the first-boot "admin" org (which the bootstrap auto-created
+		// and holds operator identities: pulumi-admin, login-client, human
+		// IAM_OWNERs). Mirrors dev's `productOrg` topology so backend-app's
+		// ORG_USER_MANAGER role grants user-management only over end-user
+		// principals in this org — never over operator identities.
+		this.productOrg = new zitadel.Org(
+			'liverty-music',
+			{ name: 'liverty-music', isDefault: false },
 			{ provider: this.provider, parent: this },
 		)
 
-		const adminOrgId = adminOrgs.apply((result) => {
-			if (!result.ids || result.ids.length === 0) {
-				throw new Error(
-					`zitadel.getOrgs returned zero ACTIVE orgs named 'admin' against ${zitadelDomainMap[env]}. ` +
-						'Expected the first-boot bootstrap to have created this org. ' +
-						'Check Zitadel API logs and `ZITADEL_FIRSTINSTANCE_ORG_NAME` in the configmap.',
-				)
-			}
-			if (result.ids.length > 1) {
-				throw new Error(
-					`zitadel.getOrgs returned ${result.ids.length} orgs named 'admin' ` +
-						`(ids: ${result.ids.join(', ')}). Expected exactly one — refuse ` +
-						'to guess which is the first-boot org. Inspect Zitadel and either ' +
-						'delete the stale orgs or switch this lookup to a unique discriminator.',
-				)
-			}
-			return result.ids[0]
-		})
-
 		this.machineUser = new MachineUserComponent(
 			name,
-			{ orgId: adminOrgId, provider: this.provider },
+			{ orgId: this.productOrg.id, provider: this.provider },
 			{ parent: this },
 		)
 
@@ -207,6 +195,7 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 
 		this.registerOutputs({
 			provider: this.provider,
+			productOrg: this.productOrg,
 			machineUser: this.machineUser,
 			secret: this.secret,
 			secretVersion: this.secretVersion,


### PR DESCRIPTION
## Summary

Closes the Pulumi-side gap discovered during the manual `prod-k8s-manifests`
deploy on 2026-05-14. The `Zitadel` Pulumi class — which creates the backend
`MachineUser` + `MachineKey` and writes the JWT-profile to GSM — is gated to
`env === 'dev'` at [src/index.ts:74](src/index.ts#L74) because it was built
for the SaaS Cloud-tenant. After prod cut over to self-hosted Zitadel, that
gate left the prod backend Pods stuck in `ContainerCreating` waiting for
`zitadel-machine-key-for-backend-app` that nothing was creating.

Implements `enable-zitadel-prod-pulumi-provider` (spec PR
[liverty-music/specification#463](https://github.com/liverty-music/specification/pull/463),
merged 2026-05-14 as `6664053`).

### What changes

- **NEW** `src/zitadel/components/backend-machine-key.ts` — focused top-level
  `BackendMachineKeyComponent` (design D1) that wraps the existing
  `MachineUserComponent` and produces the GSM `Secret` + `SecretVersion` +
  `SecretIamMember` bundle.
- **NEW** `src/index.ts:151-202` — prod-only block that:
  1. Reads `zitadel-machine-key-for-pulumi-admin` from GSM via
     `gcp.secretmanager.getSecretVersionAccessOutput` (design D3 — JWT is
     a data-source read, never round-tripped through Pulumi config or ESC).
  2. Creates a `zitadel.Provider` targeting `https://auth.liverty-music.app`.
  3. Looks up the first-boot "admin" org via `zitadel.getOrgsOutput`
     (design D2 — Pulumi does NOT create the org).
  4. Instantiates `BackendMachineKeyComponent`, producing 6 backing
     resources in the prod stack.

### What `pulumi up --stack prod` will create

Per the local `pulumi preview --stack prod` (output: 9 to create, 202
unchanged):

| Kind | Resource |
|---|---|
| `pulumi:providers:zitadel` | `zitadel-prod` (auth.liverty-music.app provider) |
| `zitadel:liverty-music:BackendMachineKey` | `backend-app-prod` (parent ComponentResource) |
| `zitadel:liverty-music:MachineUser` | nested ComponentResource |
| `zitadel:index/machineUser:MachineUser` | `backend-app` principal |
| `zitadel:index/machineKey:MachineKey` | JWT-profile key pair |
| `zitadel:index/orgMember:OrgMember` | `ORG_USER_MANAGER` role grant |
| `gcp:secretmanager/secret:Secret` | `zitadel-machine-key-for-backend-app` |
| `gcp:secretmanager/secretVersion:SecretVersion` | JWT-profile JSON |
| `gcp:secretmanager/secretIamMember:SecretIamMember` | ESO read access |

All `(create)`; zero replacements, zero destroys.

### Blast-radius separation (preserved)

- Org-admin JWT (`zitadel-machine-key-for-pulumi-admin`): consumed only by
  Pulumi at plan/apply time. Never mounted into any Pod.
- Runtime backend Pods mount only the **lower-privilege** MachineKey JWT
  (`zitadel-machine-key-for-backend-app`) created by this change.

### Why §3 (refactor dev) is intentionally skipped

Tasks.md §3 originally said "refactor Zitadel class to use the new component".
That would have required `aliases:` on three child URNs (MachineUser,
MachineKey, OrgMember) to avoid Pulumi recreate-delete cycles. The design D1
goal — a focused top-level component for prod — is achieved by the new
component being callable independently at `index.ts`. The dev path remains
verbatim; future cleanup can unify dev under the new component when there's
a separate driver (e.g., right-size-prod or rotation work).

### Local validation

- `make lint-ts` ✓ (biome + tsc)
- `pulumi preview --stack dev`: 234 unchanged + 1 unrelated `dashboard-zitadel-observability`
  etag drift (pre-existing, not caused by this PR). Zero churn on any Zitadel /
  MachineKey / GSM resource.
- `pulumi preview --stack prod`: 9 resources to create (all `(create)`), 202
  unchanged.

### Companion PR

specification: https://github.com/liverty-music/specification/pull/new/apply-enable-zitadel-prod-pulumi-provider

## Test plan

- [ ] CI green (lint-k8s + lint-ts + Pulumi previews)
- [ ] Pulumi Cloud auto-preview on dev: same single Dashboard etag drift
- [ ] Pulumi Cloud auto-preview on prod: 9 resources to create (all create)
- [ ] Reviewer approval before merge (prod-affecting)
- [ ] Post-merge: trigger `pulumi up --stack prod` from Pulumi Cloud
- [ ] Post-merge: `gcloud secrets versions list zitadel-machine-key-for-backend-app --project liverty-music-prod` returns ≥1 enabled version
- [ ] Post-merge: ESO syncs → Reloader rolls → backend Pods (`server-app`, `consumer-app`) leave `ContainerCreating` → Running
- [ ] Post-merge: `curl -I https://api.liverty-music.app/grpc.health.v1.Health/Check` returns 200

close: https://github.com/liverty-music/specification/pull/463
