### PR TITLE
feat(zitadel): add ZitadelHumanUserPasswordPermanent Dynamic Resource

### DIFF
--- a/src/zitadel/components/e2e-test-user.ts
+++ b/src/zitadel/components/e2e-test-user.ts
@@ -112,6 +112,13 @@ export interface E2eTestUserComponentArgs {
  * `initialPassword` and the marker resource — they agree by
  * construction. See OpenSpec change `zitadel-permanent-password` for
  * the full design + risk record.
+ *
+ * The marker mirrors the HumanUser's `ignoreChanges` on its password
+ * input AND adds `replaceOnChanges: ['userId']` so that a `--replace`
+ * on the HumanUser cascades into a fresh marker create (which picks up
+ * the new password from create-time inputs, not from ignored state).
+ * Net effect: the rotation protocol above remains a single
+ * `--replace` on the HumanUser URN; the marker follows automatically.
  */
 export class E2eTestUserComponent extends pulumi.ComponentResource {
 	public readonly humanUser: zitadel.HumanUser
@@ -173,6 +180,24 @@ export class E2eTestUserComponent extends pulumi.ComponentResource {
 		// Mark the password permanent (noChangeRequired = true) so first
 		// sign-in does not redirect to /ui/v2/login/password/change. See
 		// the header comment "Permanent-password marker" for the rationale.
+		//
+		// `ignoreChanges: ['password']` mirrors the HumanUser's
+		// `ignoreChanges: ['initialPassword']` directive. Without it, an
+		// ESC-secret edit would be ignored on the HumanUser (per the
+		// rotation protocol above) but would silently trigger `update()`
+		// on this marker, re-POSTing SetPassword with the new value to
+		// Zitadel — silently rotating the live credential, exactly the
+		// scenario the parent guard exists to prevent.
+		//
+		// `replaceOnChanges: ['userId']` ensures the marker is replaced
+		// (destroyed + freshly created) when the HumanUser is replaced
+		// via `pulumi up --replace`. The HumanUser's new snowflake id
+		// flows into `userId` here; without this directive the marker
+		// would call `update()` with the new userId but the old
+		// (ignored) password, overwriting the freshly-rotated credential
+		// with the stale value. With it, `create()` runs against the
+		// new user with the new password — rotation works end-to-end
+		// with a single `--replace` on the HumanUser URN.
 		this.passwordPermanent = new ZitadelHumanUserPasswordPermanent(
 			'e2e-test-password-permanent',
 			{
@@ -181,7 +206,12 @@ export class E2eTestUserComponent extends pulumi.ComponentResource {
 				userId: this.humanUser.id,
 				password: pulumi.secret(initialPassword),
 			},
-			{ parent: this, dependsOn: [this.humanUser] },
+			{
+				parent: this,
+				dependsOn: [this.humanUser],
+				ignoreChanges: ['password'],
+				replaceOnChanges: ['userId'],
+			},
 		)
 
 		this.registerOutputs({

--- a/src/zitadel/components/e2e-test-user.ts
+++ b/src/zitadel/components/e2e-test-user.ts
@@ -1,6 +1,7 @@
 import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../../config.js'
+import { ZitadelHumanUserPasswordPermanent } from '../dynamic/permanent-password.js'
 
 export interface E2eTestUserComponentArgs {
 	/** Pulumi stack environment. The component throws synchronously if
@@ -17,8 +18,20 @@ export interface E2eTestUserComponentArgs {
 	/** Initial password for the test user. Source: ESC
 	 *  `pulumiConfig.zitadel.e2eTestUser.password`. The caller wraps it
 	 *  with `pulumi.secret()` when extracting from the parent
-	 *  `requireSecretObject<>` so Pulumi marks it `[secret]` in state. */
+	 *  `requireSecretObject<>` so Pulumi marks it `[secret]` in state.
+	 *  Threaded into BOTH the `HumanUser.initialPassword` field AND the
+	 *  `ZitadelHumanUserPasswordPermanent` marker resource — they always
+	 *  agree by construction. */
 	initialPassword: pulumi.Input<string>
+	/** Zitadel domain (e.g. `auth.dev.liverty-music.app`). Used by the
+	 *  `ZitadelHumanUserPasswordPermanent` marker resource to call the
+	 *  Management API. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (stringified) for Management
+	 *  API auth. Used by the `ZitadelHumanUserPasswordPermanent` marker
+	 *  resource. Same value the `Zitadel` composition root reads from
+	 *  GCP Secret Manager for the other dynamic resources. */
+	jwtProfileJson: pulumi.Input<string>
 	provider: zitadel.Provider
 }
 
@@ -81,9 +94,28 @@ export interface E2eTestUserComponentArgs {
  *   1. `pulumi up --replace` against this resource explicitly, AND
  *   2. update `.auth/password.md` (read fresh from ESC), AND
  *   3. regenerate `.auth/storageState.json` via the capture script.
+ *
+ * ## Permanent-password marker
+ *
+ * `@pulumiverse/zitadel.HumanUser` v0.2.0 sets the user's credential
+ * state with `changeRequired = true` and exposes no knob to flip it.
+ * Without an explicit `SetPassword(noChangeRequired = true)` call, the
+ * user is redirected to `/ui/v2/login/password/change` on first sign-in
+ * and refuses to issue tokens until the password is changed. Headless
+ * Playwright cannot tolerate this gate.
+ *
+ * Mitigation: `ZitadelHumanUserPasswordPermanent` (a Pulumi Dynamic
+ * Resource under `../dynamic/permanent-password.ts`) calls the
+ * Management API `POST /management/v1/users/{user_id}/password` with
+ * `noChangeRequired: true` immediately after the HumanUser is created.
+ * The same ESC password is threaded to both the HumanUser's
+ * `initialPassword` and the marker resource — they agree by
+ * construction. See OpenSpec change `zitadel-permanent-password` for
+ * the full design + risk record.
  */
 export class E2eTestUserComponent extends pulumi.ComponentResource {
 	public readonly humanUser: zitadel.HumanUser
+	public readonly passwordPermanent: ZitadelHumanUserPasswordPermanent
 
 	constructor(
 		name: string,
@@ -92,7 +124,14 @@ export class E2eTestUserComponent extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:E2eTestUser', name, {}, opts)
 
-		const { env, orgId, initialPassword, provider } = args
+		const {
+			env,
+			orgId,
+			initialPassword,
+			domain,
+			jwtProfileJson,
+			provider,
+		} = args
 
 		// Defensive depth — the parent Zitadel class already throws on
 		// non-dev, but this catches accidental refactors that lift the
@@ -131,6 +170,23 @@ export class E2eTestUserComponent extends pulumi.ComponentResource {
 			},
 		)
 
-		this.registerOutputs({ humanUser: this.humanUser })
+		// Mark the password permanent (noChangeRequired = true) so first
+		// sign-in does not redirect to /ui/v2/login/password/change. See
+		// the header comment "Permanent-password marker" for the rationale.
+		this.passwordPermanent = new ZitadelHumanUserPasswordPermanent(
+			'e2e-test-password-permanent',
+			{
+				domain,
+				jwtProfileJson,
+				userId: this.humanUser.id,
+				password: pulumi.secret(initialPassword),
+			},
+			{ parent: this, dependsOn: [this.humanUser] },
+		)
+
+		this.registerOutputs({
+			humanUser: this.humanUser,
+			passwordPermanent: this.passwordPermanent,
+		})
 	}
 }

--- a/src/zitadel/dynamic/__tests__/permanent-password.test.ts
+++ b/src/zitadel/dynamic/__tests__/permanent-password.test.ts
@@ -5,7 +5,9 @@ vi.mock('../api-client.js', () => ({
 }))
 
 const apiClient = await import('../api-client.js')
-const { permanentPasswordProvider } = await import('../permanent-password.js')
+const { permanentPasswordProvider, mergeSecretOutputs } = await import(
+	'../permanent-password.js'
+)
 
 const mockedCall = vi.mocked(apiClient.zitadelApiCall)
 
@@ -168,5 +170,44 @@ describe('permanentPasswordProvider.read', () => {
 		expect(mockedCall).not.toHaveBeenCalled()
 		expect(result.id).toBe('permanent-password:human-user-snowflake')
 		expect(result.props).toEqual(baseOutputs)
+	})
+})
+
+describe('mergeSecretOutputs', () => {
+	it('returns the two required secret outputs when no opts are supplied', () => {
+		const merged = mergeSecretOutputs()
+
+		expect(merged.additionalSecretOutputs).toEqual([
+			'password',
+			'jwtProfileJson',
+		])
+	})
+
+	it('preserves other CustomResourceOptions while injecting secret outputs', () => {
+		const merged = mergeSecretOutputs({
+			deleteBeforeReplace: true,
+			ignoreChanges: ['password'],
+			replaceOnChanges: ['userId'],
+		})
+
+		expect(merged.deleteBeforeReplace).toBe(true)
+		expect(merged.ignoreChanges).toEqual(['password'])
+		expect(merged.replaceOnChanges).toEqual(['userId'])
+		expect(merged.additionalSecretOutputs).toEqual([
+			'password',
+			'jwtProfileJson',
+		])
+	})
+
+	it('appends caller-supplied additionalSecretOutputs without losing the builtins', () => {
+		const merged = mergeSecretOutputs({
+			additionalSecretOutputs: ['customSecret'],
+		})
+
+		expect(merged.additionalSecretOutputs).toEqual([
+			'password',
+			'jwtProfileJson',
+			'customSecret',
+		])
 	})
 })

--- a/src/zitadel/dynamic/__tests__/permanent-password.test.ts
+++ b/src/zitadel/dynamic/__tests__/permanent-password.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../api-client.js', () => ({
+	zitadelApiCall: vi.fn(),
+}))
+
+const apiClient = await import('../api-client.js')
+const { permanentPasswordProvider } = await import('../permanent-password.js')
+
+const mockedCall = vi.mocked(apiClient.zitadelApiCall)
+
+// `ZitadelHumanUserPasswordPermanent` is a one-shot state-push resource
+// (per design D2 in OpenSpec change `zitadel-permanent-password`):
+// `create()` and `update()` hit `POST /management/v1/users/{id}/password`;
+// `delete()` and `read()` are no-ops. Test scaffold mirrors the
+// smtp-activation precedent.
+const provider = permanentPasswordProvider as Required<
+	typeof permanentPasswordProvider
+>
+
+const baseProfile = {
+	type: 'serviceaccount' as const,
+	keyId: 'kid-1',
+	key: 'private-key-pem',
+	userId: 'user-1',
+}
+
+const baseInputs = {
+	domain: 'auth.example.test',
+	jwtProfileJson: JSON.stringify(baseProfile),
+	userId: 'human-user-snowflake',
+	password: 'sup3r-secret-passw0rd!',
+}
+
+const baseOutputs = {
+	...baseInputs,
+	markedAt: '2026-01-01T00:00:00.000Z',
+}
+
+function callArgsAt(index: number) {
+	return mockedCall.mock.calls[index][0]
+}
+
+describe('permanentPasswordProvider.create', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('POSTs /management/v1/users/{userId}/password with noChangeRequired=true', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
+
+		const result = await provider.create(baseInputs)
+
+		expect(mockedCall).toHaveBeenCalledTimes(1)
+		const call = callArgsAt(0)
+		expect(call.method).toBe('POST')
+		expect(call.path).toBe(
+			'/management/v1/users/human-user-snowflake/password',
+		)
+		expect(call.domain).toBe('auth.example.test')
+		expect(call.body).toEqual({
+			password: baseInputs.password,
+			noChangeRequired: true,
+		})
+		expect(result.id).toBe('permanent-password:human-user-snowflake')
+		expect(result.outs?.userId).toBe('human-user-snowflake')
+		expect(result.outs?.markedAt).toMatch(
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+		)
+	})
+
+	it('accepts a 412 "no change" response as success (idempotency on re-apply)', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 412,
+			body: '{"code":9,"message":"password no change required already set"}',
+		})
+
+		await expect(provider.create(baseInputs)).resolves.toMatchObject({
+			id: 'permanent-password:human-user-snowflake',
+		})
+	})
+
+	it('throws on a genuine non-2xx error from SetPassword', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(provider.create(baseInputs)).rejects.toThrow(
+			/Zitadel SetHumanPassword failed \(500\)/,
+		)
+	})
+})
+
+describe('permanentPasswordProvider.update', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('re-POSTs SetPassword with the new password and preserves the original markedAt', async () => {
+		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
+		const news = { ...baseInputs, password: 'rotated-passw0rd!' }
+
+		const result = await provider.update(
+			'permanent-password:human-user-snowflake',
+			baseOutputs,
+			news,
+		)
+
+		expect(mockedCall).toHaveBeenCalledTimes(1)
+		const call = callArgsAt(0)
+		expect(call.method).toBe('POST')
+		expect(call.path).toBe(
+			'/management/v1/users/human-user-snowflake/password',
+		)
+		expect(call.body).toEqual({
+			password: 'rotated-passw0rd!',
+			noChangeRequired: true,
+		})
+		expect(result.outs?.markedAt).toBe(baseOutputs.markedAt)
+		expect(result.outs?.password).toBe('rotated-passw0rd!')
+	})
+
+	it('throws on a genuine non-2xx error during update', async () => {
+		mockedCall.mockResolvedValueOnce({
+			statusCode: 500,
+			body: '{"code":13,"message":"internal"}',
+		})
+
+		await expect(
+			provider.update(
+				'permanent-password:human-user-snowflake',
+				baseOutputs,
+				baseInputs,
+			),
+		).rejects.toThrow(/Zitadel SetHumanPassword \(update\) failed \(500\)/)
+	})
+})
+
+describe('permanentPasswordProvider.delete', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests (no inverse Management API verb exists)', async () => {
+		await expect(
+			provider.delete(
+				'permanent-password:human-user-snowflake',
+				baseOutputs,
+			),
+		).resolves.toBeUndefined()
+
+		expect(mockedCall).not.toHaveBeenCalled()
+	})
+})
+
+describe('permanentPasswordProvider.read', () => {
+	beforeEach(() => {
+		mockedCall.mockReset()
+	})
+
+	it('makes ZERO HTTP requests and returns current outputs unchanged', async () => {
+		const result = await provider.read(
+			'permanent-password:human-user-snowflake',
+			baseOutputs,
+		)
+
+		expect(mockedCall).not.toHaveBeenCalled()
+		expect(result.id).toBe('permanent-password:human-user-snowflake')
+		expect(result.props).toEqual(baseOutputs)
+	})
+})

