### PR TITLE
feat(github): require Claude review on all four repos

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.BACKEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success'],
+	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
 })
 
 // Frontend Repository
@@ -148,7 +148,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.FRONTEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success'],
+	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
 })
 
 // Specification Repository
@@ -159,8 +159,8 @@ new GitHubRepositoryComponent({
 	environment: env,
 	variables: sharedVariables,
 	// Pilot repo for the Claude review Check Run gate introduced by
-	// OpenSpec change `claude-review-check-run`. Other repos keep
-	// `['CI Success']` until the pilot graduates.
+	// OpenSpec change `claude-review-check-run`. All four repos now
+	// require `Claude review` after the specification pilot graduated.
 	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
 })
 
@@ -171,7 +171,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.CLOUD_PROVISIONING,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success'],
+	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
 	requireUpToDateBranch: true,
 })
 


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/specification#474

(Final functional step of OpenSpec change `claude-review-check-run`. Sections 6/7 are optional follow-ups — `@v1` tag + onboarding docs.)

## 📝 Summary of Changes

Graduate the `Claude review` Required Status Check from the specification-only pilot to all four liverty-music repos:

```diff
- requiredStatusCheckContexts: ['CI Success'],            // backend
+ requiredStatusCheckContexts: ['CI Success', 'Claude review'],

- requiredStatusCheckContexts: ['CI Success'],            // frontend
+ requiredStatusCheckContexts: ['CI Success', 'Claude review'],

- requiredStatusCheckContexts: ['CI Success'],            // cloud-provisioning
+ requiredStatusCheckContexts: ['CI Success', 'Claude review'],

  requiredStatusCheckContexts: ['CI Success', 'Claude review'],  // specification (unchanged from pilot)
```

Each repo's caller workflow was added in:
- backend: [liverty-music/backend#298](https://github.com/liverty-music/backend/pull/298) (merged)
- frontend: [liverty-music/frontend#357](https://github.com/liverty-music/frontend/pull/357) (merged)
- cloud-provisioning: liverty-music/cloud-provisioning#271 (merged)

## 🌍 Affected Stacks

- [ ] Dev
- [x] Prod

(`BranchProtection` is `env === 'prod'`-gated.)

## 🔮 Pulumi Preview

Expected diff (drift-free):

```
~ github:index/branchProtection:BranchProtection: (update) [backend-protection]
  ~ requiredStatusChecks.contexts: ["CI Success"] → ["CI Success", "Claude review"]

~ github:index/branchProtection:BranchProtection: (update) [frontend-protection]
  ~ requiredStatusChecks.contexts: ["CI Success"] → ["CI Success", "Claude review"]

~ github:index/branchProtection:BranchProtection: (update) [cloud-provisioning-protection]
  ~ requiredStatusChecks.contexts: ["CI Success"] → ["CI Success", "Claude review"]

Resources: ~ 3 to update
```

The PR's prod preview CI will also flag the pre-existing `alert-zitadel-oidc-latency-p99` failure (unrelated metric-not-found issue from `ZitadelMonitoringComponent`); that drift needs to be resolved before this PR's `pulumi up -s prod` can succeed cleanly. Tracking that separately.

## 📦 State Changes

No `pulumi state mv` / `import` / destructive ops. Three in-place `requiredStatusChecks.contexts` updates.

## 🚦 Post-merge sequence

1. Resolve the `alert-zitadel-oidc-latency-p99` Pulumi up failure (unrelated, see above).
2. Merge this PR.
3. `pulumi up -s prod` from [Pulumi Cloud Console](https://app.pulumi.com/pannpers/liverty-music/prod/deployments).
4. Verify each repo's branch protection includes `'Claude review'`:
   ```bash
   for r in backend frontend cloud-provisioning specification; do
     echo "--- $r ---"
     gh api repos/liverty-music/$r/branches/main/protection --jq ".required_status_checks.contexts"
   done
   ```
5. Operate for ~1 month; if stable, consider Section 6 (`@v1` tag) per the OpenSpec change `tasks.md`.

## ✅ Checklist

- [x] `pulumi preview` shows only intended diff (3 branch protection updates).
- [x] No destructive changes.
- [x] No new secrets introduced.
- [x] All four `claude-code-review.yml` callers are already in their repos' `main` branches.
