### PR TITLE
fix(zitadel): use import: resource option for prod admin org

### DIFF
--- a/src/zitadel/components/zitadel-prod-stack.ts
+++ b/src/zitadel/components/zitadel-prod-stack.ts
@@ -197,16 +197,45 @@ export class ZitadelProdStackComponent extends pulumi.ComponentResource {
 
 		// 2. Admin org — bootstrap-created by Zitadel (configmap sets
 		// `ZITADEL_FIRSTINSTANCE_ORG_NAME=admin`). Brought into Pulumi state
-		// via one-time `pulumi import zitadel:index/org:Org admin
-		// <prod-admin-org-id>` BEFORE the first `pulumi up --stack prod`
-		// after this change merges. `protect: true` is mandatory: `pulumi
-		// destroy` against the admin org would lock all operators out
-		// because the `pulumi-admin` MachineUser the provider authenticates
-		// as lives inside it. Mirrors the dev path exactly.
+		// via the `import:` resource option (inline, no separate `pulumi
+		// import` CLI step). `protect: true` is mandatory: `pulumi destroy`
+		// against the admin org would lock all operators out because the
+		// `pulumi-admin` MachineUser the provider authenticates as lives
+		// inside it. Mirrors the dev path's two-org topology.
+		//
+		// ## Why `import:` (resource option) instead of `pulumi import` (CLI)
+		//
+		// The CLI form `pulumi import zitadel:index/org:Org admin <id>` was
+		// documented in `2026-05-08-add-zitadel-console-admin-via-google-idp`
+		// design D8 as the dev approach (with `--provider liverty-music-
+		// provider=<urn>`). That works after a prior `pulumi up` has already
+		// created the Zitadel provider resource in state, leaving its URN
+		// available for the `--provider` flag. For prod the provider lives
+		// inside `BackendMachineKeyComponent`, which is itself first
+		// created on the same `pulumi up --stack prod` that needs to bring
+		// the admin org into state — the chicken-and-egg means there is no
+		// pre-existing provider URN to pass to `--provider`. The Pulumi
+		// `import:` resource option resolves this by importing the resource
+		// inline during the same apply that creates its parent + provider:
+		// Pulumi resolves the provider in-graph and binds the imported
+		// resource under the correct provider on the same pass.
+		//
+		// Pulumi treats `import:` as a one-time hint; once the resource is
+		// in state on a successful apply, the `import:` value is ignored on
+		// subsequent applies and can be left in source or removed. The
+		// archived dev change `add-zitadel-console-admin-via-google-idp`
+		// documents the CLI form because its provider already existed at
+		// the time; this file's prod path uses `import:` instead. Both
+		// land the same end-state.
 		this.adminOrg = new zitadel.Org(
 			'admin',
 			{ name: 'admin', isDefault: true },
-			{ provider, protect: true, parent: this },
+			{
+				provider,
+				protect: true,
+				parent: this,
+				import: '372892288692584603',
+			},
 		)
 
 		// 3. Product Project — hosts the frontend `ApplicationOidc` below.


### PR DESCRIPTION
## Summary

Follow-up to #260. The original plan in `complete-zitadel-prod-pulumi-stack` had the operator run a separate `pulumi import zitadel:index/org:Org admin <prod-admin-org-id> --stack prod` CLI step in Phase 3 (per tasks.md §3.2). When I attempted that command tonight, it failed with:

```
pulumi:providers:zitadel default_0_2_0_github_/api.github.com/pulumiverse
  error: Provider is missing a required configuration key, try `pulumi config set zitadel:domain`
```

The chicken-and-egg: the prod Zitadel provider lives inside `BackendMachineKeyComponent` and is itself created on the same `pulumi up` that needs to import the admin org — so there's no pre-existing provider URN to pass to `pulumi import --provider`. The archived dev change `2026-05-08-add-zitadel-console-admin-via-google-idp` design D8 documents the CLI form (`--provider liverty-music-provider=<urn>`), which worked for dev because dev had already created the provider on a prior `pulumi up` before the admin org needed importing — not the case for prod's first apply.

## Fix

Use Pulumi's `import:` resource option inline on `new zitadel.Org('admin', ...)`. Pulumi resolves the provider in-graph and binds the imported resource under the correct provider on a single apply pass — no separate CLI step needed.

```typescript
this.adminOrg = new zitadel.Org(
  'admin',
  { name: 'admin', isDefault: true },
  {
    provider,
    protect: true,
    parent: this,
    import: '372892288692584603', // prod admin-org-id, discovered per tasks.md §1.2
  },
)
```

`import:` is a one-time hint: once the resource is in state on a successful apply, Pulumi ignores the value on subsequent applies. The value can stay in source for documentation or be removed in a later cleanup PR.

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [ ] `pulumi preview --stack prod` shows the same ~30 resource creates as #260 + the admin org now flagged as an import (no `create`/`replace`/`destroy` on backend MachineKey subtree)
- [ ] After merge, `pulumi up --stack prod` succeeds end-to-end, bringing the admin org into state alongside the 29 new creates
- [ ] Smoke tests per `complete-zitadel-prod-pulumi-stack/tasks.md §12` pass (SPA sign-in, sign-up email, operator Console Google IdP, JWT email claim, `zitadel-web` Pod Running)

## Related

- Implements correction to `tasks.md §3` of OpenSpec change `complete-zitadel-prod-pulumi-stack`
- The corresponding `tasks.md` doc fix (replace §3 with note that import happens inline) will land in the archive PR for `complete-zitadel-prod-pulumi-stack`
- Original PR: #260 (already merged)
