### PR TITLE
feat(infra): enable immutable tags on prod AR + pin overlays to semver

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -5,6 +5,7 @@
 | Environment | Artifact Registry tag policy | Kustomize `newTag:` pin | Tag mutation allowed? |
 |---|---|---|---|
 | **prod** (`liverty-music-prod`) | `dockerConfig.immutableTags: true` on `backend` + `frontend` repos | Semantic version (e.g., `v1.0.0`) with commit SHA in inline comment | **No** — AR API rejects re-points with HTTP 409 |
+| **staging** (not yet provisioned) | Will inherit `immutableTags: true` automatically when staging stack is created — the Pulumi conditional is `environment !== 'dev'`, fail-secure by default | TBD when staging overlays are created (expected: semver, same as prod) | **No** (post-creation) |
 | **dev** (`liverty-music-dev`) | default (`immutableTags: false`) | Not pinned in overlay — ArgoCD Image Updater resolves `:latest` / `:main` dynamically | Yes — Image Updater rewrites every push |
 
 The prod policy is enforced at two layers:

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -45,11 +45,18 @@ See `openspec/changes/archive/<date>-enable-prod-ar-immutable-tags/design.md` de
 1. Open a PR on `cloud-provisioning` updating both:
    - `k8s/namespaces/backend/overlays/prod/kustomization.yaml` — bump `newTag: v1.0.0` → `newTag: v1.0.1` for all four backend images, AND bump the corresponding inline comment SHA. Also bump the `labels:` block's `app.kubernetes.io/version: "1.0.1"`.
    - `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` — bump `newTag:` + comment + `app.kubernetes.io/version` for `web-app` if frontend was part of the release.
+
+   ⚠️ **`v`-prefix gotcha**: `newTag:` SHALL use the `v` prefix (`v1.0.1`) because that's the AR-side tag convention. `app.kubernetes.io/version:` SHALL be the bare semver (`"1.0.1"`, no `v`) because that's the Kubernetes Recommended Labels convention. Two different conventions in two adjacent fields of the same overlay — common bump-time mistake. The verification step below catches it.
+
 2. Run locally before pushing:
    ```bash
-   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E '(image:|app.kubernetes.io/version:)'
+   # Check every rendered image carries the new semver tag
+   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E 'image:.*:v[0-9]+\.[0-9]+\.[0-9]+'
+
+   # Check every label has a bare-semver value (no `v` prefix slip)
+   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E 'app\.kubernetes\.io/version: "?v' && echo "FAIL: v-prefix in label value" || echo "OK: label values are bare semver"
    ```
