### PR TITLE
fix(backend/prod): align VAPID_PUBLIC_KEY to GSM-stored prod private

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
@@ -15,5 +15,7 @@ GCP_PROJECT_ID=liverty-music-prod
 OIDC_ISSUER_URL=https://auth.liverty-music.app
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
-# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
-VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo
+# Push Notifications (VAPID) — see server/configmap.env for the full
+# derivation note. Public half of the prod keypair whose private half
+# lives in GSM `vapid-private-key`.
+VAPID_PUBLIC_KEY=BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc

--- a/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
@@ -16,5 +16,7 @@ NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
 
-# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
-VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo
+# Push Notifications (VAPID) — see server/configmap.env for the full
+# derivation note. Public half of the prod keypair whose private half
+# lives in GSM `vapid-private-key`.
+VAPID_PUBLIC_KEY=BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -16,7 +16,9 @@ kind: Kustomization
 #
 # IMPORTANT placeholders (replace before launch):
 #   - TICKET_SBT_ADDRESS (mainnet contract address)
-#   - VAPID_PUBLIC_KEY (prod keypair public key)
+# Resolved 2026-05-15:
+#   - VAPID_PUBLIC_KEY → prod-specific value derived from the GSM
+#     `vapid-private-key` private scalar (see server/configmap.env note).
 # The concert-discovery CronJob runs on the base daily schedule (no
 # Fridays-only patch), because prod's concert ingestion should be regular.
 

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -23,5 +23,12 @@ NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
 
-# Push Notifications (VAPID) — placeholder; replace with prod public key before launch
-VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo
+# Push Notifications (VAPID) — public half of the prod keypair whose private
+# half lives in GSM `vapid-private-key` (project `liverty-music-prod`).
+# Derived 2026-05-15 from the GSM scalar via Python `cryptography` (P-256
+# SECP256R1 point multiplication, Base64URL-encoded uncompressed). See
+# OpenSpec change `prepare-prod-service-in` §6 — Mode B exception case:
+# GSM was already prod-specific from the original prod bootstrap, only the
+# configmap public was carried over from dev as a placeholder, so the fix
+# is a configmap-only update rather than a full keypair regen.
+VAPID_PUBLIC_KEY=BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc


### PR DESCRIPTION
## Summary

Implements specification PR liverty-music/specification#473 (`prepare-prod-service-in`) **§6** — the Mode B exception case revealed by the §6.1-6.2 read-only VAPID audit.

The prod backend ConfigMap's `VAPID_PUBLIC_KEY` value is the dev placeholder (`BNg-zJP4Ii…`) while the GSM `vapid-private-key` is **already** a prod-specific keypair. Spec invariant *"the configmap public SHALL be byte-equal to the GSM-derived public"* is violated — but only the configmap half needs correction. This PR updates the configmap public to match the existing GSM private, without regenerating the keypair or touching GSM/ESC.

## Findings (Phase 6.1-6.2, executed locally)

```
$ gcloud secrets versions access latest --secret=vapid-private-key --project=liverty-music-prod
# → 32-byte P-256 scalar, Base64URL-encoded (43 chars)

$ python3 derive-vapid-public.py vapid-prod-private.raw
BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc
```

Compared against the current prod configmap (3 files: `server`, `consumer`, `cronjob/concert-discovery`):

```
configmap:     BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo  # = dev placeholder
GSM-derived:   BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc  # = prod-specific
```

## Why this is configmap-only (not full Mode B)

The design.md §6 procedure assumes both halves are placeholders (dev carry-over). The actual state has:
- **GSM**: prod-specific (correct, no action needed)
- **Configmap**: dev placeholder (wrong, needs correction)

So this PR is **strictly simpler than the spec's Mode B atomic-apply procedure**:

| Step | Full Mode B (spec) | This PR (Option I) |
|---|---|---|
| Generate fresh keypair | ✅ | ❌ unnecessary |
| `esc env set vapidPrivateKey` | ✅ | ❌ unchanged |
| `pulumi up --stack prod` | ✅ | ❌ ESC unchanged → GSM unchanged |
| Update 3 backend configmap.env | ✅ | ✅ |
| ESO force-sync + double-roll | ✅ | ❌ only ArgoCD-triggered Reloader roll |
| Sub-minute mismatch window | acknowledged | doesn't apply — only one half changes |

After merge:
- ArgoCD syncs the configmap on its next poll.
- Reloader rolls server-app + consumer-app pods **once**.
- New pods load new configmap public + the same GSM private (already prod-specific) → matched.
- Old pods are torn down during the rolling update; their advertised dev placeholder was the broken half all along, never validated against anything in prod (zero live push subscriptions, prod is pre-launch).

## Spec implications (for archive time)

The `prod-environment-bootstrap` requirement *"prod-specific keys SHALL be regenerated and both halves updated"* is too prescriptive — it forces a fresh keypair even when one half is already prod-specific. When archiving `prepare-prod-service-in`, soften to allow either path:

> If the configmap-baked public key was carried over from dev as a placeholder, the prod-specific halves SHALL be brought into agreement — either by regenerating a fresh keypair and updating both halves (when the GSM private is also a dev carry-over), or by updating the configmap public to match the existing prod-specific GSM private (when GSM is already correct, as was the case on 2026-05-15).

(This will be a one-line MODIFIED requirement in the archive PR; capturing here so the archive author has the context.)

## Files

```
k8s/namespaces/backend/overlays/prod/
├── kustomization.yaml          ← swap placeholder note for "Resolved 2026-05-15"
├── server/configmap.env         ← VAPID_PUBLIC_KEY=<prod-specific>
├── consumer/configmap.env       ← VAPID_PUBLIC_KEY=<prod-specific>
└── cronjob/
    └── concert-discovery/configmap.env  ← VAPID_PUBLIC_KEY=<prod-specific>

(artist-image-sync does NOT consume VAPID; no change needed there.)
```

## Verification

- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders 0-exit.
- [x] 3 rendered ConfigMaps (`server-config`, `consumer-consumer-config`, `concert-discovery-job-config`) all carry the new `VAPID_PUBLIC_KEY=BH-m9-…Crwl6Pc` value byte-for-byte.
- [x] Render diff against pre-fix state: only the 3 ConfigMap VAPID_PUBLIC_KEY values changed; no other resources touched.
- [ ] CI green
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off

## Out of scope

- Mainnet `TICKET_SBT_ADDRESS` (still placeholder; that's §13 in the parent change).
- Full Mode B regeneration — see the design rationale above.

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- Parent change merge: liverty-music/cloud-provisioning#264 (merged 2026-05-15)
- Phase 6.1-6.2 audit happened in the local CLI session prior to opening this PR; raw findings are reproducible by any operator with `secretmanager.secretAccessor` on `liverty-music-prod`.
