### PR TITLE
feat(zitadel): wire complete prod Zitadel app stack via ZitadelProdStackComponent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 	GitHubRepositoryComponent,
 	RepositoryName,
 } from './github/index.js'
-import { BackendMachineKeyComponent } from './zitadel/components/backend-machine-key.js'
+import { ZitadelProdStackComponent } from './zitadel/components/zitadel-prod-stack.js'
 import { SecretsComponent, Zitadel } from './zitadel/index.js'
 
 const brandId = 'liverty-music'
@@ -64,12 +64,17 @@ if (env === 'prod') {
 	})
 }
 
-// 4. Zitadel Identity (self-hosted, dev only post-cutover).
-// Provider points at `https://auth.dev.liverty-music.app`; admin SA key is
-// pulled from GSM `zitadel-machine-key-for-pulumi-admin` (populated once by the in-cluster
-// bootstrap-uploader sidecar). Cutover scope is dev-only (OpenSpec D10);
-// the env guard inside the Zitadel class throws if invoked from staging /
-// prod until those environments get their own self-hosted instance.
+// 4. Zitadel Identity (self-hosted).
+// dev:  `Zitadel` class — full 13-component assembly (Provider, two orgs,
+//       Project, Frontend, Smtp, ActionsV2, MachineUser, LoginClient,
+//       GoogleAdminIdp, AdminOrgConfig, HumanAdmin, E2eTestUser).
+// prod: `ZitadelProdStackComponent` — 9-component wrapper (same as dev
+//       minus `E2eTestUserComponent`, which is deferred per OpenSpec change
+//       `complete-zitadel-prod-pulumi-stack`). Re-uses every leaf component
+//       file unchanged; dev URNs do not churn.
+// Both providers pull the admin SA JWT from GSM
+// `zitadel-machine-key-for-pulumi-admin` (populated once by the in-cluster
+// `bootstrap-uploader` sidecar on first-instance Zitadel boot).
 let zitadelMachineKey: pulumi.Output<string> | undefined
 let zitadelLoginPat: pulumi.Output<string> | undefined
 if (env === 'dev') {
@@ -93,6 +98,30 @@ if (env === 'dev') {
 	})
 	zitadelMachineKey = zitadel.machineKeyDetails
 	zitadelLoginPat = zitadel.loginClientToken
+} else if (env === 'prod') {
+	const zitadelProd = new ZitadelProdStackComponent('liverty-music', {
+		env,
+		gcpProject: `${brandId}-${env}`,
+		postmarkServerApiToken: postmarkConfig.serverApiToken,
+		googleAdminIdpClientId: zitadelConfig.apply(
+			(z) => z.googleAdminIdp.clientId,
+		),
+		googleAdminIdpClientSecret: zitadelConfig.apply(
+			(z) => z.googleAdminIdp.clientSecret,
+		),
+		pannpersGoogleSub: zitadelConfig.apply(
+			(z) => z.adminGoogleSubs.pannpers,
+		),
+	})
+	zitadelLoginPat = zitadelProd.loginClientToken
+	// `zitadelMachineKey` intentionally NOT set for prod: the inner
+	// `BackendMachineKeyComponent` already creates the
+	// `zitadel-machine-key-for-backend-app` GSM Secret + Version + IAM
+	// binding directly. Routing the JWT through `Gcp.esoOnlySecrets` /
+	// `appServiceAccountSecrets` would duplicate the Secret and conflict
+	// at apply time. Dev does flow `zitadelMachineKey` through `Gcp`
+	// because dev's `Zitadel` class does not create the GSM Secret itself
+	// (handled by `Gcp.KubernetesComponent` in the dev path).
 }
 
 // 2. GCP Infrastructure (All Environments)