-   Confirm every rendered image carries `:v1.0.1` and every Deployment / CronJob carries `app.kubernetes.io/version: "1.0.1"`.
+   Confirm every rendered image carries `:v1.0.1` and every label is `app.kubernetes.io/version: "1.0.1"` (no `"v1.0.1"`).
 3. Open PR, get review, merge.
 
 ### 3. ArgoCD reconciles

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -1,0 +1,136 @@
+# Prod Image Tag Pinning — Policy & Runbook
+
+## Policy summary
+
+| Environment | Artifact Registry tag policy | Kustomize `newTag:` pin | Tag mutation allowed? |
+|---|---|---|---|
+| **prod** (`liverty-music-prod`) | `dockerConfig.immutableTags: true` on `backend` + `frontend` repos | Semantic version (e.g., `v1.0.0`) with commit SHA in inline comment | **No** — AR API rejects re-points with HTTP 409 |
+| **dev** (`liverty-music-dev`) | default (`immutableTags: false`) | Not pinned in overlay — ArgoCD Image Updater resolves `:latest` / `:main` dynamically | Yes — Image Updater rewrites every push |
+
+The prod policy is enforced at two layers:
+1. **Manifest layer** (kustomize overlays under `k8s/namespaces/{backend,frontend}/overlays/prod/`): `newTag:` SHALL be a semver string matching `^v\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$`. Commit-SHA-only tags and `:latest` SHALL NEVER appear.
+2. **Registry layer** (GCP Artifact Registry, managed by Pulumi at `src/gcp/index.ts`): `dockerConfig.immutableTags: true` is set on the prod `backend` and `frontend` Docker repos. Once a tag is written, AR rejects any subsequent `docker push` or `gcloud artifacts docker tags add` that would re-point that tag to a different digest.
+
+The combined effect is "readable semver in the manifest + cryptographic immutability at the registry boundary" — equivalent to digest pinning in immutability, superior in developer experience.
+
+## Why immutable tags + semver instead of digest pinning
+
+See `openspec/changes/archive/<date>-enable-prod-ar-immutable-tags/design.md` decision **D1** for the full rationale. Summary:
+
+- **Digest pinning** (`digest: sha256:...` in kustomize, or `image@sha256:...`) is the K8s-recommended strongest form. Cryptographically unforgeable.
+- **DX cost**: digest is only knowable after build. Operator workflow becomes: cut Release → wait for GHA → look up digest via `gcloud` → paste into overlay PR. Versus immutable-semver: cut Release → bump `newTag: v1.0.1` in overlay PR.
+- **Equivalent security guarantee at the AR boundary**: immutable-tags blocks the same attacker class (compromised AR write IAM) as digest pinning, via API-level rejection of tag overwrites.
+
+## Operator workflow: cutting a release
+
+### 1. Build + publish prod image (in `liverty-music/backend` or `liverty-music/frontend`)
+
+1. Merge release-bound PRs to `main`.
+2. From the GitHub UI: **Releases → Draft a new release → Tag = `v1.0.1`** (next patch) → Publish.
+3. GitHub Actions (`deploy.yml` for backend, `push-image.yaml` for frontend) fires on the `release: published` event:
+   - Authenticates to prod via Workload Identity Federation (`github-actions@liverty-music-prod.iam`).
+   - Builds the image.
+   - Pushes with **two tags**: `:v1.0.1` and `:<commit-sha>`.
+4. Wait for both pushes to succeed. Verify via:
+   ```bash
+   gcloud artifacts docker images list \
+     asia-northeast2-docker.pkg.dev/liverty-music-prod/backend \
+     --include-tags --filter='package~server' --limit=5
+   ```
+   The new digest SHOULD appear with both `:v1.0.1` and the SHA as tags.
+
+### 2. Bump the prod kustomize overlay (in `liverty-music/cloud-provisioning`)
+
+1. Open a PR on `cloud-provisioning` updating both:
+   - `k8s/namespaces/backend/overlays/prod/kustomization.yaml` — bump `newTag: v1.0.0` → `newTag: v1.0.1` for all four backend images, AND bump the corresponding inline comment SHA. Also bump the `labels:` block's `app.kubernetes.io/version: "1.0.1"`.
+   - `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` — bump `newTag:` + comment + `app.kubernetes.io/version` for `web-app` if frontend was part of the release.
+2. Run locally before pushing:
+   ```bash
+   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E '(image:|app.kubernetes.io/version:)'
+   ```
+   Confirm every rendered image carries `:v1.0.1` and every Deployment / CronJob carries `app.kubernetes.io/version: "1.0.1"`.
+3. Open PR, get review, merge.
+
+### 3. ArgoCD reconciles
+
+ArgoCD detects the cloud-provisioning `main` change and rolls the prod Deployments / CronJobs with the new `image:` reference and `app.kubernetes.io/version` label. Pods restart; image bytes resolve via the AR tag → digest lookup.
+
+### 4. Verify
+
+```bash
+kubectl --context=gke_liverty-music-prod_asia-northeast2_autopilot-cluster-osaka \
+    -n backend get deploy,cronjob -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[*].image}{"\n"}{end}'
+```
+
+All images SHALL end with `:v1.0.1`.
+
+## AR rejection behavior
+
+The AR API enforces tag immutability at the `docker push` / `gcloud artifacts docker tags add` boundary. The relevant error responses:
+
+| Operation | Response |
+|---|---|
+| Push a fresh tag (`:v1.0.1` on a never-existing tag) | 200 OK / success |
+| Push the same digest under an existing tag (idempotent re-tag, same bytes) | 200 OK (some clients short-circuit before contacting API) |
+| Push a different digest under an existing tag (re-point) | **HTTP 409 Conflict** — error message references "tag already exists" or "immutable tags" |
+| Delete a tag | Allowed (immutable-tags blocks RE-POINTING, not deletion) |
+
+The 409 surface in `docker/build-push-action@v5` looks like:
+```
+ERROR: failed to push asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server:v1.0.0:
+unexpected http response 409: ... tag already exists in immutable repository ...
+```
+
+This is **expected and desired** when the policy is working. A 409 on a tag push attempt means "this tag is already locked at the current digest; you cannot silently overwrite it".
+
+## Recovery procedures
+
+### Re-running a GitHub Release workflow that partially failed
+
+Common: GHA infrastructure flake mid-push, workflow re-runs.
+
+**Idempotent path (same bytes):** Re-run succeeds. `docker/build-push-action` re-builds (deterministic-ish for same git SHA), pushes succeed because the digest matches the existing tag. **AR does not reject** because the digest is the same.
+
+**Non-idempotent path (digest diverged):** Re-run fails with 409. This usually means build-time non-determinism (timestamps in image layers, dependency churn). **Do NOT try to work around it.** Cut a new patch version:
+1. Tag a new release `v1.0.2` with a no-op commit (e.g., `chore: bump release` in CHANGELOG).
+2. Bump prod overlay to `v1.0.2`.
+
+### Accidental manual `gcloud artifacts docker tags add` rejected
+
+If an operator tries:
+```bash
+gcloud artifacts docker tags add \
+  asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server@sha256:<digest-A> \
+  asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server:v1.0.0
+```
+and `v1.0.0` currently resolves to digest B, the API rejects. **Do not search for a workaround.** The policy is functioning correctly.
+
+If the goal was to roll back, see "Rollback" below. If the goal was to fix a bad release, cut a new patch version.
+
+### Rollback to a prior version
+
+The prior version's tag is already in AR (immutable, locked). To roll back:
+1. Open a PR on `cloud-provisioning` flipping `newTag: v1.0.1` → `newTag: v1.0.0` (and `app.kubernetes.io/version: "1.0.1"` → `"1.0.0"`) in both overlays.
+2. Merge. ArgoCD reconciles. Prod Pods restart pulling the locked `:v1.0.0` image bytes.
+
+No registry-side action needed. Immutable-tags has no effect on rollback because the rollback target was already published (and locked) under its own semver.
+
+### Genuine emergency requiring tag re-point (lab-only escape hatch)
+
+This SHOULD never be needed in normal operation. The scenario is something like: a compromised upstream dependency was discovered in `v1.0.0` after release, and the team wants to force-replace the `v1.0.0` tag content rather than cut a new tag (e.g., because external systems pinned to the exact name `v1.0.0`).
+
+The escape hatch:
+1. Open a PR on `cloud-provisioning` flipping `dockerConfig.immutableTags: true` → `false` in `src/gcp/index.ts` for the relevant repo.
+2. Operator-attended `pulumi up --stack prod`. (No automated apply on prod.)
+3. Re-tag via `gcloud artifacts docker tags add` (or via a new GHA push).
+4. Open a follow-up PR flipping `immutableTags: false` → `true`. Apply.
+5. **Mandatory**: write a post-incident review documenting (a) why the escape hatch was used, (b) what supply-chain compromise required force-replace, (c) what controls would prevent recurrence.
+
+The escape hatch SHALL NOT be used for routine ops (failed rebuilds, typos, "want to fix the release notes"). Cut a new patch version for all of those.
+
+## Related
+
+- Spec: `openspec/specs/prod-image-tag-immutability/spec.md` (post-archive) or the in-flight change at `openspec/changes/enable-prod-ar-immutable-tags/`.
+- Pulumi enforcement: `src/gcp/index.ts` (`gcp.artifactregistry.Repository` with `dockerConfig.immutableTags`).
+- Kustomize overlays: `k8s/namespaces/{backend,frontend}/overlays/prod/kustomization.yaml`.
+- Companion runbook: `revoke-cross-project-ar-iam.md` — closes the IAM side of the prod-image-only invariant.

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -29,6 +29,23 @@ resources:
 
 namespace: backend
 
