### PR TITLE
feat(github): add .github repo and require Claude review on specification

### DIFF
--- a/src/github/components/organization.ts
+++ b/src/github/components/organization.ts
@@ -110,11 +110,24 @@ export class GitHubOrganizationComponent extends pulumi.ComponentResource {
 			{ provider: this.provider, parent: this },
 		)
 
+		// Hosts org-wide community files and reusable workflows (e.g., the
+		// Claude review reusable workflow consumed by every other repo).
+		const dotGithubRepo = new github.Repository(
+			RepositoryName.DOT_GITHUB,
+			{
+				...defaultRepositoryArgs,
+				name: RepositoryName.DOT_GITHUB,
+				description: 'Org-wide community files and reusable workflows',
+			},
+			{ provider: this.provider, parent: this },
+		)
+
 		this.repositories = {
 			[RepositoryName.CLOUD_PROVISIONING]: cloudProvisioningRepo,
 			[RepositoryName.SPECIFICATION]: specificationRepo,
 			[RepositoryName.BACKEND]: backendRepo,
 			[RepositoryName.FRONTEND]: frontendRepo,
+			[RepositoryName.DOT_GITHUB]: dotGithubRepo,
 		}
 
 		// Create secrets

--- a/src/github/components/organization.ts
+++ b/src/github/components/organization.ts
@@ -112,8 +112,11 @@ export class GitHubOrganizationComponent extends pulumi.ComponentResource {
 
 		// Hosts org-wide community files and reusable workflows (e.g., the
 		// Claude review reusable workflow consumed by every other repo).
+		// Pulumi logical name is kebab-case (per CLAUDE.md "Code
+		// Conventions"); the actual GitHub repo name is the dotted
+		// `.github` set via the `name:` field.
 		const dotGithubRepo = new github.Repository(
-			RepositoryName.DOT_GITHUB,
+			'dot-github',
 			{
 				...defaultRepositoryArgs,
 				name: RepositoryName.DOT_GITHUB,

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -15,4 +15,5 @@ export enum RepositoryName {
 	SPECIFICATION = 'specification',
 	BACKEND = 'backend',
 	FRONTEND = 'frontend',
+	DOT_GITHUB = '.github',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,10 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.SPECIFICATION,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success'],
+	// Pilot repo for the Claude review Check Run gate introduced by
+	// OpenSpec change `claude-review-check-run`. Other repos keep
+	// `['CI Success']` until the pilot graduates.
+	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
 })
 
 // Cloud Provisioning Repository


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#474

(Not closing yet — this is the Pulumi-side pilot step of OpenSpec change [`claude-review-check-run`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/claude-review-check-run); subsequent PRs against `liverty-music/.github` and per-repo callers will follow.)

## 📝 Summary of Changes

Pulumi-side of **Step 1 (pilot)** for the [`claude-review-check-run`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/claude-review-check-run) OpenSpec change.

- Add new repo `liverty-music/.github` via `GitHubOrganizationComponent` to host the reusable Claude review workflow that will publish verdicts as GitHub Check Runs.
- Extend the `RepositoryName` enum with `DOT_GITHUB = '.github'`.
- Add `'Claude review'` alongside `'CI Success'` in the `specification` repo's `requiredStatusCheckContexts`. The specification repo is the pilot for the new Check Run gate; `backend` / `frontend` / `cloud-provisioning` keep `['CI Success']` only and will graduate after ~1 week of stable pilot operation (see [tasks.md Step 5](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/claude-review-check-run/tasks.md)).

## 🌍 Affected Stacks

- [ ] Dev
- [x] Prod

(`GitHubOrganizationComponent` is `env === 'prod'`-gated, and `BranchProtection` inside `GitHubRepositoryComponent` is `environment === 'prod'`-gated. Dev stack is unaffected.)

## 🔮 Pulumi Preview

`pulumi preview -s prod --diff` from this branch (drift-free after applying v159):

```
+ github:index/repository:Repository: (create)
    [urn=...github:liverty-music:Organization$github:index/repository:Repository::.github]
    description: "Org-wide community files and reusable workflows"
    name       : ".github"

~ github:index/branchProtection:BranchProtection: (update)
    [urn=...github:liverty-music:Repository:specification:prod$github:index/branchProtection:BranchProtection::specification-protection]
  ~ requiredStatusChecks: [
      ~ [0]: {
              ~ contexts: [
                  + [1]: "Claude review"
                ]
            }
    ]

Resources:
    + 1 to create
    ~ 1 to update
    2 changes. 242 unchanged
```

## 📦 State Changes

No `pulumi state mv` / `import` / destructive changes required. Pure additive:

- New `github.Repository::.github` resource.
- Single in-place `requiredStatusChecks.contexts` append on `specification-protection`.

## ✅ Checklist

- [x] `pulumi preview` passes locally.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config (no new secrets introduced; `ANTHROPIC_API_KEY` already provisioned as org-level `ActionsOrganizationSecret` with `visibility: 'all'`, so the new `.github` repo will inherit it automatically when its workflow runs).

## 🚀 Post-merge

This change does NOT auto-apply to prod. Per [`CLAUDE.md`](./CLAUDE.md), trigger `pulumi up -s prod` manually from [Pulumi Cloud Deployments](https://app.pulumi.com/pannpers/liverty-music/prod/deployments) after merge. Then proceed with Step 2 of [`tasks.md`](https://github.com/liverty-music/specification/tree/main/openspec/changes/archive/claude-review-check-run/tasks.md) (add reusable workflow to the newly-created `.github` repo).