@@ -121,22 +150,6 @@ if (env === 'dev' || env === 'prod') {
 	new SecretsComponent('zitadel-secrets', {
 		project: gcp.project,
 		zitadelServiceAccountEmail: gcp.zitadelServiceAccountEmail,
-		esoServiceAccountEmail: gcp.esoServiceAccountEmail,
-	})
-}
-
-// 6. Prod self-hosted Zitadel: backend MachineUser + key + GSM bundle.
-// Closes the gap discovered post-`prod-k8s-manifests` deploy. The existing
-// `Zitadel` class above is dev-only (SaaS Cloud-tenant), so prod's
-// `pulumi up` was never creating `zitadel-machine-key-for-backend-app` and
-// backend Pods sat in `ContainerCreating`. The new component owns the full
-// orchestration (admin JWT lookup → Zitadel provider → org data source →
-// MachineUser/Key/OrgMember + GSM Secret bundle) so this dispatch line is
-// the thin contract.
-if (env === 'prod') {
-	new BackendMachineKeyComponent('backend-app-prod', {
-		env,
-		gcpProject: `${brandId}-${env}`,
 		esoServiceAccountEmail: gcp.esoServiceAccountEmail,
 	})
 }

--- a/src/zitadel/components/admin-org-config.ts
+++ b/src/zitadel/components/admin-org-config.ts
@@ -7,6 +7,11 @@ export interface AdminOrgConfigComponentArgs {
 	/** ID of the instance-level Google IdP that admins sign in with. */
 	googleIdpId: pulumi.Input<string>
 	provider: zitadel.Provider
+	/** Per-environment Zitadel Console URL used as the `defaultRedirectUri`
+	 *  fallback when an OIDC AuthN arrives without an explicit redirect.
+	 *  Defaults to the dev URL for backwards compatibility with dev's
+	 *  existing call site; prod passes `https://auth.liverty-music.app/ui/console`. */
+	consoleUrl?: pulumi.Input<string>
 }
 
 /**
@@ -49,8 +54,14 @@ export class AdminOrgConfigComponent extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:AdminOrgConfig', name, {}, opts)
 
-		const { adminOrgId, googleIdpId, provider } = args
+		const { adminOrgId, googleIdpId, provider, consoleUrl } = args
 		const resourceOptions = { provider, parent: this }
+		// Default preserves the dev URL so the existing dev call site
+		// (no `consoleUrl` arg passed) produces the same Pulumi state value
+		// as before — no diff on dev. Prod's wrapper passes the prod URL
+		// explicitly.
+		const defaultRedirectUri =
+			consoleUrl ?? 'https://auth.dev.liverty-music.app/ui/console'
 
 		// Shared policy fields. Most lifetimes are the same as the existing
 		// product-org LoginPolicy in `frontend.ts` for consistency. NOT
@@ -82,8 +93,10 @@ export class AdminOrgConfigComponent extends pulumi.ComponentResource {
 			// step (mirrors product-org policy).
 			ignoreUnknownUsernames: true,
 			// Default redirect after a context-less login completes. Send to
-			// the Console UI so admins land somewhere meaningful.
-			defaultRedirectUri: 'https://auth.dev.liverty-music.app/ui/console',
+			// the Console UI so admins land somewhere meaningful. Pulled from
+			// the env-keyed `consoleUrl` arg with dev as the backwards-compat
+			// default.
+			defaultRedirectUri,
 			// Standard session lifetimes (mirrored from product org policy).
 			passwordCheckLifetime: '240h0m0s',
 			externalLoginCheckLifetime: '240h0m0s',

--- a/src/zitadel/components/backend-machine-key.ts
+++ b/src/zitadel/components/backend-machine-key.ts
@@ -78,6 +78,16 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 	public readonly secretVersion: gcp.secretmanager.SecretVersion
 	public readonly secretAccessorBinding: gcp.secretmanager.SecretIamMember
 
+	/** Admin (`pulumi-admin`) JWT-profile JSON read from GSM
+	 *  `zitadel-machine-key-for-pulumi-admin` at plan time, wrapped in
+	 *  `pulumi.secret()`. Exposed so sibling components needing direct
+	 *  Zitadel Management API calls outside the @pulumiverse provider
+	 *  surface (SmtpComponent activation, ActionsV2Component Target /
+	 *  Execution dynamic resources, HumanAdminComponent IdP-link dynamic
+	 *  resource) can re-use the same secret-wrapped value rather than
+	 *  re-fetching it from GSM. Never log directly. */
+	public readonly adminJwt: pulumi.Output<string>
+
 	/** The JWT-profile JSON for authenticating as the backend machine user.
 	 *  Stored in GSM via this component; exposed here for callers that want
 	 *  to test or reference it programmatically. Never log directly. */
@@ -192,6 +202,7 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 		)
 
 		this.keyDetails = this.machineUser.keyDetails