+# Apply the Kubernetes Recommended Label `app.kubernetes.io/version` to every
+# rendered resource (Deployment, CronJob, Service, etc.). Value SHALL be the
+# bare semver without the leading `v` (per Kubernetes Recommended Labels
+# convention: `1.0.0`, not `v1.0.0`). Bump this in lock-step with the `images:`
+# block `newTag:` below — they SHALL refer to the same release.
+#
+# - `includeSelectors: false` keeps the label out of `selector.matchLabels`
+#   and Service selectors; modifying selectors mid-rollout would orphan running
+#   Pods. The label is metadata-only.
+# - `includeTemplates: true` propagates the label to `spec.template.metadata.labels`
+#   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
+labels:
+- pairs:
+    app.kubernetes.io/version: "1.0.0"
+  includeSelectors: false
+  includeTemplates: true
+
 patches:
 - path: serviceaccount_patch.yaml
   target:
@@ -139,38 +156,45 @@ configMapGenerator:
   envs:
   - consumer/configmap.env
 
-# Pin all four backend images to the prod Artifact Registry. Per OpenSpec
-# `prepare-prod-service-in` §9 + the `prod-image-pipeline` spec, prod must
-# pull from `liverty-music-prod/backend/*` and never from dev AR. The
-# `<sha>` tag is the commit SHA of liverty-music/backend `main` HEAD at
-# the time `v1.0.0` was published (= merge commit of PR #297 — see
-# `gcloud artifacts docker images list ... --include-tags` for the
-# v1.0.0 tag → SHA mapping). Bump these tags on each subsequent prod
-# release tag cut.
+# Pin all four backend images to the prod Artifact Registry with an
+# immutable semantic-version tag. Per OpenSpec `enable-prod-ar-immutable-tags`
+# + the `prod-image-tag-immutability` spec, prod uses semver tags (e.g.,
+# v1.0.0) backed by AR's `dockerConfig.immutableTags: true` policy, which
+# rejects tag-overwrite attempts at the registry API. Combined, this gives
+# at-a-glance version visibility AND digest-equivalent immutability. The
+# inline comment after each `newTag:` records the source commit SHA so
+# incident-response trace from manifest → exact commit does not require
+# an Artifact Registry round-trip.
+#
+# Policy: see docs/runbooks/prod-image-tag-pinning.md
 #
 # Note on the `name:` field: each backend sub-base (`base/server/`,
 # `base/consumer/`, `base/cronjob/*/`) already has its own `images:`
 # transformer that rewrites the bare container `image: server` →
 # `asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server:latest`
 # (env-specific config in base is pre-existing tech debt; out of scope
