### PR TITLE
feat(k8s): pin prod overlays to prod AR + add IAM revoke runbook

### DIFF
--- a/docs/runbooks/revoke-cross-project-ar-iam.md
+++ b/docs/runbooks/revoke-cross-project-ar-iam.md
@@ -1,0 +1,72 @@
+# Revoke cross-project Artifact Registry IAM grant
+
+**Scope**: removing the manual `roles/artifactregistry.reader` grant on `liverty-music-dev` for the prod GKE node service account. Part of OpenSpec change `prepare-prod-service-in` §11.
+
+## Background
+
+During the original prod bring-up (early 2026-Q1), prod GKE pods needed to pull container images, but the prod Artifact Registry had no images yet — only `liverty-music-dev/{backend,frontend}` did. As a one-time stopgap, an operator added a cross-project IAM grant via `gcloud`:
+
+```bash
+gcloud projects add-iam-policy-binding liverty-music-dev \
+  --member='serviceAccount:gke-node@liverty-music-prod.iam.gserviceaccount.com' \
+  --role='roles/artifactregistry.reader'
+```
+
+This grant is **not** managed by Pulumi (no corresponding resource in `src/`). It's invisible to `pulumi state` and `pulumi preview`. It allowed prod GKE nodes to pull `liverty-music-dev/*` images.
+
+## When this runbook applies
+
+Run this revocation procedure AFTER all of the following are true:
+
+1. The prod kustomize overlay's `images:` block (per `prepare-prod-service-in` §9) has merged to `cloud-provisioning/main`.
+2. ArgoCD has fully reconciled the prod cluster's `backend` and `frontend` Applications. Both report `Synced/Healthy`.
+3. Every running Pod in the prod cluster references an image from `asia-northeast2-docker.pkg.dev/liverty-music-prod/*` (NOT `liverty-music-dev/*`). Verify:
+   ```bash
+   kubectl --context=gke_liverty-music-prod_asia-northeast2_autopilot-cluster-osaka \
+     get pods -A -o jsonpath='{range .items[*]}{.spec.containers[*].image}{"\n"}{end}' \
+     | grep liverty-music-dev/
+   # output MUST be empty
+   ```
+
+If any prod Pod still references `liverty-music-dev/*`, **HALT** — revoking the IAM grant will cause those Pods to `ImagePullBackOff` on their next image pull. Investigate the overlay or ArgoCD sync state and fix the source first.
+
+## Revocation procedure
+
+Once the precondition above is satisfied:
+
+```bash
+gcloud projects remove-iam-policy-binding liverty-music-dev \
+  --member='serviceAccount:gke-node@liverty-music-prod.iam.gserviceaccount.com' \
+  --role='roles/artifactregistry.reader'
+```
+
+Then wait 5 minutes and verify:
+
+```bash
+# Should return empty: no prod-cluster SA on the dev project policy.
+gcloud projects get-iam-policy liverty-music-dev \
+  --flatten='bindings[].members' \
+  --filter='bindings.members~liverty-music-prod'
+
+# Should return empty: no Pod stuck on ImagePullBackOff.
+kubectl --context=gke_liverty-music-prod_asia-northeast2_autopilot-cluster-osaka \
+  get pods -A | grep -E 'ImagePullBackOff|ErrImagePull'
+```
+
+## Recovery
+
+If a Pod hits `ImagePullBackOff` after revocation (= a missed dev-AR reference somewhere), re-add the grant immediately:
+
+```bash
+gcloud projects add-iam-policy-binding liverty-music-dev \
+  --member='serviceAccount:gke-node@liverty-music-prod.iam.gserviceaccount.com' \
+  --role='roles/artifactregistry.reader'
+```
+
+Then root-cause the missed reference: typically a sub-base `images:` block that the prod overlay didn't override (see `backend/base/server/kustomization.yaml` etc. for the pre-existing dev-AR pinning in base — the prod overlay must override each of those by name).
+
+## Why this isn't in Pulumi
+
+This grant was a stopgap, not a long-term design. The OpenSpec `prepare-prod-service-in` change makes prod-AR the canonical source so the grant is no longer needed. Reintroducing it as an IaC-managed resource (rather than removing it) would commit us to a cross-project image dependency that violates the `prod-image-pipeline` spec.
+
+If a future change ever requires prod-cluster pulls from dev AR (e.g., shared base images across envs), introduce it via Pulumi `gcp.projects.IAMMember` declared in `cloud-provisioning/src/gcp/`, NOT via manual `gcloud`.

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -138,3 +138,39 @@ configMapGenerator:
   behavior: merge
   envs:
   - consumer/configmap.env
