### PR TITLE
fix(consumer): lower KEDA activationLagThreshold to 0 to drain single pending events

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -17,7 +17,7 @@ spec:
       stream: "CONCERT"
       consumer: "CONCERT_discovered"
       lagThreshold: "10"
-      activationLagThreshold: "1"
+      activationLagThreshold: "0"
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
@@ -25,7 +25,7 @@ spec:
       stream: "CONCERT"
       consumer: "CONCERT_created"
       lagThreshold: "10"
-      activationLagThreshold: "1"
+      activationLagThreshold: "0"
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
@@ -33,7 +33,7 @@ spec:
       stream: "ARTIST"
       consumer: "ARTIST_created"
       lagThreshold: "1"
-      activationLagThreshold: "1"
+      activationLagThreshold: "0"
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
@@ -41,4 +41,4 @@ spec:
       stream: "USER"
       consumer: "USER_created"
       lagThreshold: "1"
-      activationLagThreshold: "1"
+      activationLagThreshold: "0"


### PR DESCRIPTION
## Summary

Fixes a latent KEDA configuration bug where a single pending NATS JetStream message fails to activate the consumer, leaving the message stranded until a second message arrives.

Surfaced during `prepare-prod-service-in` §18.5 push-notification end-to-end verification ([#482](https://github.com/liverty-music/specification/issues/482)): a single new follow's `concert.discovered` event got stuck for 30+ minutes, breaking the push pipeline.

## Root cause

The KEDA NATS JetStream scaler's `activationLagThreshold` uses **strict greater-than** semantics: `isActive` becomes true only when `lag > activationLagThreshold`. With `activationLagThreshold: "1"`, a single pending message (`lag == 1`) fails the `1 > 1` predicate and the consumer never scales from 0 → 1.

### Live evidence (prod, 2026-05-18)

```
04:17:18  FollowService/Follow OK              (ZUTOMAYO, new artist)
04:17:22  FollowService/SetHype OK             (hype = away, eligible for push)
04:17:49  server-app: published concert.discovered event
…         consumer never scaled up, push never fired
```

KEDA state at the time:

```yaml
externalMetric s0-nats-jetstream-CONCERT: value=1   # 1 stuck message
ScaledObject status.isActive: false
ScaledObject status.lastActiveTime: 2026-05-18T03:53:39Z (Novelbright window)
```

The previous, large 14-follow signup wave masked this bug because multiple follows in quick succession kept `lag > 1`. Single-follow flows in normal day-to-day usage hit it 100%.

## Fix

`k8s/namespaces/backend/base/consumer/scaledobject.yaml` — set `activationLagThreshold: "0"` on all four `nats-jetstream` triggers:

| Stream | Consumer | Before | After |
|---|---|---|---|
| CONCERT | CONCERT_discovered | `"1"` | `"0"` |
| CONCERT | CONCERT_created | `"1"` | `"0"` |
| ARTIST | ARTIST_created | `"1"` | `"0"` |
| USER | USER_created | `"1"` | `"0"` |

Now `lag > 0` (i.e., any pending message ≥ 1) activates the consumer. The "ignore 1 stuck message as noise" interpretation of the threshold was wrong for this service — every published JetStream message is real product work, and the cost of an unnecessary scale-up is bounded at one extra Pod-minute per cooldown period (300 s).

`lagThreshold` (per-replica scale-up threshold) is unchanged.

## Verification

- [x] `kubectl kustomize k8s/namespaces/backend/overlays/dev` renders the ScaledObject with all four `activationLagThreshold: "0"` values intact.
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` same.
- [x] No Pulumi `src/` changes; pure k8s manifest update.

## Post-merge expectation

After ArgoCD picks up the change on prod:
1. KEDA reconciles ScaledObject and reads the new threshold.
2. The stuck CONCERT.discovered message (~30 minutes old at time of writing) immediately satisfies `1 > 0` → consumer scales 0 → 1.
3. consumer's `create-concerts` handler picks up the message, creates concerts in DB, publishes `concert.created`.
4. consumer's `notify-fans` handler picks up `concert.created`, hits `hype = away` (set by the operator pre-merge), sends Web Push.
5. Operator's browser receives the push notification — completes §18.5 end-to-end verification.

## Related

- Follow-up issue: liverty-music/specification#482 (prepare-prod-service-in §18.5)
- KEDA scaler docs: https://keda.sh/docs/scalers/nats-jetstream/

## Test plan

- [ ] CI green (Lint + Pulumi previews — preview should show 0 src diff since this is k8s-only)
- [ ] `Claude review` Check Run green
- [ ] Post-merge: confirm prod consumer scales up + push received