-# for this change). By the time this overlay's `images:` block runs,
-# the rendered image is already the dev-AR form, so we match against
-# THAT name. Kustomize's last-write-wins semantics then rewrites to
-# the prod AR FQDN + commit-SHA tag.
+# here). By the time this overlay's `images:` block runs, the rendered
+# image is already the dev-AR form, so we match against THAT name.
+# Kustomize's last-write-wins semantics then rewrites to the prod AR FQDN
+# + semver tag.
 #
-# Dev overlay omits an `images:` block: ArgoCD Image Updater resolves
-# the dev-AR `:latest` reference dynamically. Prod uses explicit
-# pinning (no `:latest` allowed per spec).
+# Dev overlay omits an `images:` block: ArgoCD Image Updater resolves the
+# dev-AR `:latest` reference dynamically. Prod uses explicit semver
+# pinning; dev AR repos stay mutable so Image Updater can rewrite tags.
+#
+# Bumping on release: cut a new GH Release (e.g., v1.0.1) on backend.
+# GHA pushes both `:v1.0.1` and `:<new-sha>` to prod AR. Open a PR here
+# updating `newTag:` + comment for all four entries to the new values.
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -10,6 +10,23 @@ resources:
 
 namespace: frontend
 
+# Apply the Kubernetes Recommended Label `app.kubernetes.io/version` to every
+# rendered resource. Value SHALL be the bare semver without the leading `v`
+# (per Kubernetes Recommended Labels convention: `1.0.0`, not `v1.0.0`). Bump
+# this in lock-step with the `images:` block `newTag:` below — they SHALL refer
+# to the same release.
+#
+# - `includeSelectors: false` keeps the label out of `selector.matchLabels`
+#   and Service selectors; modifying selectors mid-rollout would orphan running
+#   Pods. The label is metadata-only.
+# - `includeTemplates: true` propagates the label to `spec.template.metadata.labels`
+#   on the Deployment so Pods carry it for Prometheus / OTel scraping.
+labels:
+- pairs:
+    app.kubernetes.io/version: "1.0.0"
+  includeSelectors: false
+  includeTemplates: true
+
 patches:
 - path: spot-vm_patch.yaml
   target:
@@ -45,26 +62,35 @@ patches:
       path: /spec/hostnames
       value: ["liverty-music.app"]
 
