### PR TITLE
fix(zitadel): scope SetHumanPassword to product org via x-zitadel-orgid

### DIFF
--- a/src/zitadel/components/e2e-test-user.ts
+++ b/src/zitadel/components/e2e-test-user.ts
@@ -203,6 +203,12 @@ export class E2eTestUserComponent extends pulumi.ComponentResource {
 			{
 				domain,
 				jwtProfileJson,
+				// The HumanUser lives in the product org; passing this
+				// explicitly via `x-zitadel-orgid` is required because the
+				// admin SA token's default org (admin org) cannot resolve
+				// product-org user events — Zitadel would otherwise
+				// return `COMMAND-G8dh3 "Password not found"`.
+				orgId,
 				userId: this.humanUser.id,
 				password: pulumi.secret(initialPassword),
 			},

--- a/src/zitadel/dynamic/__tests__/permanent-password.test.ts
+++ b/src/zitadel/dynamic/__tests__/permanent-password.test.ts
@@ -30,6 +30,7 @@ const baseProfile = {
 const baseInputs = {
 	domain: 'auth.example.test',
 	jwtProfileJson: JSON.stringify(baseProfile),
+	orgId: 'product-org-snowflake',
 	userId: 'human-user-snowflake',
 	password: 'sup3r-secret-passw0rd!',
 }
@@ -48,7 +49,7 @@ describe('permanentPasswordProvider.create', () => {
 		mockedCall.mockReset()
 	})
 
-	it('POSTs /management/v1/users/{userId}/password with noChangeRequired=true', async () => {
+	it('POSTs /management/v1/users/{userId}/password with noChangeRequired=true and x-zitadel-orgid header', async () => {
 		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
 
 		const result = await provider.create(baseInputs)
@@ -60,12 +61,19 @@ describe('permanentPasswordProvider.create', () => {
 			'/management/v1/users/human-user-snowflake/password',
 		)
 		expect(call.domain).toBe('auth.example.test')
+		// The x-zitadel-orgid header is required so Zitadel resolves the
+		// password write model against the user's actual org (not the
+		// admin SA's default org, which would return COMMAND-G8dh3).
+		expect(call.headers).toEqual({
+			'x-zitadel-orgid': 'product-org-snowflake',
+		})
 		expect(call.body).toEqual({
 			password: baseInputs.password,
 			noChangeRequired: true,
 		})
 		expect(result.id).toBe('permanent-password:human-user-snowflake')
 		expect(result.outs?.userId).toBe('human-user-snowflake')
+		expect(result.outs?.orgId).toBe('product-org-snowflake')
 		expect(result.outs?.markedAt).toMatch(
 			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
 		)
@@ -128,6 +136,9 @@ describe('permanentPasswordProvider.update', () => {
 		expect(call.path).toBe(
 			'/management/v1/users/human-user-snowflake/password',
 		)
+		expect(call.headers).toEqual({
+			'x-zitadel-orgid': 'product-org-snowflake',
+		})
 		// password is the unchanged prior-state value (ignoreChanges
 		// guarantees news.password === olds.password in practice).
 		expect(call.body).toEqual({

--- a/src/zitadel/dynamic/api-client.ts
+++ b/src/zitadel/dynamic/api-client.ts
@@ -138,6 +138,14 @@ export async function httpRequest(
 /**
  * Convenience helper that runs the token exchange + an authenticated REST call
  * in one step. Used by Dynamic Resource CRUD handlers below.
+ *
+ * `headers` lets a caller add request headers on top of the always-present
+ * `Authorization`, `Content-Type`, `Accept`. The most common use is
+ * `x-zitadel-orgid` to scope a Management API call to a specific
+ * org when the SA token's default org differs from the target user's
+ * resourceOwner — without it, `passwordWriteModel(ctx, userID, saOrgID)`
+ * loads an empty event stream and Zitadel returns
+ * `COMMAND-G8dh3 "Password not found"`.
  */
 export async function zitadelApiCall(opts: {
 	domain: string
@@ -145,6 +153,7 @@ export async function zitadelApiCall(opts: {
 	method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 	path: string
 	body?: unknown
+	headers?: Record<string, string>
 }): Promise<{ statusCode: number; body: string }> {
 	const token = await getAccessToken(opts.domain, opts.profile)
 	return httpRequest({
@@ -154,6 +163,7 @@ export async function zitadelApiCall(opts: {
 			Authorization: `Bearer ${token}`,
 			'Content-Type': 'application/json',
 			Accept: 'application/json',
+			...opts.headers,
 		},
 		body: opts.body ? JSON.stringify(opts.body) : undefined,
 	})

--- a/src/zitadel/dynamic/permanent-password.ts
+++ b/src/zitadel/dynamic/permanent-password.ts
@@ -6,6 +6,17 @@ export interface ZitadelHumanUserPasswordPermanentArgs {
 	domain: pulumi.Input<string>
 	/** Admin machine user JWT profile JSON (stringified) for Management API auth. */
 	jwtProfileJson: pulumi.Input<string>
+	/**
+	 * Resource-owner org id of the HumanUser. Sent as `x-zitadel-orgid`
+	 * header so Zitadel's `passwordWriteModel(ctx, userID, orgID)` loads
+	 * the right event stream. Without this, the SA token's default org
+	 * is used and Zitadel returns
+	 * `COMMAND-G8dh3 "Password not found"` whenever the SA org differs
+	 * from the user's org (which is the normal setup here: admin SA
+	 * lives in the admin org, e2e-test-password user lives in the
+	 * product org).
+	 */
+	orgId: pulumi.Input<string>
 	/** ID of the `HumanUser` whose password should be marked permanent. */
 	userId: pulumi.Input<string>
 	/**
@@ -20,6 +31,7 @@ export interface ZitadelHumanUserPasswordPermanentArgs {
 interface PermanentPasswordInputs {
 	domain: string
 	jwtProfileJson: string
+	orgId: string
 	userId: string
 	password: string
 }
@@ -62,6 +74,7 @@ export const permanentPasswordProvider: pulumi.dynamic.ResourceProvider = {
 			profile,
 			method: 'POST',
 			path: `/management/v1/users/${inputs.userId}/password`,
+			headers: { 'x-zitadel-orgid': inputs.orgId },
 			body: {
 				password: inputs.password,
 				noChangeRequired: true,
@@ -95,6 +108,7 @@ export const permanentPasswordProvider: pulumi.dynamic.ResourceProvider = {
 			profile,
 			method: 'POST',
 			path: `/management/v1/users/${news.userId}/password`,
+			headers: { 'x-zitadel-orgid': news.orgId },
 			body: {
 				password: news.password,
 				noChangeRequired: true,
@@ -154,9 +168,14 @@ function isAlreadyPermanent(body: string): boolean {
  * (the provider v0.2.0 exposes no knob to flip this flag at create
  * time).
  *
- * The caller MUST pass the same password value used for the HumanUser's
- * `initialPassword` input — the resource cannot read it back from the
- * upstream provider.
+ * The caller MUST pass:
+ * - the same password value used for the HumanUser's `initialPassword`
+ *   input (the resource cannot read it back — `initialPassword` is
+ *   write-only on the upstream @pulumiverse/zitadel provider), AND
+ * - the HumanUser's resource-owner `orgId` (sent as `x-zitadel-orgid`
+ *   so Zitadel scopes the password write-model lookup to the right
+ *   org; the admin SA's default org differs from the product org
+ *   where end-user HumanUsers live).
  *
  * See OpenSpec change `zitadel-permanent-password` for the full
  * decision record (D1–D5) and risk table.


### PR DESCRIPTION
## Summary

Pulumi Cloud dev deployment [#303](https://app.pulumi.com/pannpers/liverty-music/dev/updates/303) (post-merge of [#258](https://github.com/liverty-music/cloud-provisioning/pull/258)) failed when creating the new `e2e-test-password-permanent` marker resource:

```
Zitadel SetHumanPassword failed (400):
{"code":9,"message":"Password not found (COMMAND-G8dh3)"}
```

Root cause: the SA token used by `zitadelApiCall` is `zitadel-machine-key-for-pulumi-admin`, scoped to the **admin** org by default. The HumanUser whose password we're trying to mark permanent (`e2e-test-password@dev.liverty-music.app`) lives in the **product** org. Zitadel's [`setPasswordCommand`](https://github.com/zitadel/zitadel/blob/main/internal/command/user_human_password.go#L226-L234) calls `passwordWriteModel(ctx, userID, saOrgID)` with the SA's org as `resourceOwner`, eventstore lookup against `(userID, adminOrgID)` returns no events → unspecified user state → `COMMAND-G8dh3 "Password not found"`.

Other dynamic resources here either target `/admin/v1/...` (instance-level — no org context needed, like smtp-activation) or operate on admin-org users (`pannpers-google-link`), so this is the first `/management/v1/...` resource that crosses the admin-SA-to-product-org boundary; none of the existing precedents needed an explicit org header.

## Fix

| File | Change |
|---|---|
| [`src/zitadel/dynamic/api-client.ts`](src/zitadel/dynamic/api-client.ts) | `zitadelApiCall` accepts optional `headers?: Record<string,string>`, merged on top of always-present Authorization/Content-Type/Accept. Backward-compatible. |
| [`src/zitadel/dynamic/permanent-password.ts`](src/zitadel/dynamic/permanent-password.ts) | `ZitadelHumanUserPasswordPermanentArgs` gains `orgId`. `create()` + `update()` set `x-zitadel-orgid: <orgId>` on the SetHumanPassword call. JSDoc on the resource class updated. |
| [`src/zitadel/components/e2e-test-user.ts`](src/zitadel/components/e2e-test-user.ts) | Pass `productOrg.id` (already `orgId` in component args) to the marker resource with an inline explanatory comment. |
| [`src/zitadel/dynamic/__tests__/permanent-password.test.ts`](src/zitadel/dynamic/__tests__/permanent-password.test.ts) | baseInputs gets `orgId: 'product-org-snowflake'`. Create + update tests assert the `x-zitadel-orgid` header is sent. |

## Pulumi preview on dev

```
+ pulumi-nodejs:dynamic:Resource e2e-test-password-permanent  (create, with orgId input)
~ 5 dynamic resources [diff: ~__provider]  (no-op closure-hash diff
                                            because api-client.ts module changed)
Resources: +1 to create, ~5 to update (5 are no-ops), 230 unchanged.
```

The previous failed-create attempt is gone from state (failed creates don't persist), so this PR's apply will retry from scratch with the correct header.

## Test plan

- [x] `npx vitest run` → 50/50 passed (including 2 updated tests asserting the org header)
- [x] `make lint-ts` → biome + tsc clean
- [x] `pulumi preview --stack dev` → expected diff (+1 create with correct inputs)
- [ ] Post-merge: dev Pulumi Cloud Deployment completes successfully and the marker resource lands in dev Zitadel state
- [ ] Verify in dev Zitadel admin console that `e2e-test-password@dev.liverty-music.app` shows `noChangeRequired = true` on first sign-in (no `/password/change` redirect)
- [ ] Then proceed with the frontend cleanup PR

## Refs

- Failed deployment: https://app.pulumi.com/pannpers/liverty-music/dev/updates/303
- Original PR: liverty-music/cloud-provisioning#258
- OpenSpec change: [`zitadel-permanent-password`](https://github.com/liverty-music/specification/tree/main/openspec/changes/zitadel-permanent-password)
- Zitadel error source: [`setPasswordCommand` line 226-234](https://github.com/zitadel/zitadel/blob/main/internal/command/user_human_password.go#L226-L234)