+
+# Pin all four backend images to the prod Artifact Registry. Per OpenSpec
+# `prepare-prod-service-in` §9 + the `prod-image-pipeline` spec, prod must
+# pull from `liverty-music-prod/backend/*` and never from dev AR. The
+# `<sha>` tag is the commit SHA of liverty-music/backend `main` HEAD at
+# the time `v1.0.0` was published (= merge commit of PR #297 — see
+# `gcloud artifacts docker images list ... --include-tags` for the
+# v1.0.0 tag → SHA mapping). Bump these tags on each subsequent prod
+# release tag cut.
+#
+# Note on the `name:` field: each backend sub-base (`base/server/`,
+# `base/consumer/`, `base/cronjob/*/`) already has its own `images:`
+# transformer that rewrites the bare container `image: server` →
+# `asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server:latest`
+# (env-specific config in base is pre-existing tech debt; out of scope
+# for this change). By the time this overlay's `images:` block runs,
+# the rendered image is already the dev-AR form, so we match against
+# THAT name. Kustomize's last-write-wins semantics then rewrites to
+# the prod AR FQDN + commit-SHA tag.
+#
+# Dev overlay omits an `images:` block: ArgoCD Image Updater resolves
+# the dev-AR `:latest` reference dynamically. Prod uses explicit
+# pinning (no `:latest` allowed per spec).
+images:
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
+  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
+  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
+  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
+  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -44,3 +44,27 @@ patches:
     - op: add
       path: /spec/hostnames
       value: ["liverty-music.app"]
+
+# Pin the web-app image to prod Artifact Registry. Per OpenSpec
+# `prepare-prod-service-in` §9 + the `prod-image-pipeline` spec, prod
+# must pull from `liverty-music-prod/frontend/*` and never from dev AR.
+# The `<sha>` tag is the commit SHA of liverty-music/frontend `main` HEAD
+# at the time `v1.0.0` was published (= merge commit of PR #356). Bump
+# this tag on each subsequent prod release tag cut.
+#
+# Note on the `name:` field: `base/web/kustomization.yaml` already has
+# its own `images:` transformer that rewrites the bare container
+# `image: web-app` → `asia-northeast2-docker.pkg.dev/liverty-music-dev/
+# frontend/web-app:latest` (env-specific config in base is pre-existing
+# tech debt; out of scope for this change). By the time this overlay's
+# `images:` block runs, the rendered image is already the dev-AR form,
+# so we match against THAT name. Kustomize's last-write-wins semantics
+# then rewrites to the prod AR FQDN + commit-SHA tag.
+#
+# Dev overlay omits an `images:` block: ArgoCD Image Updater resolves
+# the dev-AR `:latest` reference dynamically. Prod uses explicit
+# pinning (no `:latest` allowed per spec).
+images:
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
+  newTag: 51f5bce376d4eda670f83b4a654cf1f924c2f4f1


### PR DESCRIPTION
## Summary

Implements OpenSpec change `prepare-prod-service-in` **§9** — pin prod overlays to the prod Artifact Registry images that backend `v1.0.0` (`3bc2dada`) and frontend `v1.0.0` (`51f5bce3`) just published. Once merged + ArgoCD reconciles, the prod cluster will pull all 5 images from `liverty-music-prod/*` instead of the dev project AR — closing the cross-project dependency that has been operational since the original prod bring-up.

## Changes