+		this.adminJwt = adminJwt
 
 		this.registerOutputs({
 			provider: this.provider,
@@ -200,6 +211,7 @@ export class BackendMachineKeyComponent extends pulumi.ComponentResource {
 			secret: this.secret,
 			secretVersion: this.secretVersion,
 			secretAccessorBinding: this.secretAccessorBinding,
+			adminJwt: this.adminJwt,
 			keyDetails: this.keyDetails,
 		})
 	}

--- a/src/zitadel/components/zitadel-prod-stack.ts
+++ b/src/zitadel/components/zitadel-prod-stack.ts
@@ -1,0 +1,354 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+import type { Environment } from '../../config.js'
+import {
+	BACKEND_WEBHOOK_BASE_URL,
+	PRE_ACCESS_TOKEN_PATH,
+	zitadelDomainMap,
+} from '../constants.js'
+import { ActionsV2Component } from './actions-v2.js'
+import { AdminOrgConfigComponent } from './admin-org-config.js'
+import { BackendMachineKeyComponent } from './backend-machine-key.js'
+import { FrontendComponent } from './frontend.js'
+import { GoogleAdminIdpComponent } from './google-admin-idp.js'
+import { HumanAdminComponent } from './human-admin.js'
+import { LoginClientComponent } from './login-client.js'
+import { SmtpComponent } from './smtp.js'
+
+export interface ZitadelProdStackComponentArgs {
+	/** Pulumi stack environment. Drives the Zitadel provider's `domain` and
+	 *  several env-keyed maps (FrontendComponent redirect URIs,
+	 *  SmtpComponent sender-address). The wrapper enforces `env === 'prod'`
+	 *  to avoid accidental dev/staging instantiation; dev uses the existing
+	 *  `Zitadel` class verbatim. */
+	env: Environment
+	/** GCP project that owns the admin JWT GSM Secret
+	 *  `zitadel-machine-key-for-pulumi-admin` (read at plan time) and the
+	 *  `zitadel-machine-key-for-backend-app` Secret the inner
+	 *  `BackendMachineKeyComponent` creates. */
+	gcpProject: pulumi.Input<string>
+	/** Postmark Server API Token. Used as both SMTP username and password.
+	 *  Sourced from ESC `pulumiConfig.postmark.serverApiToken`. */
+	postmarkServerApiToken: string
+	/** Google OAuth 2.0 Web Application client_id for the prod admin
+	 *  Google IdP. Distinct from the dev client; sourced from
+	 *  `pulumiConfig.zitadel.googleAdminIdp.clientId`. */
+	googleAdminIdpClientId: pulumi.Input<string>
+	/** Google OAuth 2.0 Web Application client_secret for the prod admin
+	 *  Google IdP. MUST be passed wrapped in `pulumi.secret()` upstream;
+	 *  sourced from `pulumiConfig.zitadel.googleAdminIdp.clientSecret`. */
+	googleAdminIdpClientSecret: pulumi.Input<string>
+	/** Google OIDC `sub` claim for the human admin (`pannpers@pannpers.dev`).
+	 *  Same numeric value as dev (the sub is account-scoped). Sourced from
+	 *  `pulumiConfig.zitadel.adminGoogleSubs.pannpers`. */
+	pannpersGoogleSub: pulumi.Input<string>
+}
+
+/**
+ * ZitadelProdStackComponent wraps the full Zitadel application stack for
+ * the `prod` Pulumi stack into a single top-level ComponentResource so
+ * that `src/index.ts` stays as a thin dispatch line (per CLAUDE.md "Main
+ * entry point dispatching to GCP and GitHub components") while dev's
+ * existing `Zitadel` class remains untouched — no URN churn on dev.
+ *
+ * ## Why not extend the dev `Zitadel` class?
+ *
+ * Loosening its `env !== 'dev'` guard or refactoring its arg shape would
+ * force a Pulumi state migration on every dev URN underneath it. The
+ * cost-benefit (one class vs. two) does not justify churning settled dev
+ * state. This wrapper is a *parallel* assembly that re-uses every leaf
+ * component file unchanged.
+ *
+ * ## Component dependency order
+ *
+ *   1. BackendMachineKeyComponent — creates `zitadel.Provider`,
+ *      productOrg (`liverty-music`), backend `MachineUser` + `MachineKey`,
+ *      `OrgMember`, and the `zitadel-machine-key-for-backend-app` GSM
+ *      Secret + Version + ESO IAM binding. The provider + productOrg
+ *      outputs flow into all 9 leaves below.
+ *   2. adminOrg — `zitadel.Org('admin', { isDefault: true })`. Imported
+ *      from existing bootstrap-created state via a one-time
+ *      `pulumi import zitadel:index/org:Org admin <prod-admin-org-id>`.
+ *      `protect: true` guards against `pulumi destroy` locking everyone
+ *      out (the `pulumi-admin` MachineUser the provider authenticates as
+ *      lives inside).
+ *   3. project — `zitadel.Project('liverty-music')` in productOrg.
+ *   4. frontend — `ApplicationOidc` + product-org `LoginPolicy`.
+ *   5. smtp — Postmark `SmtpConfig` + dynamic `_activate` call.
+ *   6. actionsV2 — `Target` + `Execution` on the `preaccesstoken` flow,
+ *      injects the `email` claim into JWT access tokens before issuance.
+ *   7. loginClient — admin-org `MachineUser` + instance `IAM_LOGIN_CLIENT`
+ *      role + `PersonalAccessToken`. The PAT surfaces as
+ *      `loginClientToken`, routed via `src/index.ts` into `Gcp`'s
+ *      `esoOnlySecrets` to create the `zitadel-login-pat` GSM Secret
+ *      (symmetric with the dev path).
+ *   8. googleAdminIdp — instance-level Google IdP for operator sign-in.
+ *      Keyed on a separate prod Google OAuth Web client (NOT the dev
+ *      client) created out-of-band in Google Cloud Console.
+ *   9. adminOrgConfig — admin-org `LoginPolicy` (`userLogin=false`,
+ *      `idps=[googleIdpId]`) + instance `DefaultLoginPolicy` mirroring it.
+ *  10. humanAdmin — `pannpers@pannpers.dev` `HumanUser` + instance
+ *      `IAM_OWNER` `OrgMember` + dynamic `ZitadelUserIdpLink` pre-linking
+ *      the prod Google identity to the local user (no auto-create / no
+ *      userLogin in the admin org policy, so first sign-in needs a
+ *      pre-existing link to succeed).
+ *
+ * E2eTestUserComponent is intentionally **out of scope** — prod E2E test
+ * infra is deferred to a follow-up change (`enable-zitadel-prod-e2e-user`).
+ *
+ * ## Secret-handling invariants
+ *
+ *  - The admin JWT (`zitadel-machine-key-for-pulumi-admin`) is read via
+ *    `BackendMachineKeyComponent` and re-exposed as `adminJwt` so SMTP,
+ *    ActionsV2, and HumanAdmin dynamic-resource API calls can re-use the
+ *    same `pulumi.secret()`-wrapped value. Without the wrap, the embedded
+ *    RSA private key would surface in `pulumi preview` output and Pulumi
+ *    service state history.
+ *  - `loginClientToken` is exposed as `pulumi.Output<string>`. Callers
+ *    (here, `src/index.ts`) wrap it in `pulumi.secret()` before passing
+ *    it into Gcp's `esoOnlySecrets` so the PAT does not leak in state.
+ */
+export class ZitadelProdStackComponent extends pulumi.ComponentResource {
+	public readonly backendMachineKey: BackendMachineKeyComponent
+	public readonly adminOrg: zitadel.Org
+	public readonly project: zitadel.Project
+	public readonly frontend: FrontendComponent
+	public readonly smtp: SmtpComponent
+	public readonly actionsV2: ActionsV2Component
+	public readonly loginClient: LoginClientComponent
+	public readonly googleAdminIdp: GoogleAdminIdpComponent
+	public readonly adminOrgConfig: AdminOrgConfigComponent
+	public readonly humanAdmin: HumanAdminComponent
+
+	/** PAT for the `login-client` Zitadel MachineUser. Routed via
+	 *  `src/index.ts` into Gcp's `esoOnlySecrets` so a GSM Secret named
+	 *  `zitadel-login-pat` is created (matches the dev path's wiring). */
+	public readonly loginClientToken: pulumi.Output<string>
+
+	/** JWT-profile JSON for the `backend-app` Zitadel MachineUser.
+	 *  Exposed for symmetry with the dev `Zitadel` class. Not currently
+	 *  routed into Gcp for prod — the inner `BackendMachineKeyComponent`
+	 *  already creates the `zitadel-machine-key-for-backend-app` GSM
+	 *  Secret + Version + IAM binding directly (the prod path baked in
+	 *  by `enable-zitadel-prod-pulumi-provider`). */
+	public readonly machineKeyDetails: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: ZitadelProdStackComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:ZitadelProdStack', name, {}, opts)
+
+		const {
+			env,
+			gcpProject,
+			postmarkServerApiToken,
+			googleAdminIdpClientId,
+			googleAdminIdpClientSecret,
+			pannpersGoogleSub,
+		} = args
+
+		if (env !== 'prod') {
+			// Mirrors the env guard on the dev `Zitadel` class. Staging
+			// adoption (if ever required) needs its own bootstrap-uploaded
+			// admin JWT + Google OAuth client + ESC wiring; a separate
+			// wrapper class is the cleanest path then.
+			throw new Error(
+				`ZitadelProdStackComponent is prod-only; got env=${env}. ` +
+					'Use the dev `Zitadel` class for dev, or create a ' +
+					'staging-specific wrapper if staging is ever needed.',
+			)
+		}
+
+		const domain = zitadelDomainMap[env]
+		const consoleUrl = pulumi.interpolate`https://${domain}/ui/console`
+
+		// 1. BackendMachineKeyComponent — provider + productOrg + backend
+		// MachineUser + GSM `zitadel-machine-key-for-backend-app`. Reparented
+		// under this ComponentResource so the prod block in `src/index.ts`
+		// is a single dispatch line. The `parent` change re-anchors the
+		// existing prod state under our new URN; `aliases` preserves
+		// stateful resources (the backend MachineKey JWT must NOT be
+		// re-minted — re-mint cascades the §13.15 `Errors.AuthNKey.NotFound`
+		// auth failure).
+		this.backendMachineKey = new BackendMachineKeyComponent(
+			'backend-app-prod',
+			{ env, gcpProject },
+			{
+				parent: this,
+				// Previously a top-level resource (no explicit parent → root
+				// stack). `{ parent: pulumi.rootStackResource }` is the
+				// canonical "previously had no parent" alias form per the
+				// Pulumi SDK comment on `Alias.parent`. Aliases on a parent
+				// propagate to child URNs automatically (the child URN's
+				// parent-chain segment changes alongside this one), so the
+				// inner `MachineUser` + GSM `zitadel-machine-key-for-backend-
+				// app` resources keep their state without a destroy-replace
+				// cycle (re-mint would cascade the §13.15
+				// `Errors.AuthNKey.NotFound` auth failure).
+				aliases: [{ parent: pulumi.rootStackResource }],
+			},
+		)
+
+		const provider = this.backendMachineKey.provider
+		const productOrg = this.backendMachineKey.productOrg
+		const adminJwt = this.backendMachineKey.adminJwt
+
+		// 2. Admin org — bootstrap-created by Zitadel (configmap sets
+		// `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`). Brought into Pulumi state
+		// via one-time `pulumi import zitadel:index/org:Org admin
+		// <prod-admin-org-id>` BEFORE the first `pulumi up --stack prod`
+		// after this change merges. `protect: true` is mandatory: `pulumi
+		// destroy` against the admin org would lock all operators out
+		// because the `pulumi-admin` MachineUser the provider authenticates
+		// as lives inside it. Mirrors the dev path exactly.
+		this.adminOrg = new zitadel.Org(
+			'admin',
+			{ name: 'admin', isDefault: true },
+			{ provider, protect: true, parent: this },
+		)
+
+		// 3. Product Project — hosts the frontend `ApplicationOidc` below.
+		// Mirrors dev's `Zitadel.project` constructor args verbatim.
+		this.project = new zitadel.Project(
+			name,
+			{
+				name,
+				orgId: productOrg.id,
+				projectRoleAssertion: false,
+				projectRoleCheck: false,
+				hasProjectCheck: false,
+				privateLabelingSetting: 'PRIVATE_LABELING_SETTING_UNSPECIFIED',
+			},
+			{ provider, parent: this, dependsOn: [productOrg] },
+		)
+
+		// 4. Frontend SPA — `ApplicationOidc` + product-org `LoginPolicy`
+		// (passkey + username/password, `userLogin=true`, `allowRegister=true`).
+		this.frontend = new FrontendComponent(
+			name,
+			{
+				env,
+				orgId: productOrg.id,
+				projectId: this.project.id,
+				provider,
+			},
+			{ parent: this },
+		)
+
+		// 5. Postmark SMTP + dynamic `_activate` call. The activation is
+		// required for prod sign-up verification emails — Zitadel v4
+		// SmtpConfig provisioning alone does NOT activate the config; a
+		// separate admin API call is needed (per cutover §13.16 incident).
+		this.smtp = new SmtpComponent(
+			name,
+			{
+				env,
+				serverApiToken: postmarkServerApiToken,
+				provider,
+				domain,
+				jwtProfileJson: adminJwt,
+			},
+			{ parent: this },
+		)
+
+		// 6. Actions V2 — REST webhook to backend's `/pre-access-token`
+		// endpoint, fires on the `preaccesstoken` flow to inject the
+		// `email` claim into JWT access tokens before issuance. Without
+		// this, backend's `ValidateIdentity` fails closed (the `email`
+		// claim is required across all backend code paths).
+		this.actionsV2 = new ActionsV2Component(
+			name,
+			{
+				domain,
+				jwtProfileJson: adminJwt,
+				preAccessTokenEndpoint: `${BACKEND_WEBHOOK_BASE_URL}${PRE_ACCESS_TOKEN_PATH}`,
+				provider,
+			},
+			{ parent: this },
+		)
+
+		// 7. Login V2 UI service identity — admin-org `MachineUser` +
+		// instance `IAM_LOGIN_CLIENT` role + `PersonalAccessToken`. Lives
+		// in the admin org per the "Place Machine Users by Responsibility"
+		// rule (operator-tier identities go in admin, end-user-tier in
+		// product). The PAT surfaces via `loginClientToken` below.
+		this.loginClient = new LoginClientComponent(
+			name,
+			{ orgId: this.adminOrg.id, provider },
+			{ parent: this },
+		)
+
+		// 8. Instance-level Google IdP for operator (Admin Console) sign-in.
+		// Keyed on a SEPARATE prod Google OAuth Web Application client
+		// (created out-of-band in Google Cloud Console); not the dev
+		// client. The admin-org LoginPolicy below references this IdP's id.
+		this.googleAdminIdp = new GoogleAdminIdpComponent(
+			name,
+			{
+				clientId: googleAdminIdpClientId,
+				clientSecret: googleAdminIdpClientSecret,
+				provider,
+			},
+			{ parent: this },
+		)
+
+		// 9. Login policies — admin-org explicit override + instance
+		// `DefaultLoginPolicy` mirror. Both reference the Google IdP so
+		// Console login surfaces the Google button regardless of which
+		// routing path Login V2 takes (instance default vs. user's home
+		// org — design D8). `userLogin=false` + `allowRegister=false`
+		// confine Console sign-in to the Google IdP path.
+		this.adminOrgConfig = new AdminOrgConfigComponent(
+			name,
+			{
+				adminOrgId: this.adminOrg.id,
+				googleIdpId: this.googleAdminIdp.idp.id,
+				provider,
+				consoleUrl,
+			},
+			{ parent: this },
+		)
+
+		// 10. Human admin (pannpers@pannpers.dev) in the admin org. The
+		// Google identity is pre-linked via `ZitadelUserIdpLink` (inside
+		// the component) — required because the admin org's policy
+		// disables auto-create + userLogin, so the very first Console
+		// sign-in needs a pre-existing `(idpId, externalUserId)` link
+		// to resolve to the local IAM_OWNER user.
+		this.humanAdmin = new HumanAdminComponent(
+			name,
+			{
+				adminOrgId: this.adminOrg.id,
+				email: 'pannpers@pannpers.dev',
+				firstName: 'Kyosuke',
+				lastName: 'Hamada',
+				googleIdpId: this.googleAdminIdp.idp.id,
+				googleSub: pannpersGoogleSub,
+				domain,
+				jwtProfileJson: adminJwt,
+				provider,
+			},
+			{ parent: this },
+		)
+
+		this.loginClientToken = this.loginClient.token
+		this.machineKeyDetails = this.backendMachineKey.keyDetails
+
+		this.registerOutputs({
+			backendMachineKey: this.backendMachineKey,
+			adminOrg: this.adminOrg,
+			project: this.project,
+			frontend: this.frontend,
+			smtp: this.smtp,
+			actionsV2: this.actionsV2,
+			loginClient: this.loginClient,
+			googleAdminIdp: this.googleAdminIdp,
+			adminOrgConfig: this.adminOrgConfig,
+			humanAdmin: this.humanAdmin,
+			loginClientToken: this.loginClientToken,
+			machineKeyDetails: this.machineKeyDetails,
+		})
+	}
+}

