### PR TITLE
chore(infra): flip workloadEnabled=false on dev to shut down workload tier

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -2,9 +2,11 @@ environment:
   - liverty-music/dev
 config:
   gcp:project: liverty-music-dev
-  # To shut the dev workload tier down (~¥7,000/mo → ~¥300/mo), set
-  # `liverty-music:workloadEnabled: "false"` here in a separate PR
-  # AFTER completing the pre-merge gates documented in
-  # docs/runbooks/dev-shutdown-restart.md (k8s Gateway delete + admin
-  # Org unprotect). The feature code stays committed to main; only
-  # the flag flip triggers the destroy via auto `pulumi up`.
+  # Dev workload tier shut down to reduce idle cost from ~¥7,000/mo
+  # to ~¥300/mo. Pre-merge gates were completed before this PR:
+  # k8s Gateway + HTTPRoutes deleted (orphan GCLB resources verified
+  # cleaned up) and admin Zitadel Org unprotected. To restart, flip
+  # back to `true` and follow procedure B in
+  # docs/runbooks/dev-shutdown-restart.md (expect a two-PR sequence
+  # for `adminOrgIdMap[dev]` refresh).
+  liverty-music:workloadEnabled: "false"


### PR DESCRIPTION
## 🔗 Related Issue

Refs #277 (continues the work after #278 landed the `workloadEnabled` flag feature).

## 📝 Summary of Changes

Flips `liverty-music:workloadEnabled` to `"false"` in `Pulumi.dev.yaml`. This is **the actual shutdown** — merging triggers an auto `pulumi up` that destroys ~141 resources in the dev workload tier (GKE cluster + node pool + cluster subnet, Cloud SQL + PSC endpoint, monitoring policies, Zitadel orchestrator state, GSM bootstrap secret shells).

Restores **dev idle cost from ~¥7,000/mo to ~¥300/mo (−96%)** until restored via procedure B in [`docs/runbooks/dev-shutdown-restart.md`](../blob/main/docs/runbooks/dev-shutdown-restart.md).

## 🛡️ Pre-merge Gates — All Completed Before Opening This PR

Per runbook procedure A:

- [x] **A1 pre-flight** — `gh issue list --label blocks-shutdown` returned empty. Cloud SQL `db-f1-micro` still RUNNABLE today; restart-side tier rejection risk is documented in runbook A1 as a known caveat.
- [x] **A2 (expanded beyond runbook)** — Found and fixed a runbook bug during execution:
  - k8s `Gateway/external-gateway` deleted
  - 3 HTTPRoutes deleted (`backend/server-route`, `frontend/web-route`, `zitadel/zitadel-route`) — the runbook originally only mentioned Gateway, but HTTPRoutes own the GCLB backend-services
  - `argocd-application-controller` StatefulSet scaled to 0 replicas to halt reconciliation (initial `kubectl patch application ... syncPolicy: null` was overwritten by `root-app`'s `selfHeal`; scaling the controller is the only reliable pause)
  - GKE Gateway controller cleaned up: 1 forwarding rule + 1 target-https-proxy + 1 url-map + 6 backend-services
  - 4 orphan health-checks deleted manually (controller doesn't clean up these on backend-service deletion in our case)
  - NEGs (6) remain — zero-cost metadata; will go with the cluster destroy
- [x] **A4a** — `pulumi state unprotect 'urn:pulumi:dev::liverty-music::zitadel:index/org:Org::admin'` executed against dev state. Previous preview failures on the protect flag now resolved.

## 🌍 Affected Stacks
- [x] Dev (destroying workload tier)
- [ ] Prod (untouched — `workloadEnabled` defaults to `true` and prod stack file doesn't override; the `env !== 'dev' && !workloadEnabled` throw in `src/index.ts` would also fail loudly if anyone ever copied this flip to prod)

## 🔮 Pulumi Preview (Local)

```
- 141 to delete
  93 unchanged
   0 errored
```

Stack output changes:
- `webFrontendClientId: [secret] => "DEV_SHUTDOWN_workloadEnabled=false"` (sentinel)
- `productOrgId: "371348346264093539" => "DEV_SHUTDOWN_workloadEnabled=false"` (sentinel)

Frontend CI / build pipelines reading these outputs MUST compare against `DEV_SHUTDOWN_SENTINEL` (the canonical constant exported from `src/index.ts`) before treating the value as a real OIDC client id.

## 📦 State Changes (Planned by This Merge)

The 141 deletes touch only the **Guarded** tier:

- `KubernetesComponent` — GKE Standard cluster, Spot node pool, cluster subnet
- `PostgresComponent` — Cloud SQL instance + PSC consumer endpoint + IAM bindings + DB users
- `MonitoringComponent` + `ZitadelMonitoringComponent` — log-based alert policies, dashboards, Slack channel notification
- Zitadel orchestrator — Org/Project/Apps/Policies, GSM bootstrap secret shells (`zitadel-masterkey`, `zitadel-machine-key-for-pulumi-admin`)
- ServiceAccounts + IAM bindings tied to the workload tier
- 5 service APIs disabled-on-destroy (`container`, `secretmanager`, `sqladmin`, `servicenetworking`, `places`)

The 93 unchanged are the **Preserved** tier: GCP Project + Folders, VPC + DNS zones + Cloudflare records, Cert Manager `cert-map`, static IP (`api-gateway-static-ip`), Artifact Registry (backend + frontend repos), Workload Identity Federation, GitHub repo bindings, cost budget.

## ⚠️ Auto-Deploy Trigger

`Pulumi.dev.yaml` is in the dev stack's deployment trigger paths (`pulumi deployment settings pull` to verify), so this single-line YAML change is sufficient to fire `pulumi up` on merge. Expected duration ~5–10 min (destroys are faster than creates).

## ✅ Checklist
- [x] `pulumi preview` clean locally (141 delete / 93 unchanged / 0 errored)
- [x] All pre-merge gates completed (A1, A2 expanded, A4a)
- [x] Preserved set verified unchanged in preview
- [x] No secrets introduced or modified by this PR

## 💰 Cost Effect

Steady-state dev cost: **~¥7,000/mo → ~¥300/mo (−96%)** once `pulumi up` completes.