### `k8s/namespaces/backend/overlays/prod/kustomization.yaml`
- Add `images:` block pinning all four backend images to `liverty-music-prod/backend/<name>:3bc2dada3c4cd06c218235eb7fe21ad638e29bf3` (merge commit of backend PR #297, the source of the v1.0.0 release build).
- **Note on the `name:` keys**: matched against the FULL dev-AR FQDN, not the bare image name. Each backend sub-base (`base/server/`, `base/consumer/`, `base/cronjob/*/`) has its own `images:` transformer that rewrites `image: server` → `liverty-music-dev/backend/server:latest` before this overlay runs. Matching against the post-base name lets kustomize's last-write-wins rewrite to the prod-AR FQDN. The pre-existing env-specific config in base is tech debt out of scope here.

### `k8s/namespaces/frontend/overlays/prod/kustomization.yaml`
- Same pattern for `web-app`, pinned to `liverty-music-prod/frontend/web-app:51f5bce376d4eda670f83b4a654cf1f924c2f4f1` (merge commit of frontend PR #356, the source of the v1.0.0 release build).

### `docs/runbooks/revoke-cross-project-ar-iam.md` (new)
Per `prepare-prod-service-in` §11 — documents the procedure for removing the manual `roles/artifactregistry.reader` grant on `liverty-music-dev` for `gke-node@liverty-music-prod`. Includes:
- Background on why the grant exists (one-time stopgap during original prod bring-up, never made it into Pulumi state).
- **Preconditions** to verify before revocation (this PR merged + ArgoCD reconciled + zero prod Pods referencing `liverty-music-dev`).
- The exact `gcloud projects remove-iam-policy-binding` invocation.
- **Recovery** procedure if revocation triggers `ImagePullBackOff` (re-add grant immediately + root-cause the missed dev-AR reference).
- Forward-looking guidance: if cross-project pull ever returns as a requirement, declare it via Pulumi `gcp.projects.IAMMember`, not manual `gcloud`.

## Verification

- [x] `make lint-ts` passes (biome + tsc, 0 issues).
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders all 4 backend containers with `liverty-music-prod/backend/*:3bc2dada...` images. No `liverty-music-dev/` references remain in rendered output.
- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders the `web-app` Deployment with `liverty-music-prod/frontend/web-app:51f5bce3...`. No `liverty-music-dev/` references.
- [x] Both prod AR image sets verified to exist via `gcloud artifacts docker images list`:
  - `liverty-music-prod/backend/{server,consumer,concert-discovery,artist-image-sync}` at `3bc2dada3c4cd06c218235eb7fe21ad638e29bf3,v1.0.0`
  - `liverty-music-prod/frontend/web-app` at `51f5bce376d4eda670f83b4a654cf1f924c2f4f1,v1.0.0`

## Side fix during release (FYI)

During the backend v1.0.0 release attempt, GitHub Actions auth via Workload Identity Federation failed with:

```
Permission 'iam.serviceAccounts.getAccessToken' denied on resource
```

Root cause: the prod `github-actions` SA's `workloadIdentityUser` binding for `liverty-music/backend` repo had been silently dropped from GCP IAM (Pulumi state still showed it as existing — state drift). Restored via manual `gcloud iam service-accounts add-iam-policy-binding`. The backend release reran successfully after the restore.

A separate `pulumi refresh + up` cycle on prod should reconcile state to match live IAM going forward. Not included in this PR (separate concern from overlay pinning); flagging for visibility.

## Sequencing after merge

Per OpenSpec design D7 + tasks.md migration plan:

1. dev `pulumi up` auto-fires from Pulumi Cloud Deployments (cloud-prov main change), but this PR touches only `k8s/` not `src/`, so no Pulumi diff.
2. ArgoCD detects the cloud-prov main-branch change → syncs the prod cluster's `backend` and `frontend` Applications → Reloader rolls the existing Deployments with the new pinned images.
3. **Operator (§10)**: verify ArgoCD shows both apps `Synced/Healthy` + every prod Pod's `image:` starts with `liverty-music-prod/`. Smoke `api.liverty-music.app/healthz` (401) and `auth.liverty-music.app/.well-known/openid-configuration` (200).
4. **Operator (§11)**: run the IAM revocation per the new runbook.

## Out of scope

- Mainnet ticket SBT contract deploy + `TICKET_SBT_ADDRESS` configmap update (§13).
- Stale ESC field cleanup (§17).
- The state-drift reconciliation for the prod `github-actions` SA's WIF binding (noted above; separate concern).

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- Companion PRs (all merged): cloud-prov #264 #265 #266; backend #296 #297; frontend #356
- Release tags consumed: liverty-music/backend@v1.0.0, liverty-music/frontend@v1.0.0

## Test plan

- [ ] CI green (Lint workflow; Pulumi previews for dev + prod should show ZERO src changes since this PR is k8s-only)
- [ ] claude-review feedback addressed
- [ ] Reviewer sign-off