--- a/src/zitadel/components/zitadel-prod-stack.ts
+++ b/src/zitadel/components/zitadel-prod-stack.ts
@@ -333,8 +333,20 @@ export class ZitadelProdStackComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
-		this.loginClientToken = this.loginClient.token
-		this.machineKeyDetails = this.backendMachineKey.keyDetails
+		// Wrap at the wrapper boundary per D4: both `LoginClient.token`
+		// (sourced from `@pulumiverse/zitadel`'s `PersonalAccessToken.token`)
+		// and `BackendMachineKey.keyDetails` (sourced from `MachineKey.
+		// keyDetails`) are plain `Output<string>` carrying credential bytes.
+		// Without `pulumi.secret()` here, the values would surface in this
+		// ComponentResource's `registerOutputs(...)` state record. Downstream
+		// consumers (`Gcp.esoOnlySecrets` for the PAT, the GSM SecretVersion
+		// for the MachineKey JWT) ALSO wrap defensively, but D4 requires the
+		// wrap as early as possible to prevent leak via intermediate
+		// component-graph traversal.
+		this.loginClientToken = pulumi.secret(this.loginClient.token)
+		this.machineKeyDetails = pulumi.secret(
+			this.backendMachineKey.keyDetails,
+		)
 
 		this.registerOutputs({
 			backendMachineKey: this.backendMachineKey,


### PR DESCRIPTION
## Summary

- Implements OpenSpec change `complete-zitadel-prod-pulumi-stack` (spec PR: liverty-music/specification#468).
- Adds `ZitadelProdStackComponent` — a single top-level wrapper that instantiates the 9 Pulumi Zitadel components currently unwired for prod (admin-org `pulumi import`, `Project`, `Frontend ApplicationOidc`, `Smtp + activation`, `ActionsV2 preaccesstoken`, `LoginClient PAT`, `GoogleAdminIdp`, `AdminOrgConfig`, `HumanAdmin`). `E2eTestUserComponent` deferred to follow-up.
- Re-uses `BackendMachineKeyComponent` as a composed sub-component (NOT deleted) with `parent: this` + `aliases: [{ parent: pulumi.rootStackResource }]` so the existing prod backend MachineKey state survives the parent reshape (re-mint would cascade §13.15 `Errors.AuthNKey.NotFound`).
- `loginClientToken` routed through `Gcp.esoOnlySecrets` so the prod GSM `zitadel-login-pat` Secret is created the same way as dev — single code path for both envs.

## Pulumi Preview Verified (prod stack)

[Preview #261](https://app.pulumi.com/pannpers/liverty-music/prod/previews/f1e301fa-f0fb-4f3d-97f4-a9d2ed8db2a5) shows:

- **30 creates** (admin org, product Project, 9 component wrappers + their leaves, 3 dynamic resources, GSM `zitadel-login-pat` Secret + Version + IAM)
- **1 update** (`kubernetes-cluster` — KubernetesComponent adding `zitadel-login-pat` to `esoOnlySecrets`)
- **0 replace / 0 destroy** ✓ (alias propagation preserved the backend MachineKey subtree)

## Post-Merge Operator Runbook

> **DO NOT trigger `pulumi up --stack prod` until ALL pre-flight steps below complete.** Skipping the admin-org `pulumi import` will cause Pulumi to attempt to create a *new* `admin` org that conflicts with the bootstrap-created one, breaking the provider auth chain.

### Phase 1 — Pre-flight (out-of-band, before first `pulumi up`)

Reference: [spec tasks.md §1-3](https://github.com/liverty-music/specification/blob/main/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md#1-pre-flight-out-of-band-before-first-pulumi-up---stack-prod) (after spec PR #468 merges).

1. **§1.1** Verify GSM `zitadel-machine-key-for-pulumi-admin` has at least one ENABLED version:
   ```bash
   gcloud secrets versions list zitadel-machine-key-for-pulumi-admin --project liverty-music-prod
   ```
2. **§1.2** Fetch the prod admin-org-id via the Zitadel admin API (JWT-bearer grant against `https://auth.liverty-music.app/oauth/v2/token`, then `GET /admin/v1/orgs`, record the org id where `name == "admin"`).
3. **§1.3** Check the prod Zitadel admin API for any pre-seeded `SmtpConfig`: `GET /admin/v1/smtp`. Document/resolve before `pulumi up`.
4. **§1.4** Create the prod Google OAuth 2.0 Web Application client in [Google Cloud Console](https://console.cloud.google.com/apis/credentials?project=liverty-music-prod). Authorized redirect URI: `https://auth.liverty-music.app/ui/v2/login/login/callback`. Record `client_id` + `client_secret` to a secure password manager.
5. **§1.5** Confirm `pannpers@pannpers.dev`'s Google `sub` claim matches dev's `pulumiConfig.zitadel.adminGoogleSubs.pannpers` value.

### Phase 2 — ESC seeding ([§2.1-2.5](https://github.com/liverty-music/specification/blob/main/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md#2-esc-seeding-liverty-musicprod))

```bash
esc env set liverty-music/prod pulumiConfig.zitadel.googleAdminIdp.clientId "<prod-client-id>"
esc env set liverty-music/prod pulumiConfig.zitadel.googleAdminIdp.clientSecret "<prod-client-secret>" --secret
esc env set liverty-music/prod pulumiConfig.zitadel.adminGoogleSubs.pannpers "<pannpers-google-sub>" --secret
esc env get liverty-music/prod   # verify all 3 entries resolve
```

No `pulumiJwtProfileJson` entry needed — sourced from GSM at plan time inside `ZitadelProdStackComponent`.

### Phase 3 — Pulumi import (one-time, [§3.1-3.3](https://github.com/liverty-music/specification/blob/main/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md#3-one-time-pulumi-import-of-admin-org))

```bash
cd cloud-provisioning
pulumi stack select prod
pulumi import zitadel:index/org:Org admin <prod-admin-org-id>
pulumi stack export | jq '.deployment.resources[] | select(.type == "zitadel:index/org:Org")'
# expect: { name: "admin", isDefault: true, protect: true }
```

### Phase 4 — Deploy ([§11.4](https://github.com/liverty-music/specification/blob/main/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md))

Manually trigger from [Pulumi Cloud prod console](https://app.pulumi.com/pannpers/liverty-music/prod/deployments). Watch deploy logs for: SMTP `_activate`, `ZitadelUserIdpLink` dynamic resource for `pannpers`, login-client PAT, frontend `ApplicationOidc`.

### Phase 5 — Smoke tests ([§12.1-12.6](https://github.com/liverty-music/specification/blob/main/openspec/changes/complete-zitadel-prod-pulumi-stack/tasks.md#12-smoke-tests-post-deploy))

- **§12.1** SPA sign-in flow at `https://liverty-music.app` — Login V2 UI presents passkey + username/password
- **§12.2** Sign-up email verification arrives via Postmark
- **§12.3** Operator Console sign-in at `https://auth.liverty-music.app/ui/console` via Google IdP resolves to `pannpers@pannpers.dev` with IAM_OWNER
- **§12.4** Decode SPA-issued access token — `email` claim present
- **§12.5** `kubectl get externalsecret -n zitadel zitadel-web-secrets -o yaml --context prod` → `Status=Ready`
- **§12.6** `zitadel-web` Pod transitions `ContainerCreating` → `Running` (1/1 Ready)

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [x] `pulumi preview --stack prod` shows 30 creates + 1 update + 0 replace + 0 destroy (alias propagation verified)
- [x] `pulumi preview --stack dev` shows cosmetic dashboard JSON normalization only (Zitadel changes env-guarded ✓)
- [ ] Operator completes Phases 1-3 above
- [ ] `pulumi up --stack prod` succeeds (Phase 4)
- [ ] Smoke tests §12.1-12.6 all pass (Phase 5)
- [ ] Operator marks tasks.md §11-13 complete, then runs `/opsx:archive complete-zitadel-prod-pulumi-stack`
