### PR TITLE
fix(github): allow release-tag deploys to prod environment

### DIFF
--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -56,25 +56,62 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 			{ parent: this },
 		)
 
-		// Create Environment
+		// Create Environment.
+		//
+		// Both dev and prod use `customBranchPolicies: true` so each env can
+		// explicitly allow-list the refs it accepts. The previous prod-only
+		// `protectedBranches: true` blocked release-tag deploys with
+		// "Tag X is not allowed to deploy to prod due to environment
+		// protection rules" because tags are never "protected branches" in
+		// GitHub's data model. The OpenSpec change `prepare-prod-service-in`
+		// §5 release-tag-triggered prod build path needs the `v*` tag
+		// pattern declared below; D7 OQ1 anticipated this gap.
 		this.environment = new github.RepositoryEnvironment(
 			`${repositoryName}`,
 			{
 				repository: repositoryName,
 				environment: environment,
-				deploymentBranchPolicy:
-					environment === 'dev'
-						? {
-								protectedBranches: false,
-								customBranchPolicies: true,
-							}
-						: {
-								protectedBranches: true,
-								customBranchPolicies: false,
-							},
+				deploymentBranchPolicy: {
+					protectedBranches: false,
+					customBranchPolicies: true,
+				},
 			},
 			{ provider, parent: this },
 		)
+
+		// Per-env allowed deployment branches / tags. dev historically ran
+		// with zero patterns yet permitted push-to-main deploys (GitHub
+		// empirically allows refs when custom_branch_policies is true and
+		// patterns are absent); making the allow-list explicit removes that
+		// ambiguity and gives prod the `v*` tag entry it needs for the
+		// release-triggered build path. The Pulumi `@pulumi/github` API
+		// distinguishes `branchPattern` from `tagPattern` (two different
+		// resources cover the two ref types), so we declare them as separate
+		// arrays.
+		const allowedBranches = ['main']
+		const allowedTags = environment === 'prod' ? ['v*'] : []
+		for (const pattern of allowedBranches) {
+			new github.RepositoryEnvironmentDeploymentPolicy(
+				`${repositoryName}-deploy-branch-${pattern.replace(/[^a-z0-9-]/gi, '-')}`,
+				{
+					repository: repositoryName,
+					environment: this.environment.environment,
+					branchPattern: pattern,
+				},
+				{ provider, parent: this, dependsOn: [this.environment] },
+			)
+		}
+		for (const pattern of allowedTags) {
+			new github.RepositoryEnvironmentDeploymentPolicy(
+				`${repositoryName}-deploy-tag-${pattern.replace(/[^a-z0-9-]/gi, '-')}`,
+				{
+					repository: repositoryName,
+					environment: this.environment.environment,
+					tagPattern: pattern,
+				},
+				{ provider, parent: this, dependsOn: [this.environment] },
+			)
+		}
 
 		// Create Variables
 		for (const [key, value] of Object.entries(variables)) {


### PR DESCRIPTION
## Summary

Fixes the prod GitHub Environment protection rule that blocked the §5 backend release-tag deploy with `Tag "v1.0.0" is not allowed to deploy to prod due to environment protection rules`.

Implements OpenSpec design D7 **OQ1** — which explicitly anticipated this exact gap:
> *OQ1: Does the existing prod GitHub Environment (set up by Pulumi's GitHubRepositoryComponent with reviewers + branch protections) work for Release events the same way it works for push events? ... verify before Phase 5.*

The audit caught up with the fix.

## Root cause

In [`src/github/components/repository.ts`](src/github/components/repository.ts), the prod env was configured with:

```ts
{ protectedBranches: true, customBranchPolicies: false }
```

GitHub's `protected_branches` policy only allows refs that have branch protection rules attached. **Tags are NEVER "protected branches"** in GitHub's data model — so any tag ref (including release tags `v*`) is rejected wholesale.

## Fix

1. Switch both dev and prod env policy to `customBranchPolicies: true, protectedBranches: false`.
2. Declare explicit allow-list patterns via `RepositoryEnvironmentDeploymentPolicy` resources:
   - **All envs**: branch pattern `main` (covers push-to-main deploys).
   - **Prod only**: tag pattern `v*` (covers the release-triggered build path).

The Pulumi `@pulumi/github` provider distinguishes `branchPattern` from `tagPattern` (two different settings on the same resource type), so we declare them as separate resource sets.

dev historically ran with `customBranchPolicies: true` and zero patterns yet permitted push-to-main deploys (GitHub empirically allows refs when `custom_branch_policies` is true and patterns are absent). This change makes that allow-list explicit so the behavior is no longer implicit.

## `pulumi preview` results

### `--stack dev`
```
Resources:
    + 4 to create
    ~ 1 to update
    5 changes. 230 unchanged
```

- **4 creates**: `RepositoryEnvironmentDeploymentPolicy` for branch `main` × 4 repos (backend, frontend, specification, cloud-provisioning).
- **1 incidental update**: `dashboard-zitadel-observability` (unrelated pre-existing drift on the `etag`/`name`/`xPos`/`yPos` fields; the GCP API canonicalizes those server-side).

### `--stack prod`
```
Resources:
    + 8 to create
    ~ 4 to update
    12 changes. 231 unchanged
```

- **4 in-place updates** on `RepositoryEnvironment` (one per repo):
  ```
  ~ deploymentBranchPolicy: {
      ~ customBranchPolicies: false => true
      ~ protectedBranches   : true  => false
    }
  ```
  These are in-place updates — the env's attached vars + secrets (PROJECT_ID, REGION, WORKLOAD_IDENTITY_PROVIDER, SERVICE_ACCOUNT) survive intact.
- **8 creates**: 4 branch-`main` policies + 4 tag-`v*` policies × 4 repos.

Zero destroys, zero replacements.

## Sequencing after merge

1. dev `pulumi up` auto-fires via Pulumi Cloud Deployments → 4 branch policies materialize on dev envs.
2. **Operator**: trigger `pulumi up --stack prod` manually via [Pulumi Cloud console](https://app.pulumi.com/pannpers/liverty-music/prod/deployments). This combines:
   - The §3 prod Zitadel `ApplicationOidc` + product org provisioning (still pending from PR #264's merge).
   - This env-policy fix.
   - Any other queued prod diffs.
3. Re-cut the backend `v1.0.0` release on `main` HEAD (`c1a9e208…`). The release-triggered `Deploy Backend` run is then expected to succeed and push 4 images to `liverty-music-prod/backend/`.

## Spec implications (for archive time)

Add an explicit allow-list requirement to `prod-environment-bootstrap` covering tag patterns for the prod env, e.g.:

> The prod GitHub Environment SHALL declare an explicit `tagPattern: "v*"` deployment policy on every repo so release-triggered Deploy workflows can enter the env.

Capturing here so the archive author has the context.

## Test plan

- [x] `make lint-ts` passes (biome + tsc, 0 issues).
- [x] `pulumi preview --stack dev` returns expected 4 creates + 1 incidental update.
- [x] `pulumi preview --stack prod` returns expected 8 creates + 4 in-place updates.
- [ ] CI green
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- Parent change: liverty-music/cloud-provisioning#264 (merged 2026-05-15)
- VAPID configmap PR (in flight): liverty-music/cloud-provisioning#265
- Failed first release attempt: https://github.com/liverty-music/backend/actions/runs/25918502384 (now deleted along with the `v1.0.0` tag)