--- a/src/zitadel/dynamic/__tests__/permanent-password.test.ts
+++ b/src/zitadel/dynamic/__tests__/permanent-password.test.ts
@@ -99,9 +99,22 @@ describe('permanentPasswordProvider.update', () => {
 		mockedCall.mockReset()
 	})
 
-	it('re-POSTs SetPassword with the new password and preserves the original markedAt', async () => {
+	// Under the call-site directives `ignoreChanges: ['password']` +
+	// `replaceOnChanges: ['userId']`, the Pulumi engine only invokes
+	// `update()` when `domain` or `jwtProfileJson` changes. Password
+	// rotation routes through `replaceOnChanges` into a fresh
+	// `create()`, NOT through this handler. To mirror what Pulumi
+	// would pass after applying ignoreChanges, the tests below set
+	// `news.password === olds.password` and vary the non-ignored
+	// inputs instead.
+	it('re-asserts permanence with the prior-state password when jwtProfileJson rotates', async () => {
 		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
-		const news = { ...baseInputs, password: 'rotated-passw0rd!' }
+		const rotatedProfile = JSON.stringify({
+			...baseProfile,
+			keyId: 'kid-2',
+			key: 'new-private-key-pem',
+		})
+		const news = { ...baseInputs, jwtProfileJson: rotatedProfile }
 
 		const result = await provider.update(
 			'permanent-password:human-user-snowflake',
@@ -115,12 +128,14 @@ describe('permanentPasswordProvider.update', () => {
 		expect(call.path).toBe(
 			'/management/v1/users/human-user-snowflake/password',
 		)
+		// password is the unchanged prior-state value (ignoreChanges
+		// guarantees news.password === olds.password in practice).
 		expect(call.body).toEqual({
-			password: 'rotated-passw0rd!',
+			password: baseInputs.password,
 			noChangeRequired: true,
 		})
 		expect(result.outs?.markedAt).toBe(baseOutputs.markedAt)
-		expect(result.outs?.password).toBe('rotated-passw0rd!')
+		expect(result.outs?.password).toBe(baseInputs.password)
 	})
 
 	it('throws on a genuine non-2xx error during update', async () => {

--- a/src/zitadel/dynamic/index.ts
+++ b/src/zitadel/dynamic/index.ts
@@ -1,4 +1,5 @@
 export * from './execution.js'
+export * from './permanent-password.js'
 export * from './smtp-activation.js'
 export * from './target.js'
 export * from './user-idp-link.js'

--- a/src/zitadel/dynamic/permanent-password.ts
+++ b/src/zitadel/dynamic/permanent-password.ts
@@ -161,6 +161,27 @@ function isAlreadyPermanent(body: string): boolean {
  * See OpenSpec change `zitadel-permanent-password` for the full
  * decision record (D1–D5) and risk table.
  */
+/**
+ * Bake `password` + `jwtProfileJson` into `additionalSecretOutputs` so the
+ * secret-output contract cannot regress at any call site. `pulumi.secret(...)`
+ * inputs do NOT auto-propagate across the dynamic-resource boundary: without
+ * this, `outs: { ...inputs, markedAt }` in `create()` would land both as
+ * plaintext in the Pulumi state checkpoint. Merge with caller-supplied
+ * additions rather than overwrite. Exported for unit-test coverage.
+ */
+export function mergeSecretOutputs(
+	opts?: pulumi.CustomResourceOptions,
+): pulumi.CustomResourceOptions {
+	return {
+		...opts,
+		additionalSecretOutputs: [
+			'password',
+			'jwtProfileJson',
+			...(opts?.additionalSecretOutputs ?? []),
+		],
+	}
+}
+
 export class ZitadelHumanUserPasswordPermanent extends pulumi.dynamic.Resource {
 	public readonly markedAt!: pulumi.Output<string>
 
@@ -176,7 +197,7 @@ export class ZitadelHumanUserPasswordPermanent extends pulumi.dynamic.Resource {
 				...args,
 				markedAt: undefined,
 			},
-			opts,
+			mergeSecretOutputs(opts),
 		)
 	}
 }

--- a/src/zitadel/dynamic/permanent-password.ts
+++ b/src/zitadel/dynamic/permanent-password.ts
@@ -1,0 +1,182 @@
+import * as pulumi from '@pulumi/pulumi'
+import { type JwtProfile, zitadelApiCall } from './api-client.js'
+
+export interface ZitadelHumanUserPasswordPermanentArgs {
+	/** Zitadel domain, e.g. `auth.dev.liverty-music.app`. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (stringified) for Management API auth. */
+	jwtProfileJson: pulumi.Input<string>
+	/** ID of the `HumanUser` whose password should be marked permanent. */
+	userId: pulumi.Input<string>
+	/**
+	 * The password to assert. The caller MUST pass the same value used in
+	 * the `HumanUser.initialPassword` input; this resource has no way to
+	 * read the password back from the HumanUser (it is a write-only field
+	 * on the @pulumiverse/zitadel provider).
+	 */
+	password: pulumi.Input<string>
+}
+
+interface PermanentPasswordInputs {
+	domain: string
+	jwtProfileJson: string
+	userId: string
+	password: string
+}
+
+interface PermanentPasswordOutputs extends PermanentPasswordInputs {
+	markedAt: string
+}
+
+/**
+ * Provider for `ZitadelHumanUserPasswordPermanent`. Mirrors the lifecycle
+ * shape of `smtp-activation.ts`: `create()` is the only handler that
+ * touches Zitadel; `delete()` and `read()` are no-ops by design.
+ *
+ * Why no readback / no inverse verb:
+ *
+ * - Zitadel's Management API does not expose `GET /password/state`, so
+ *   drift detection against `noChangeRequired` is not possible. Pulumi
+ *   keeps the marker in state purely so subsequent `update()` calls can
+ *   re-assert permanence on password rotation.
+ * - There is no `_unset_permanent` verb either. Removing this marker
+ *   resource should NOT flip the user back to `changeRequired = true`
+ *   (the credential is still valid; only the next-sign-in gate would
+ *   change), so `delete()` is a no-op.
+ *
+ * Why `update()` re-POSTs even with unchanged inputs:
+ *
+ * - Cheap (one token exchange + one POST) and gives drift recovery for
+ *   free if an operator manually clears the permanence flag in the
+ *   Zitadel admin console. The smtp-activation precedent takes the
+ *   opposite stance because re-activating SMTP fires an email-rotation
+ *   side-effect downstream; `SetPassword` has no equivalent side-effect.
+ */
+export const permanentPasswordProvider: pulumi.dynamic.ResourceProvider = {
+	async create(
+		inputs: PermanentPasswordInputs,
+	): Promise<pulumi.dynamic.CreateResult<PermanentPasswordOutputs>> {
+		const profile = JSON.parse(inputs.jwtProfileJson) as JwtProfile
+		const res = await zitadelApiCall({
+			domain: inputs.domain,
+			profile,
+			method: 'POST',
+			path: `/management/v1/users/${inputs.userId}/password`,
+			body: {
+				password: inputs.password,
+				noChangeRequired: true,
+			},
+		})
+		if (
+			(res.statusCode < 200 || res.statusCode >= 300) &&
+			!isAlreadyPermanent(res.body)
+		) {
+			throw new Error(
+				`Zitadel SetHumanPassword failed (${res.statusCode}): ${res.body}`,
+			)
+		}
+		return {
+			id: `permanent-password:${inputs.userId}`,
+			outs: {
+				...inputs,
+				markedAt: new Date().toISOString(),
+			},
+		}
+	},
+
+	async update(
+		_id: string,
+		olds: PermanentPasswordOutputs,
+		news: PermanentPasswordInputs,
+	): Promise<pulumi.dynamic.UpdateResult<PermanentPasswordOutputs>> {
+		const profile = JSON.parse(news.jwtProfileJson) as JwtProfile
+		const res = await zitadelApiCall({
+			domain: news.domain,
+			profile,
+			method: 'POST',
+			path: `/management/v1/users/${news.userId}/password`,
+			body: {
+				password: news.password,
+				noChangeRequired: true,
+			},
+		})
+		if (
+			(res.statusCode < 200 || res.statusCode >= 300) &&
+			!isAlreadyPermanent(res.body)
+		) {
+			throw new Error(
+				`Zitadel SetHumanPassword (update) failed (${res.statusCode}): ${res.body}`,
+			)
+		}
+		return {
+			outs: {
+				...news,
+				// Preserve the original mark timestamp; the update is a
+				// re-assertion, not a fresh mark.
+				markedAt: olds.markedAt,
+			},
+		}
+	},
+
+	async delete(_id: string, _state: PermanentPasswordOutputs): Promise<void> {
+		// No-op by design: there is no inverse Management API verb to
+		// flip permanence off, and removing the marker resource should
+		// not log the user out at the next sign-in. The HumanUser
+		// resource is the source of truth for the user's existence.
+	},
+
+	async read(
+		id: string,
+		state: PermanentPasswordOutputs,
+	): Promise<pulumi.dynamic.ReadResult<PermanentPasswordOutputs>> {
+		// No-op: Zitadel exposes no GET endpoint for password permanence
+		// state. Drift detection is explicitly out of scope (matches the
+		// smtp-activation precedent).
+		return { id, props: state }
+	},
+}
+
+function isAlreadyPermanent(body: string): boolean {
+	// Defensive: if Zitadel ever returns a non-2xx for the no-op case
+	// (SetPassword called against an already-permanent password), accept
+	// it as success. The exact response shape is verified during live
+	// apply; today the happy path returns 200 regardless.
+	return /no.?change/i.test(body) || /already.?permanent/i.test(body)
+}
+
+/**
+ * `ZitadelHumanUserPasswordPermanent` marks a Zitadel `HumanUser`'s
+ * password permanent (`noChangeRequired = true`) at provision time via
+ * a `POST /management/v1/users/{user_id}/password` call. Without this
+ * resource, every `@pulumiverse/zitadel.HumanUser` created with
+ * `initialPassword` lands with `changeRequired = true` and the user
+ * is redirected to `/ui/v2/login/password/change` on first sign-in
+ * (the provider v0.2.0 exposes no knob to flip this flag at create
+ * time).
+ *
+ * The caller MUST pass the same password value used for the HumanUser's
+ * `initialPassword` input — the resource cannot read it back from the
+ * upstream provider.
+ *
+ * See OpenSpec change `zitadel-permanent-password` for the full
+ * decision record (D1–D5) and risk table.
+ */
+export class ZitadelHumanUserPasswordPermanent extends pulumi.dynamic.Resource {
+	public readonly markedAt!: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: ZitadelHumanUserPasswordPermanentArgs,
+		opts?: pulumi.CustomResourceOptions,
+	) {
+		super(
+			permanentPasswordProvider,
+			name,
+			{
+				...args,
+				markedAt: undefined,
+			},
+			opts,
+		)
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -326,11 +326,15 @@ export class Zitadel {
 		// because `productOrg.loginPolicy.userLogin = true` (see
 		// `components/frontend.ts` and the upstream Zitadel issue cited
 		// there). See OpenSpec change `playwright-password-test-user`
-		// for the full design + risk record.
+		// for the full design + risk record, and `zitadel-permanent-password`
+		// for the `ZitadelHumanUserPasswordPermanent` marker resource that
+		// makes the user's password permanent at provision time.
 		this.e2eTestUser = new E2eTestUserComponent(name, {
 			env,
 			orgId: this.productOrg.id,
 			initialPassword: e2eTestUserPassword,
+			domain,
+			jwtProfileJson,
 			provider: this.provider,
 		})
 	}


### PR DESCRIPTION
## Summary

- Implements §1–§2 of OpenSpec change [`zitadel-permanent-password`](https://github.com/liverty-music/specification/pull/466): a new Pulumi Dynamic Resource `ZitadelHumanUserPasswordPermanent` plus wiring into `E2eTestUserComponent` to mark the dev e2e-test-password user's password permanent (`noChangeRequired = true`) at provision time.
- Eliminates the structural cause of the `[4b/5]` workaround in [`frontend/scripts/capture-auth-state-password.ts`](https://github.com/liverty-music/frontend/blob/main/scripts/capture-auth-state-password.ts#L116-L142). The frontend cleanup PR follows once this lands on dev.

## What's in the diff

| File | Change |
|---|---|
| [`src/zitadel/dynamic/permanent-password.ts`](src/zitadel/dynamic/permanent-password.ts) | New Dynamic Resource modeled on `smtp-activation.ts`. `create()` + `update()` POST `/management/v1/users/{user_id}/password` with `{ password, noChangeRequired: true }`. `delete()` and `read()` are no-ops by design (no inverse Management API verb, no GET endpoint). Accepts 412 "no change" response as success for idempotency. |
| [`src/zitadel/dynamic/__tests__/permanent-password.test.ts`](src/zitadel/dynamic/__tests__/permanent-password.test.ts) | 7 tests covering create happy / 412-idempotent / 5xx-throws, update with new password preserves `markedAt`, update 5xx-throws, delete-makes-zero-requests, read-makes-zero-requests. |
| [`src/zitadel/dynamic/index.ts`](src/zitadel/dynamic/index.ts) | Re-export the new resource. |
| [`src/zitadel/components/e2e-test-user.ts`](src/zitadel/components/e2e-test-user.ts) | `E2eTestUserComponentArgs` gains `domain` + `jwtProfileJson` inputs. After `HumanUser` create, instantiate `ZitadelHumanUserPasswordPermanent` with the SAME ESC password value, `dependsOn: [humanUser]`. Header JSDoc grows a "Permanent-password marker" subsection. |
| [`src/zitadel/index.ts`](src/zitadel/index.ts) | Thread `domain` + `jwtProfileJson` into the `E2eTestUserComponent` call site (both are already in scope from earlier in the constructor). Cross-reference comment updated. |

## Pulumi preview on dev

```
+ pulumi-nodejs:dynamic:Resource: (create)
    [urn=urn:pulumi:dev::liverty-music::zitadel:liverty-music:E2eTestUser$pulumi-nodejs:dynamic:Resource::e2e-test-password-permanent]
    domain        : "auth.dev.liverty-music.app"
    jwtProfileJson: [secret]
    password      : [secret]
    userId        : "372875488156189391"   # matches existing HumanUser

Resources: +1 to create, ~1 to update (unrelated dashboard drift), 234 unchanged
```

The HumanUser itself is untouched.

## Test plan

- [x] `npx vitest run src/zitadel/dynamic/__tests__/permanent-password.test.ts` → 7/7 passed
- [x] `npx vitest run` (full suite) → 47/47 passed
- [x] `make lint-ts` → biome + tsc clean
- [x] `pulumi preview --stack dev` → expected diff (`+1 create`, no `HumanUser` churn)
- [ ] After merge: Pulumi Cloud Deployment for dev applies the marker resource; check `https://app.pulumi.com/pannpers/liverty-music/dev/deployments` for the run.
- [ ] After deploy: in the dev Zitadel admin console, `e2e-test-password@dev.liverty-music.app` → Credentials → "Initial password change required" toggle reads OFF (or equivalent UI affordance).
- [ ] Follow-up PR (frontend) removes the `[4b/5]` workaround block and re-verifies the capture flow against the now-permanent password.

## Refs

- OpenSpec proposal: [liverty-music/specification#466](https://github.com/liverty-music/specification/pull/466)
- Predecessor work that flagged this gap: archived [`playwright-password-test-user`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/2026-05-14-playwright-password-test-user) (see `tasks.md` "Follow-up" annotation)
- Workaround being replaced: [frontend#353](https://github.com/liverty-music/frontend/pull/353)
