### PR TITLE
feat(github): provision CLAUDE_CODE_OAUTH_TOKEN as org-level secret

### DIFF
--- a/src/github/components/organization.ts
+++ b/src/github/components/organization.ts
@@ -172,6 +172,33 @@ export class GitHubOrganizationComponent extends pulumi.ComponentResource {
 			this.secrets.push(anthropicApiKeySecret)
 		}
 
+		// Authenticates the reusable Claude review workflow
+		// (`liverty-music/.github/.github/workflows/claude-review.yml`)
+		// against the Claude.ai Max plan subscription instead of the
+		// console.anthropic.com pay-as-you-go API credit balance. See
+		// OpenSpec change `claude-review-check-run` design.md for the
+		// auth-path rationale.
+		//
+		// `visibility: 'all'` makes the secret available to every repo in
+		// the org, including any repo-level `CLAUDE_CODE_OAUTH_TOKEN` that
+		// may have been manually configured earlier — when both exist,
+		// GitHub's `secrets` context resolves to the repo-level secret,
+		// so this org-level secret only supplies the value to repos that
+		// do not yet have it (currently backend/frontend/cloud-provisioning).
+		if (githubConfig.claudeCodeOauthToken) {
+			const claudeCodeOauthTokenSecret =
+				new github.ActionsOrganizationSecret(
+					'claude-code-oauth-token',
+					{
+						secretName: 'CLAUDE_CODE_OAUTH_TOKEN',
+						visibility: 'all',
+						plaintextValue: githubConfig.claudeCodeOauthToken,
+					},
+					{ provider: this.provider, parent: this },
+				)
+			this.secrets.push(claudeCodeOauthTokenSecret)
+		}
+
 		// Register outputs
 		this.registerOutputs({
 			provider: this.provider,

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -4,6 +4,7 @@ export interface GitHubConfig {
 	billingEmail: string
 	geminiApiKey?: string
 	anthropicApiKey?: string
+	claudeCodeOauthToken?: string
 }
 
 export interface BufConfig {


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#474

(Section 5 prerequisite of OpenSpec change `claude-review-check-run`. The follow-up Section 5 main PR — adding `'Claude review'` to backend / frontend / cloud-provisioning `requiredStatusCheckContexts` + caller workflow PRs — comes after this one is deployed.)

## 📝 Summary of Changes

Provision `CLAUDE_CODE_OAUTH_TOKEN` as an org-level Actions secret so backend / frontend / cloud-provisioning can call the reusable Claude review workflow at [`liverty-music/.github/.github/workflows/claude-review.yml@main`](https://github.com/liverty-music/.github/blob/main/.github/workflows/claude-review.yml).

The reusable workflow authenticates via `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` (routes through Claude.ai Max plan subscription). The token currently exists only as a per-repo secret on `specification` (manually set 2026-02-24). To roll out the caller workflow to the other 3 repos, the token needs to be available there.

### Why org-level

Mirrors the existing `anthropic-api-key` pattern in this file. `visibility: 'all'` makes the secret available to every repo in the org. The new `.github` repo also inherits it (relevant if it ever consumes the reusable workflow itself).

### Resolution order

GitHub's `secrets.<name>` resolves to the **repo-level** secret first if one exists, else falls back to org-level. So:

- **specification**: `CLAUDE_CODE_OAUTH_TOKEN` already exists at repo level → keeps using it (no change in behavior)
- **backend / frontend / cloud-provisioning**: no repo-level secret → uses the new org-level secret

### Activation (manual steps after merge)

1. Set the value in ESC (private):
   ```bash
   esc env set liverty-music/prod \
     pulumiConfig.github.claudeCodeOauthToken "<oauth-token>" --secret
   ```
   The token can be generated via `claude setup-token` (from any Claude Code-authenticated terminal) or reused from the existing specification repo-level secret if recoverable.

2. Trigger `pulumi up -s prod` from [Pulumi Cloud Deployments](https://app.pulumi.com/pannpers/liverty-music/prod/deployments) → creates the `ActionsOrganizationSecret`.

3. Confirm via:
   ```bash
   gh secret list --org liverty-music   # requires admin
   ```

## 🌍 Affected Stacks

- [ ] Dev
- [x] Prod

(`GitHubOrganizationComponent` is `env === 'prod'`-gated.)

## 🔮 Pulumi Preview

With ESC value unset (current state): preview shows `+ 0` from this change. The `if (githubConfig.claudeCodeOauthToken)` gate keeps the new resource inert until activation.

With ESC value set (post-activation): preview will show:
```
+ github:index/actionsOrganizationSecret:ActionsOrganizationSecret: (create)
    name: "claude-code-oauth-token"
    secretName: "CLAUDE_CODE_OAUTH_TOKEN"
    visibility: "all"
```

Note: the prod preview on this PR is likely to report unrelated pending drift (e.g., `ZitadelMonitoringComponent` and ~10 monitoring resources from PR #268 awaiting their prod up). That drift is preexisting and outside the scope of this PR; it should be cleared by the next normal prod up.

## 📦 State Changes

No `pulumi state mv` / `import` / destructive ops. Pure additive once activated (single `ActionsOrganizationSecret`).

## ✅ Checklist

- [x] `pulumi preview` succeeded; only intended change visible from this PR (others are preexisting drift).
- [x] No destructive changes.
- [x] Secret value is provisioned via Pulumi ESC, not committed.