-# Pin the web-app image to prod Artifact Registry. Per OpenSpec
-# `prepare-prod-service-in` §9 + the `prod-image-pipeline` spec, prod
-# must pull from `liverty-music-prod/frontend/*` and never from dev AR.
-# The `<sha>` tag is the commit SHA of liverty-music/frontend `main` HEAD
-# at the time `v1.0.0` was published (= merge commit of PR #356). Bump
-# this tag on each subsequent prod release tag cut.
+# Pin the web-app image to prod Artifact Registry with an immutable
+# semantic-version tag. Per OpenSpec `enable-prod-ar-immutable-tags` +
+# the `prod-image-tag-immutability` spec, prod uses semver tags (e.g.,
+# v1.0.0) backed by AR's `dockerConfig.immutableTags: true` policy,
+# which rejects tag-overwrite attempts at the registry API. Combined,
+# this gives at-a-glance version visibility AND digest-equivalent
+# immutability. The inline comment after the `newTag:` records the
+# source commit SHA so incident-response trace from manifest → exact
+# commit does not require an Artifact Registry round-trip.
+#
+# Policy: see docs/runbooks/prod-image-tag-pinning.md
 #
 # Note on the `name:` field: `base/web/kustomization.yaml` already has
 # its own `images:` transformer that rewrites the bare container
 # `image: web-app` → `asia-northeast2-docker.pkg.dev/liverty-music-dev/
 # frontend/web-app:latest` (env-specific config in base is pre-existing
-# tech debt; out of scope for this change). By the time this overlay's
-# `images:` block runs, the rendered image is already the dev-AR form,
-# so we match against THAT name. Kustomize's last-write-wins semantics
-# then rewrites to the prod AR FQDN + commit-SHA tag.
+# tech debt; out of scope here). By the time this overlay's `images:`
+# block runs, the rendered image is already the dev-AR form, so we
+# match against THAT name. Kustomize's last-write-wins semantics then
+# rewrites to the prod AR FQDN + semver tag.
 #
 # Dev overlay omits an `images:` block: ArgoCD Image Updater resolves
