### PR TITLE
feat(zitadel): expose webFrontendClientId + productOrgId as outputs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,3 +177,14 @@ export const folder = gcp.folder
 export const project = gcp.project
 // Export for debug/reference
 export const githubEnv = env
+
+// Frontend SPA OIDC client_id + product-org id — consumed by the
+// frontend repo's `.env.{dev,prod}` to bake into the SPA bundle at
+// build time. Operators retrieve via `pulumi stack output
+// webFrontendClientId` / `pulumi stack output productOrgId` after
+// `pulumi up`. See OpenSpec change `prepare-prod-service-in` §1.2 /
+// §2.3 for the prod consumption path; the identity-management spec's
+// "Manage OIDC Application" requirement makes these per-env values
+// the contract surface the frontend build depends on.
+export const webFrontendClientId = zitadel.frontend.application.clientId
+export const productOrgId = zitadel.productOrg.id


### PR DESCRIPTION
## Summary

Implements specification PR liverty-music/specification#473 (`prepare-prod-service-in`) task **§1**.

Adds two Pulumi stack outputs (`webFrontendClientId`, `productOrgId`) that the frontend repo's `.env.prod` will consume to embed prod identifiers into the SPA bundle at build time.

§1.1 was effectively a no-op: the `FrontendComponent` (which provisions the `web-frontend` ApplicationOidc + product-org LoginPolicy) is already called for ALL envs without an `env === 'dev'` gate (per `refactor-unify-env-dispatch`). So prod's `web-frontend` ApplicationOidc + `liverty-music` product org already exist after the next `pulumi up --stack prod`. Only §1.2 (stack outputs) needed implementation.

## What changes

### `src/index.ts`
- Add `export const webFrontendClientId = zitadel.frontend.application.clientId`
- Add `export const productOrgId = zitadel.productOrg.id`

These become consumable via:
```bash
pulumi stack output webFrontendClientId --stack prod
pulumi stack output productOrgId --stack prod
```
after the next prod `pulumi up`.

Neither value is sensitive:
- `clientId` is a public OIDC client identifier (SPA `AuthMethodType=NONE` — no client secret exists).
- `orgId` is referenced in every OIDC discovery request anyway.

No secret marking applied.

## Verification

- [x] `make lint-ts` passes (biome + tsc, 0 issues).
- [x] Change is purely additive — 2 new exports, no resource creates / updates / deletes expected in `pulumi preview --stack prod`.

## Expected Pulumi preview

This PR triggers `pulumi preview` automatically on Pulumi Cloud (per the dev + prod Pulumi Cloud Deployments wiring). Expected diff:
- **dev**: 0 resource changes; new outputs `webFrontendClientId`, `productOrgId` appear.
- **prod**: 0 resource changes; new outputs `webFrontendClientId`, `productOrgId` appear.

The actual preview output should appear as a Pulumi Cloud comment on this PR within a few minutes; reviewer should confirm 0 resource creates / updates / deletes.

## Sequencing

Per the specification's design D7 migration plan:
- This PR is item B (cloud-provisioning ApplicationOidc) — can run in parallel with item C (backend deploy.yml + Atlas overlay, separate PR).
- After this PR merges: **§2** operator action — manually trigger `pulumi up --stack prod` via Pulumi Cloud console. This provisions the prod-side `ApplicationOidc` + Project + LoginPolicy + GoogleAdminIdp + ... that the unified `Zitadel` class instantiates. Record `pulumi stack output webFrontendClientId` / `productOrgId` for §7's `.env.prod` consumption.
- After §2: the frontend PR (§7, separate, gated on these stack outputs) can be opened.

## Out of scope

- The actual `pulumi up --stack prod` execution — operator-attended (CLAUDE.md "Pulumi Deployments (Automated)" — prod is manual-trigger only).
- The frontend `.env.prod` commit and Release tag cut — separate PR (§7, §8) gated on this PR's stack outputs being available.
- The prod kustomize overlay image-pinning (§9) — separate PR, gated on backend + frontend Release cuts.

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- Companion PR (backend, in parallel): coming separately for §3 + §4 (deploy.yml release-tag path + Atlas prod overlay)

## Test plan

- [ ] CI green (biome + tsc lint)
- [ ] Pulumi Cloud preview for `prod` shows 0 resource changes + 2 new outputs
- [ ] Pulumi Cloud preview for `dev` shows 0 resource changes + 2 new outputs
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off
