### PR TITLE
feat(k8s/frontend): mount per-env runtime config via ConfigMap

### DIFF
--- a/k8s/namespaces/frontend/base/web/deployment.yaml
+++ b/k8s/namespaces/frontend/base/web/deployment.yaml
@@ -2,6 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
+  annotations:
+    # Trigger a rolling restart when web-app-runtime-config ConfigMap changes.
+    # The ConfigMap is mounted as a single-file subPath volume which kubelet
+    # does NOT live-update; explicit rollout via Reloader is the contract.
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   template:
@@ -38,3 +43,15 @@ spec:
           limits:
             cpu: 200m
             memory: 128Mi
+        volumeMounts:
+        - name: runtime-config
+          mountPath: /srv/config.json
+          subPath: config.json
+          readOnly: true
+      volumes:
+      - name: runtime-config
+        configMap:
+          # ConfigMap with this name is provided by each environment overlay
+          # (overlays/<env>/configmap.yaml). The mounted file shadows the
+          # image's bundled public/config.json fallback.
+          name: web-app-runtime-config

--- a/k8s/namespaces/frontend/overlays/dev/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-app-runtime-config
+data:
+  config.json: |
+    {
+      "environment": "dev",
+      "apiBaseUrl": "https://api.dev.liverty-music.app",
+      "zitadelIssuer": "https://auth.dev.liverty-music.app",
+      "zitadelClientId": "371355407710421859",
+      "zitadelOrgId": "371348346264093539",
+      "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
+      "circuitBaseUrl": "/circuits/ticketcheck-v1",
+      "previewArtistIds": [
+        "019c8655-7a05-71ef-82b4-a4ac2494e29f",
+        "019c8655-7a05-721d-b0a8-4c11724d5c90",
+        "019c8655-7a05-71e9-9af5-e1cd4fbfd367",
+        "019c899e-baff-7ecd-8af2-e8dc819e29e4",
+        "019c8655-7a05-71f5-acd4-46157dcb0bec",
+        "019c8655-7a05-722a-bdae-a89596378f90",
+        "019c8655-7a05-72ff-8654-4e09e64043da",
+        "019c8655-7a05-723e-bef1-2d2433cd53f5",
+        "019c8655-7a05-7217-8f63-7a261ebcfceb",
+        "019c8655-7a05-72e7-a9c3-44a27d2bf07e",
+        "019c8655-7a05-71fc-bc48-92705b9ddb68"
+      ],
+      "previewArtistNames": [
+        "Mrs. GREEN APPLE",
+        "YOASOBI",
+        "Vaundy",
+        "SUPER BEAVER",
+        "King Gnu",
+        "Official髭男dism",
+        "Creepy Nuts",
+        "Ado",
+        "back number",
+        "ONE OK ROCK",
+        "RADWIMPS"
+      ],
+      "logLevel": "debug"
+    }

--- a/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../../base
+- configmap.yaml
 
 namespace: frontend
 

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-app-runtime-config
+data:
+  config.json: |
+    {
+      "environment": "prod",
+      "apiBaseUrl": "https://api.liverty-music.app",
+      "zitadelIssuer": "https://auth.liverty-music.app",
+      "zitadelClientId": "373015520582107291",
+      "zitadelOrgId": "373015514391249051",
+      "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
+      "circuitBaseUrl": "/circuits/ticketcheck-v1",
+      "previewArtistIds": [
+        "019c8655-7a05-71ef-82b4-a4ac2494e29f",
+        "019c8655-7a05-721d-b0a8-4c11724d5c90",
+        "019c8655-7a05-71e9-9af5-e1cd4fbfd367",
+        "019c899e-baff-7ecd-8af2-e8dc819e29e4",
+        "019c8655-7a05-71f5-acd4-46157dcb0bec",
+        "019c8655-7a05-722a-bdae-a89596378f90",
+        "019c8655-7a05-72ff-8654-4e09e64043da",
+        "019c8655-7a05-723e-bef1-2d2433cd53f5",
+        "019c8655-7a05-7217-8f63-7a261ebcfceb",
+        "019c8655-7a05-72e7-a9c3-44a27d2bf07e",
+        "019c8655-7a05-71fc-bc48-92705b9ddb68"
+      ],
+      "previewArtistNames": [
+        "Mrs. GREEN APPLE",
+        "YOASOBI",
+        "Vaundy",
+        "SUPER BEAVER",
+        "King Gnu",
+        "Official髭男dism",
+        "Creepy Nuts",
+        "Ado",
+        "back number",
+        "ONE OK ROCK",
+        "RADWIMPS"
+      ],
+      "logLevel": "info"
+    }

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -3,10 +3,13 @@ kind: Kustomization
 
 # Prod frontend overlay. Env-divergent fields per design D2 / spec Requirement 3:
 #   - HTTPRoute hostname: liverty-music.app (apex) vs dev's dev.liverty-music.app
+#   - Runtime config (web-app-runtime-config ConfigMap) — prod hostnames,
+#     prod OIDC client/org IDs, prod VAPID key, `info` log level.
 # Resource sizing matches dev exactly; spot label matches.
 
 resources:
 - ../../base
+- configmap.yaml
 
 namespace: frontend
 


### PR DESCRIPTION
## Summary

K8s half of OpenSpec change `adopt-runtime-config-for-frontend`. Moves per-environment frontend values out of the SPA image and into a per-overlay ConfigMap mounted at `/srv/config.json` (single-file `subPath` mount). The container image becomes env-agnostic — the same digest can run in dev, prod, or staging with only the ConfigMap differing.

## Companion PRs

- specification: liverty-music/specification#486
- frontend: liverty-music/frontend#358

## What changed

- **`base/web/deployment.yaml`**: add `reloader.stakater.com/auto: "true"` annotation (subPath mounts don't live-update in kubelet — explicit rollout via Reloader is the contract). Add `runtime-config` volume + `volumeMount` at `/srv/config.json`.
- **`overlays/dev/configmap.yaml`** (new): `web-app-runtime-config` ConfigMap with dev values (apex `api.dev` / `auth.dev` hostnames, dev OIDC client/org IDs, dev VAPID public key, `debug` log level).
- **`overlays/prod/configmap.yaml`** (new): same shape with prod values (apex hostnames without `dev.` prefix, prod OIDC client/org IDs, prod VAPID public key, `info` log level).
- Both overlay kustomizations reference the new ConfigMap.

## Test plan

- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/dev`: renders ConfigMap + Deployment with expected mount; environment=dev; Reloader annotation present
- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod`: renders prod ConfigMap (environment=prod), prod AR image pin preserved
- [x] `kube-linter` on frontend overlays: no errors
- [ ] After merge: ArgoCD applies dev ConfigMap; old image (which doesn't yet read /config.json) continues to work. Verify ConfigMap exists: `kubectl get configmap web-app-runtime-config -n frontend -o yaml`
- [ ] After frontend PR merges: new image fetches `/config.json` from this ConfigMap. Verify `curl https://dev.liverty-music.app/config.json` returns dev values
- [ ] After prod release-tag rebuild + prod image pin bump in this overlay: prod pod fetches prod ConfigMap. Verify `curl https://liverty-music.app/config.json` returns prod values

## Rollout ordering

Land this BEFORE the frontend PR so the ConfigMap exists in cluster before the new image arrives. The old (v1.0.0) image will mount the ConfigMap but ignore it — no breakage.

Refs: liverty-music/specification#485