-# the dev-AR `:latest` reference dynamically. Prod uses explicit
-# pinning (no `:latest` allowed per spec).
+# the dev-AR `:latest` reference dynamically. Prod uses explicit semver
+# pinning; dev AR repos stay mutable so Image Updater can rewrite tags.
+#
+# Bumping on release: cut a new GH Release (e.g., v1.0.1) on frontend.
+# GHA pushes both `:v1.0.1` and `:<new-sha>` to prod AR. Open a PR here
+# updating `newTag:` + comment to the new values.
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: 51f5bce376d4eda670f83b4a654cf1f924c2f4f1
+  newTag: v1.0.0  # commit 51f5bce376d4eda670f83b4a654cf1f924c2f4f1

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -117,14 +117,9 @@ export class Gcp {
 		// })
 
 		// 4. Artifact Registry
-		// Prod repos enable Immutable Tags so that once a tag (e.g., v1.0.0) is
-		// pushed, it cannot be re-pointed to a different digest. This pairs with
-		// the prod kustomize overlays' semver-tag pin to give GitOps
-		// reproducibility at the registry boundary. Dev repos stay mutable so
-		// ArgoCD Image Updater can rewrite :latest/:main on every push.
-		// Policy: see docs/runbooks/prod-image-tag-pinning.md
+		// immutableTags: non-dev only; dev stays mutable for ArgoCD Image Updater
 		const dockerConfig =
-			environment === 'prod' ? { immutableTags: true } : undefined
+			environment !== 'dev' ? { immutableTags: true } : undefined
 
 		const backendArtifactRegistry = new gcp.artifactregistry.Repository(
 			'github-backend-repository',

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -117,6 +117,15 @@ export class Gcp {
 		// })
 
 		// 4. Artifact Registry
+		// Prod repos enable Immutable Tags so that once a tag (e.g., v1.0.0) is
+		// pushed, it cannot be re-pointed to a different digest. This pairs with
+		// the prod kustomize overlays' semver-tag pin to give GitOps
+		// reproducibility at the registry boundary. Dev repos stay mutable so
+		// ArgoCD Image Updater can rewrite :latest/:main on every push.
+		// Policy: see docs/runbooks/prod-image-tag-pinning.md
+		const dockerConfig =
+			environment === 'prod' ? { immutableTags: true } : undefined
+
 		const backendArtifactRegistry = new gcp.artifactregistry.Repository(
 			'github-backend-repository',
 			{
@@ -125,6 +134,7 @@ export class Gcp {
 				format: 'DOCKER',
 				project: this.project.projectId,
 				description: 'Docker repository for GitHub Backend Repository',
+				dockerConfig,
 			},
 			{ parent: this.project },
 		)
@@ -137,6 +147,7 @@ export class Gcp {
 				format: 'DOCKER',
 				project: this.project.projectId,
 				description: 'Docker repository for GitHub Frontend Repository',
+				dockerConfig,
 			},
 			{ parent: this.project },
 		)


### PR DESCRIPTION
## Summary

Implements OpenSpec change `enable-prod-ar-immutable-tags` (spec PR: liverty-music/specification#484). Switches prod image pinning from opaque commit-SHA tags to readable semver tags backed by Artifact Registry's `dockerConfig.immutableTags: true` policy. Combined, this gives at-a-glance version visibility (`v1.0.0` in the manifest) AND digest-equivalent immutability (AR rejects re-point attempts with 409).

## What changed

**Pulumi (`src/gcp/index.ts`)**: prod-stack `backend` + `frontend` AR repos now declare `dockerConfig.immutableTags: true` via an `environment === 'prod'` conditional. Dev AR repos remain mutable so ArgoCD Image Updater can continue rewriting `:latest`.

**Kustomize prod overlays**:
- `k8s/namespaces/backend/overlays/prod/kustomization.yaml`: 4 `newTag:` entries rewritten from commit-SHA `3bc2dada3c...` → `v1.0.0`, with commit SHA preserved in inline comments. New `labels:` block applies `app.kubernetes.io/version: "1.0.0"` (bare semver per K8s Recommended Labels convention) with `includeSelectors: false` (metadata-only) + `includeTemplates: true` (propagates to Pod template).
- `k8s/namespaces/frontend/overlays/prod/kustomization.yaml`: same pattern for `web-app` image.

**Runbook (`docs/runbooks/prod-image-tag-pinning.md`, new)**: documents the policy (prod immutable / dev mutable), why immutable-tags + semver instead of digest pinning (links to OpenSpec design.md D1), operator workflow for cutting a release, AR rejection behavior, and 4 recovery procedures (Release re-run, manual re-tag attempt rejected, rollback, lab-only escape hatch).

## Pulumi preview

```
~ gcp:artifactregistry/repository:Repository: (update)
    [github-frontend-repository]
  + dockerConfig: { + immutableTags: true }

~ gcp:artifactregistry/repository:Repository: (update)
    [github-backend-repository]
  + dockerConfig: { + immutableTags: true }

~ gcp:monitoring/dashboard:Dashboard: (update)
    [dashboard-zitadel-observability]
  ~ dashboardJson: <pre-existing drift, unrelated to this change>

Resources:
    ~ 3 to update
    256 unchanged
```

The dashboard update represents pre-existing drift from a prior manual GCP Console edit — Pulumi state reconciliation will harmlessly restore it to the IaC version. No resource creation or deletion in the preview.

## Verification

- [x] `make lint-ts` passes (biome + tsc, 47 files, 0 issues)
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` — all 4 backend images render with `:v1.0.0` and `liverty-music-prod/backend/` prefix; `app.kubernetes.io/version: 1.0.0` on Deployment + CronJob metadata AND Pod template
- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod` — `web-app` renders `liverty-music-prod/frontend/web-app:v1.0.0` with the same label
- [x] No `selector.matchLabels.app.kubernetes.io/version` added (label is metadata-only — selector mutation would orphan running Pods)
- [x] `scripts/check-spot-nodeselector.sh` passes on rendered prod overlays
- [x] `git diff k8s/namespaces/*/overlays/dev/` empty — dev overlays untouched

## Operator follow-ups (post-merge)

- [ ] Trigger `pulumi up --stack prod` via Pulumi Cloud console
- [ ] Verify `gcloud artifacts repositories describe {backend,frontend} --project=liverty-music-prod --format='value(dockerConfig.immutableTags)'` returns `True` for both
- [ ] Verify `kubectl get deploy,cronjob -A -o yaml | grep image:` on prod shows `:v1.0.0` everywhere
- [ ] Smoke: `curl -I https://liverty-music.app/` returns 200; `api.liverty-music.app/healthz` returns 401; `auth.liverty-music.app/.well-known/openid-configuration` returns 200

## Test plan

- [x] make lint-ts passes
- [x] Pulumi preview reviewed (expected 2 AR updates + unrelated dashboard drift)
- [x] kustomize render verified for both overlays
- [ ] CI green
- [ ] Operator `pulumi up --stack prod` (post-merge)
- [ ] ArgoCD reconciles, prod Pods restart with `:v1.0.0` image references
- [ ] Smoke tests post-rollout

## Related

- Spec: liverty-music/specification#484
- Builds on `prepare-prod-service-in` §9 (introduced the SHA pin convention being replaced)
- Companion runbook: `docs/runbooks/revoke-cross-project-ar-iam.md` (closes the IAM side of the prod-image-only invariant)

Refs: liverty-music/specification#484