### PR TITLE
chore(k8s/frontend): bump prod image pin to v1.0.1

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.0.0  # commit 51f5bce376d4eda670f83b4a654cf1f924c2f4f1
+  newTag: v1.0.1  # commit 9fafbcec8875c98d3031ed1c64956a2e81ac68d6


### PR DESCRIPTION
## Summary

OpenSpec change `adopt-runtime-config-for-frontend` rollout step 8.7. Bumps the prod frontend image pin from v1.0.0 → v1.0.1. After merge, ArgoCD syncs the prod cluster and the v1.0.1 image replaces the currently-blank v1.0.0 deploy.

## Why

v1.0.0 prod renders blank at https://liverty-music.app/ because `@aurelia/vite-plugin@2.0.0-rc.1` literal-checks `config.mode === 'production'` when bundling component templates; `vite build --mode prod` (chosen to load `.env.prod`) silently stripped templates from every lazy route chunk.

v1.0.1 removes that whole interaction surface — the bundle is env-agnostic; per-env values come from the `web-app-runtime-config` ConfigMap mounted at `/srv/config.json` (landed in #275 against this same overlay).

## Changes

- `app.kubernetes.io/version` label: `1.0.0` → `1.0.1`
- `images[*].newTag`: `v1.0.0` → `v1.0.1`
- Inline SHA comment: `51f5bce` → `9fafbce`

These move in lock-step per the per-release-bump comment in the file.

## Companion artifacts

- frontend release: liverty-music/frontend@v1.0.1 (commit `9fafbcec...`)
- frontend image: `asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:v1.0.1`
- ConfigMap (prod values): committed in this overlay's `configmap.yaml` (from #275)

## Test plan

- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders the v1.0.1 tag + label
- [x] `kube-linter` clean
- [ ] After ArgoCD sync: `curl -sS https://liverty-music.app/config.json` returns `{"environment":"prod", ...}`
- [ ] `https://liverty-music.app/` renders the welcome route (no longer blank)
- [ ] `SMOKE_BASE_URL=https://liverty-music.app npm run test:smoke` (from frontend repo) passes

## Rollback

If prod rendering still fails post-deploy, revert this PR. ArgoCD will re-sync to v1.0.0 (still broken — only fix-forward is meaningful from here on).

Refs: liverty-music/specification#485