### PR TITLE
chore(frontend-config): pin prod preview artists to live prod UUIDs

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -13,17 +13,17 @@ data:
       "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
       "previewArtistIds": [
-        "019c8655-7a05-71ef-82b4-a4ac2494e29f",
-        "019c8655-7a05-721d-b0a8-4c11724d5c90",
-        "019c8655-7a05-71e9-9af5-e1cd4fbfd367",
-        "019c899e-baff-7ecd-8af2-e8dc819e29e4",
-        "019c8655-7a05-71f5-acd4-46157dcb0bec",
-        "019c8655-7a05-722a-bdae-a89596378f90",
-        "019c8655-7a05-72ff-8654-4e09e64043da",
-        "019c8655-7a05-723e-bef1-2d2433cd53f5",
-        "019c8655-7a05-7217-8f63-7a261ebcfceb",
-        "019c8655-7a05-72e7-a9c3-44a27d2bf07e",
-        "019c8655-7a05-71fc-bc48-92705b9ddb68"
+        "019e3029-8044-75fc-a662-2ddfce51178e",
+        "019e3029-8044-7603-b047-c713d5183f2c",
+        "019e3029-8044-75f7-ad29-c1748b5a46a6",
+        "019e302a-3ea8-7a7e-b077-8cf6068fdb4b",
+        "019e3029-8044-7600-997d-7d3e09fda531",
+        "019e3029-8044-7615-82a7-6b213a265b3f",
+        "019e3029-8044-763e-81d3-7b73868f10f7",
+        "019e3029-8044-761c-80f7-03302b865e72",
+        "019e3029-8044-75fe-9b06-d3595786cf2e",
+        "019e3029-8044-7638-909e-35a3fc09fe01",
+        "019e3029-f15b-77bc-b0fc-a45df1176f0d"
       ],
       "previewArtistNames": [
         "Mrs. GREEN APPLE",
@@ -36,7 +36,7 @@ data:
         "Ado",
         "back number",
         "ONE OK ROCK",
-        "RADWIMPS"
+        "緑黄色社会"
       ],
       "logLevel": "info"
     }


### PR DESCRIPTION
## Summary

Implements `prepare-prod-service-in` §16 — pin the prod welcome page's preview artist list to UUIDs that actually exist in the prod `app.artists` table, so each preview card clicks through to a populated artist-detail page instead of 404.

The original task targeted `frontend/.env.prod`, but the adopt-runtime-config refactor (`frontend@98b80b0`) replaced build-time `VITE_*` envs with a `/config.json` fetched at bootstrap. The runtime config is mounted from this ConfigMap (`web-app-runtime-config`). The effective update path is therefore this overlay — no frontend image rebuild needed.

## Changes

- **`k8s/namespaces/frontend/overlays/prod/configmap.yaml`** — `previewArtistIds` rewritten to the 11 prod UUIDs sourced from `SELECT id FROM app.artists WHERE name = ?` against prod Cloud SQL. Composition unchanged for 10 artists; `RADWIMPS` swapped for `緑黄色社会`.

### Why the swap

| Slot | Before | After | Reason |
|---|---|---|---|
| 11 | RADWIMPS | 緑黄色社会 | Gemini grounded search returned 0 concerts for RADWIMPS (no announced 2026 tour) → preview card would render an empty timetable. 緑黄色社会 has 10 prod-discovered concerts and is one of the 14 artists the operator naturally followed during onboarding. Same J-pop genre; minimal composition drift. |

The previous UUIDs (`019c8655-...` time window) were copied from dev DB during the original `prepare-prod-service-in` proposal, before any prod artists existed. They reference rows that have never been in the prod `app.artists` table — clicking any card on the live site would 404.

## Preview artist final list

| # | Artist | UUID (prod) | Concerts |
|---|---|---|---|
| 1 | Mrs. GREEN APPLE | `019e3029-8044-75fc-a662-2ddfce51178e` | 4 |
| 2 | YOASOBI | `019e3029-8044-7603-b047-c713d5183f2c` | 18 |
| 3 | Vaundy | `019e3029-8044-75f7-ad29-c1748b5a46a6` | 43 |
| 4 | SUPER BEAVER | `019e302a-3ea8-7a7e-b077-8cf6068fdb4b` | 16 |
| 5 | King Gnu | `019e3029-8044-7600-997d-7d3e09fda531` | 11 |
| 6 | Official髭男dism | `019e3029-8044-7615-82a7-6b213a265b3f` | 22 |
| 7 | Creepy Nuts | `019e3029-8044-763e-81d3-7b73868f10f7` | 11 |
| 8 | Ado | `019e3029-8044-761c-80f7-03302b865e72` | 4 |
| 9 | back number | `019e3029-8044-75fe-9b06-d3595786cf2e` | 13 |
| 10 | ONE OK ROCK | `019e3029-8044-7638-909e-35a3fc09fe01` | 8 |
| 11 | 緑黄色社会 | `019e3029-f15b-77bc-b0fc-a45df1176f0d` | 10 |

## Verification

- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders the updated ConfigMap cleanly; rest of the overlay (Service, Deployment, HTTPRoute) unchanged.
- [x] All 11 UUIDs verified to exist in prod `app.artists` table.
- [x] All 11 artists have ≥4 prod-discovered concerts in `app.concerts` (preview cards link to live data).

## Rollout

After merge:
1. ArgoCD `frontend` Application on prod reconciles.
2. Reloader (`reloader.stakater.com/auto: "true"` on `web-app` Deployment) rolls the Pod when the ConfigMap changes.
3. New `/config.json` is served on the next page load.
4. Welcome page preview cards now link to live prod artist details.

No Pulumi changes; no frontend image rebuild; no Release tag needed.

## Related

- Follow-up issue: liverty-music/specification#482 (§16)
- Archived OpenSpec change: `2026-05-16-prepare-prod-service-in`
- Runtime-config refactor: `liverty-music/frontend@98b80b0`, archived OpenSpec change `2026-05-16-adopt-runtime-config-for-frontend`

## Test plan

- [ ] CI green (Lint + Pulumi prod preview — preview should show 0 diff since this is k8s-only)
- [ ] `Claude review` Check Run green
- [ ] Reviewer sign-off