### PR TITLE
fix(gcp): enable billingbudgets API for the Budget resource

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -364,6 +364,23 @@ export class Gcp {
 		// `pulumi up` of this refactor because there's no existing state
 		// to migrate.
 		if (gcpConfig.billingAlertEmail) {
+			// Cloud Billing Budget needs `billingbudgets.googleapis.com`
+			// enabled on the consuming project. The `gcp.billing.Budget`
+			// resource itself doesn't have an implicit dependency on the
+			// API, so we declare it explicitly and dependsOn-link below.
+			// First prod up of this block on 2026-05-15 failed at
+			// `gcp.billing.Budget` because the API wasn't yet enabled;
+			// codifying the API enable here is the IaC fix.
+			const billingBudgetsApi = new gcp.projects.Service(
+				'billingbudgets',
+				{
+					project: this.projectId,
+					service: 'billingbudgets.googleapis.com',
+					disableOnDestroy: true,
+				},
+				{ parent: this.project },
+			)
+
 			const billingEmailChannel = new gcp.monitoring.NotificationChannel(
 				'billing-alert-email',
 				{
@@ -405,7 +422,7 @@ export class Gcp {
 						],
 					},
 				},
-				{ parent: this.project },
+				{ parent: this.project, dependsOn: [billingBudgetsApi] },
 			)
 		}
 	}

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -7,6 +7,7 @@ export type GoogleApis =
 	| 'serviceusage.googleapis.com'
 	| 'iam.googleapis.com'
 	| 'cloudbilling.googleapis.com'
+	| 'billingbudgets.googleapis.com'
 	| 'compute.googleapis.com'
 	| 'storage.googleapis.com'
 	| 'logging.googleapis.com'


### PR DESCRIPTION
## Summary

Fix the root cause of the v162 prod up failure during OpenSpec `prepare-prod-service-in` §12 ESC seeding. The prod `gcp.billing.Budget` resource failed to create because `billingbudgets.googleapis.com` was not enabled on the prod project, and Pulumi's dependency graph had no edge from Budget → API enable to sequence them.

## Background

v162 (`pulumi up --stack prod` at 2026-05-15T16:13:36Z) hit `Create failed` on the `cost-budget` Budget resource. Pulumi had already created 3 upstream resources (MonitoringComponent grouping + 2 NotificationChannels) before stopping.

Investigation:
- `gcloud services list --enabled --project=liverty-music-prod` returned no `billingbudgets.googleapis.com`.
- The Pulumi codebase had no API enable for `billingbudgets` (kubernetes.ts enables only container + places; ApiService class type union didn't include billing budgets).
- `gcp.billing.Budget` has no implicit `dependsOn` on a project Service, so even after enabling the API, a race could repeat the failure.

To unblock immediate retry, the API was manually enabled via `gcloud services enable billingbudgets.googleapis.com --project=liverty-music-prod`. That's a state drift (Pulumi state didn't know about the enable) — this PR closes the gap by codifying the API enable.

## Changes

### `src/gcp/services/api.ts`
- Add `'billingbudgets.googleapis.com'` to the `GoogleApis` union type.

### `src/gcp/index.ts`
- Inside the `if (gcpConfig.billingAlertEmail)` block (where the Budget is declared), add a `gcp.projects.Service` named `billingbudgets` enabling the API.
- Add `dependsOn: [billingBudgetsApi]` on `gcp.billing.Budget`. Without this explicit edge, Pulumi has no way to know Budget depends on the API enable; with it, the next prod up always sequences correctly even on fresh stacks.

## Drift adoption

The manual `gcloud services enable` from earlier is silently adopted by this PR: the new `gcp:projects/service:Service::billingbudgets` resource resolves as "already enabled" against GCP, no GCP-side mutation. After merge + prod up, IaC state and GCP state agree.

## Preview

```
$ pulumi preview --stack prod --diff
Resources:
    + 12 to create
    247 unchanged
```

The 12 creates:
- **1 new from this PR**: `gcp:projects/service:Service::billingbudgets` (adopts the manual enable).
- **11 leftover from v162**: `gcp:billing/budget:Budget::cost-budget`, 5 AlertPolicies under MonitoringComponent (4 log-based for backend + 1 atlas-migration), ZitadelMonitoringComponent grouping with its 4 AlertPolicies + LogMetric + Dashboard.

Zero updates / deletes / replaces.

## Verification

- [x] `make lint-ts` passes (biome + tsc, 0 issues).
- [x] `pulumi preview --stack prod` shows clean diff (additive only).
- [ ] CI green.
- [ ] claude-review feedback addressed.
- [ ] Reviewer sign-off.

## Sequencing after merge

1. dev `pulumi up` auto-fires via Pulumi Cloud Deployments. dev does NOT have `billingAlertEmail` seeded so the Budget block stays dormant — but the `gcp.projects.Service::billingbudgets` resource will still be created on dev (it's outside the gate). That's fine; an enabled-but-unused API is harmless. Skipping the enable on dev would require gating the API resource too, which is more code than benefit.
2. **Operator**: trigger `pulumi up --stack prod` via Pulumi Cloud console. The 11 leftover Phase 12 resources + the new API service all create. After this, MonitoringComponent + ZitadelMonitoringComponent are no longer dormant — alerts fire and budget tracks.

## Related

- Spec PR: liverty-music/specification#473 (merged 2026-05-15)
- v162 failed deployment: https://app.pulumi.com/pannpers/liverty-music/prod/deployments
