### PR TITLE
feat(gcp): grant prod CI SA repo-scoped reader on dev frontend AR

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -136,6 +136,53 @@ The escape hatch:
 
 The escape hatch SHALL NOT be used for routine ops (failed rebuilds, typos, "want to fix the release notes"). Cut a new patch version for all of those.
 
+## Retag failure recovery (frontend, post-`promote-prod-image-via-retag`)
+
+After the `promote-prod-image-via-retag` change lands, the frontend release path no longer runs `docker build` — it resolves the dev AR digest for `github.sha` and copies it to prod AR via `gcloud artifacts docker tags add`. This section covers the three failure modes specific to the retag flow.
+
+### Failure: dev AR `:<sha>` does not exist
+
+**Symptom**: the "Resolve dev AR digest" workflow step retries 6 times (initial + 5 retries × 60 s) and fails with:
+
+```
+::error::dev AR tag :<sha> not found after 6 attempts (~5 min total wait).
+Either the dev build for this commit failed, or the release was cut on a non-main commit.
+```
+
+**Causes**:
+- **Most likely**: the release was cut on a commit whose dev build failed or was filtered out (e.g., a doc-only commit that didn't trigger the `Deploy Frontend` workflow's `paths:` filter — see `frontend/.github/workflows/push-image.yaml`).
+- **Less likely**: the release was cut seconds after the merge-to-main and the dev push was still in-flight when the 5-minute retry budget expired. Almost always: the dev build is slower than expected; the retry budget already absorbs the typical 60–180 s ArgoCD Image Updater poll.
+- **Edge case**: the release `target_commitish` is a non-main SHA. The workflow's "Verify release commit is on main" step should catch this earlier — if you reach the digest-resolve step with a non-main SHA, something else broke.
+
+**Recovery**:
+1. Check the dev `Deploy Frontend` run for the same commit SHA: `gh run list --repo liverty-music/frontend --branch main --workflow push-image.yaml --limit 10`. If the dev build failed, fix the failure and push to `main`. Then either re-run the existing release (`gh release delete vX.Y.Z` then `gh release create vX.Y.Z --target <new-sha>`) or cut a new patch.
+2. If the dev build was skipped entirely (paths filter), make a trivial commit that DOES match the filter (e.g., bump `package.json`'s patch version), push, wait for the dev image to land in dev AR, then re-cut the release on the new SHA.
+3. If the dev build IS in AR and the digest-resolve step still failed, the IAM grant likely regressed — see "Cross-project IAM grant revoked" below.
+
+### Failure: cross-project IAM grant revoked accidentally
+
+**Symptom**: the "Resolve dev AR digest" workflow step fails immediately with a `PERMISSION_DENIED` from `gcloud artifacts docker images describe`, or the `gcloud artifacts docker tags add` step fails with a 403.
+
+**Cause**: the `prod-ci-frontend-ar-reader` resource (`gcp.artifactregistry.RepositoryIamMember`) was removed from dev project IAM. Most likely a manual `gcloud artifacts repositories remove-iam-policy-binding` invocation, or a `pulumi destroy` that targeted the resource.
+
+**Recovery**:
+1. Verify the binding's absence: `gcloud artifacts repositories get-iam-policy frontend --project=liverty-music-dev --location=asia-northeast2 --format=json | jq '.bindings[] | select(.members[] | contains("github-actions@liverty-music-prod"))'`. Empty output confirms the missing grant.
+2. Re-apply by running `pulumi up --stack dev` on a clean cloud-provisioning checkout. The Pulumi state will recreate `prod-ci-frontend-ar-reader` from `src/gcp/index.ts`. Dev stack auto-applies on merge to main; if the manual revoke was off-cycle, an empty no-op PR followed by a manual Pulumi Cloud Deployments run is the cleanest re-trigger.
+3. The next release will succeed once the binding is restored (no `gcloud` cache to invalidate; `gcloud artifacts` queries are live).
+
+### Failure: immutable-tag re-publish rejected (HTTP 409)
+
+**Symptom**: the `gcloud artifacts docker tags add ... :vX.Y.Z` step fails with `tags.add: ALREADY_EXISTS` / HTTP 409 / "tag already exists".
+
+**Cause**: this is the `prod-image-tag-immutability` capability working as designed. The `:vX.Y.Z` tag was already published in a previous release event and points at a different digest; AR refuses to re-point it. Most likely the operator:
+- Deleted the GitHub Release for `vX.Y.Z`, made a code change, and re-cut the release with the same tag name (the dev rebuild produced a new SHA → new digest → conflict on tag-add).
+- Or, less commonly, the same commit was rebuilt non-deterministically and now has two distinct dev AR digests.
+
+**Recovery**:
+- **Always** cut a new patch version (`v1.0.2` becomes `v1.0.3`). Do NOT delete the published tag in prod AR; the immutability is the whole point. Re-publishing the same name is an explicit anti-pattern.
+- If you genuinely need to roll back, update the kustomize prod overlay's `newTag:` to the older version's tag — the older immutable tag still resolves to its original digest.
+- For a true emergency tag re-point (compromised upstream dep), use the "Genuine emergency requiring tag re-point" escape hatch above. The retag flow's recovery is identical to the rebuild flow's recovery for this failure mode.
+
 ## Related
 
 - Spec: `openspec/specs/prod-image-tag-immutability/spec.md` (post-archive) or the in-flight change at `openspec/changes/enable-prod-ar-immutable-tags/`.

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -167,7 +167,7 @@ Either the dev build for this commit failed, or the release was cut on a non-mai
 
 **Recovery**:
 1. Verify the binding's absence: `gcloud artifacts repositories get-iam-policy frontend --project=liverty-music-dev --location=asia-northeast2 --format=json | jq '.bindings[] | select(.members[] | contains("github-actions@liverty-music-prod"))'`. Empty output confirms the missing grant.
-2. Re-apply by running `pulumi up --stack dev` on a clean cloud-provisioning checkout. The Pulumi state will recreate `prod-ci-frontend-ar-reader` from `src/gcp/index.ts`. Dev stack auto-applies on merge to main; if the manual revoke was off-cycle, an empty no-op PR followed by a manual Pulumi Cloud Deployments run is the cleanest re-trigger.
+2. Re-apply via Pulumi Cloud Deployments — the dev stack auto-applies `src/**` changes on merge to `main` via the automated job, so the cleanest re-trigger is to either (a) wait for the next legitimate PR to land or (b) push an empty no-op commit and merge it, OR (c) trigger the dev stack run manually from the [Pulumi Cloud console](https://app.pulumi.com/pannpers/liverty-music/dev/deployments). Any of those recreates `prod-ci-frontend-ar-reader` from `src/gcp/index.ts`. **Do not run `pulumi up --stack dev` locally** — it conflicts with the automated job (see `cloud-provisioning/CLAUDE.md`).
 3. The next release will succeed once the binding is restored (no `gcloud` cache to invalidate; `gcloud artifacts` queries are live).
 
 ### Failure: immutable-tag re-publish rejected (HTTP 409)

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -164,6 +164,38 @@ export class Gcp {
 			{ parent: this.project },
 		)
 
+		// 4.1. Cross-project AR reader for the prod CI service account.
+		//
+		// Per OpenSpec change `promote-prod-image-via-retag` (archive
+		// pending), the frontend prod release path stops rebuilding and
+		// instead retags the dev AR digest into prod AR. The prod
+		// `github-actions` service account needs READ on the dev project's
+		// frontend AR repo to resolve the digest. Scope is intentionally
+		// minimal: ONE repository, READ only, exactly one direction
+		// (prod CI → dev AR). The cluster-SA cross-project prohibition
+		// (see `prod-image-pipeline` spec) is untouched — CI SAs are
+		// ephemeral Workflow-run identities, structurally distinct from
+		// the persistent cluster identities the prohibition targets.
+		//
+		// Lives in the dev stack because the AR resource being granted on
+		// lives in the dev project. The prod SA email is referenced by
+		// literal because the prod stack constructs that exact email
+		// (verified against `WorkloadIdentityComponent`'s SA name +
+		// project naming).
+		if (environment === 'dev') {
+			new gcp.artifactregistry.RepositoryIamMember(
+				'prod-ci-frontend-ar-reader',
+				{
+					repository: frontendArtifactRegistry.name,
+					location: this.region,
+					project: this.project.projectId,
+					role: 'roles/artifactregistry.reader',
+					member: 'serviceAccount:github-actions@liverty-music-prod.iam.gserviceaccount.com',
+				},
+				{ parent: this.project },
+			)
+		}
+
 		// 4.5. Cloud KMS — etcd CMEK key for the prod GKE cluster.
 		// Application-layer Secrets Encryption is irreversible at cluster
 		// creation, so the key must exist before KubernetesComponent runs.

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -181,19 +181,18 @@ export class Gcp {
 		// lives in the dev project. The prod SA email is constructed by
 		// mirroring `WorkloadIdentityComponent`'s naming convention:
 		// SA short name `github-actions` (literal in workload-identity.ts)
-		// + project ID `${brandId}-prod` (= `liverty-music-prod`). If
-		// either changes, this derivation MUST be updated in lock-step;
-		// otherwise the prod CI loses its dev-AR read grant and every
-		// release hits "Cross-project IAM grant revoked" recovery.
+		// + project ID `${brandId}-prod` (the codebase-wide
+		// `${brandId}-${environment}` pattern; see project.ts). If the
+		// SA short name OR the project-ID pattern ever changes, the
+		// derivation here MUST be updated in lock-step.
 		//
 		// A pulumi.StackReference to the prod stack's exported
 		// githubActionsSAEmail would decouple this, but is heavier
 		// machinery (cross-stack dependency, additional output to maintain)
-		// for what is functionally a single static value. The named
-		// constant + co-located coupling note is the minimum-noise
-		// alternative.
+		// for what is functionally a single static value derivable from
+		// `brandId` already in scope.
 		if (environment === 'dev') {
-			const PROD_PROJECT_ID = 'liverty-music-prod'
+			const PROD_PROJECT_ID = `${brandId}-prod`
 			const PROD_CI_SA_EMAIL = `serviceAccount:github-actions@${PROD_PROJECT_ID}.iam.gserviceaccount.com`
 
 			new gcp.artifactregistry.RepositoryIamMember(

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -178,11 +178,24 @@ export class Gcp {
 		// the persistent cluster identities the prohibition targets.
 		//
 		// Lives in the dev stack because the AR resource being granted on
-		// lives in the dev project. The prod SA email is referenced by
-		// literal because the prod stack constructs that exact email
-		// (verified against `WorkloadIdentityComponent`'s SA name +
-		// project naming).
+		// lives in the dev project. The prod SA email is constructed by
+		// mirroring `WorkloadIdentityComponent`'s naming convention:
+		// SA short name `github-actions` (literal in workload-identity.ts)
+		// + project ID `${brandId}-prod` (= `liverty-music-prod`). If
+		// either changes, this derivation MUST be updated in lock-step;
+		// otherwise the prod CI loses its dev-AR read grant and every
+		// release hits "Cross-project IAM grant revoked" recovery.
+		//
+		// A pulumi.StackReference to the prod stack's exported
+		// githubActionsSAEmail would decouple this, but is heavier
+		// machinery (cross-stack dependency, additional output to maintain)
+		// for what is functionally a single static value. The named
+		// constant + co-located coupling note is the minimum-noise
+		// alternative.
 		if (environment === 'dev') {
+			const PROD_PROJECT_ID = 'liverty-music-prod'
+			const PROD_CI_SA_EMAIL = `serviceAccount:github-actions@${PROD_PROJECT_ID}.iam.gserviceaccount.com`
+
 			new gcp.artifactregistry.RepositoryIamMember(
 				'prod-ci-frontend-ar-reader',
 				{
@@ -190,9 +203,14 @@ export class Gcp {
 					location: this.region,
 					project: this.project.projectId,
 					role: 'roles/artifactregistry.reader',
-					member: 'serviceAccount:github-actions@liverty-music-prod.iam.gserviceaccount.com',
+					member: PROD_CI_SA_EMAIL,
 				},
-				{ parent: this.project },
+				// protect: true — the grant is on the prod CI critical
+				// path. A `pulumi destroy --target` or operator slip
+				// silently breaks every subsequent release. Removal
+				// requires deliberate `pulumi state unprotect` first,
+				// which is the blast-radius-proportional barrier we want.
+				{ parent: this.project, protect: true },
 			)
 		}
 


### PR DESCRIPTION
## Summary

Implements `promote-prod-image-via-retag` §2 (spec landed in [liverty-music/specification#495](https://github.com/liverty-music/specification/pull/495)). The frontend prod release path will stop rebuilding and instead retag the dev AR digest into prod AR. This PR grants the **scoped IAM** that makes the retag possible.

## What changes

**One new resource in the dev stack:**

```ts
gcp.artifactregistry.RepositoryIamMember(
  'prod-ci-frontend-ar-reader',
  {
    repository: <dev frontend AR repo>,
    location: 'asia-northeast2',
    project: 'liverty-music-dev',
    role: 'roles/artifactregistry.reader',
    member: 'serviceAccount:github-actions@liverty-music-prod.iam.gserviceaccount.com',
  }
)
```

- **One repo** (frontend; backend retag is a separate change)
- **One role** (reader; no writer/admin)
- **One direction** (prod CI → dev AR; not reverse)
- **One member** (prod github-actions SA only)
- **Repo-level, not project-level** — minimum blast radius

The spec carves CI service accounts out of `prod-image-pipeline`'s cross-project AR prohibition. Cluster SAs remain blocked because their blast radius is structurally different (persistent runtime privilege exfiltratable from a compromised Pod vs ephemeral Workflow-run identity scoped via WIF to a specific GitHub repo).

**Runbook update**: `docs/runbooks/prod-image-tag-pinning.md` §"Retag failure recovery" covers three failure modes:
- dev AR `:<sha>` missing — diagnosis + 3 recovery paths
- cross-project IAM grant revoked accidentally — re-apply via `pulumi up --stack dev`
- HTTP 409 immutable-tag rejection — cut new patch version

## Preview (already verified locally)

| Stack | Result |
|---|---|
| `pulumi preview --stack dev` | `+ 1 to create` (`prod-ci-frontend-ar-reader`) |
| `pulumi preview --stack prod` | No resource changes from this code (env-gate keeps it dev-only) |

A pre-existing `zitadel-observability` dashboard JSON drift surfaces in both preview outputs; it predates this branch and is not my change.

## Deploy sequence (after this PR merges)

1. **Auto-apply** — Pulumi Cloud Deployments runs `pulumi up --stack dev` automatically when this PR's `src/**` changes hit main.
2. **Verify** — `gcloud artifacts repositories get-iam-policy frontend --project=liverty-music-dev --location=asia-northeast2 --format=json` should show `serviceAccount:github-actions@liverty-music-prod...` under `roles/artifactregistry.reader`.
3. **Open the frontend workflow PR** (separate; refactors `push-image.yaml` release-event branch to retag). The frontend PR must merge AFTER step 1 completes; otherwise the next release event's `gcloud artifacts docker images describe` call fails with `PERMISSION_DENIED`.
4. **Cut the next release tag** to exercise the retag flow end-to-end.

> **Note on prod stack**: this change does NOT touch prod-side resources, so no manual `pulumi up --stack prod` is needed. The prod stack's `pulumi preview` will show no changes from this code once the PR merges. (Standard prod IaC protocol still applies for any future changes — preview-then-up via Pulumi Cloud console.)

## Test plan

- [x] `make lint-ts` passes (biome + tsc clean)
- [x] `pulumi preview --stack dev` shows `+ 1 to create` for `prod-ci-frontend-ar-reader`, nothing else from this branch
- [x] `pulumi preview --stack prod` shows no resource changes from this branch
- [ ] After merge: dev auto-apply runs and the new binding is verifiable via `gcloud artifacts repositories get-iam-policy`
- [ ] Companion frontend PR's workflow can `gcloud artifacts docker images describe` against `liverty-music-dev/frontend/web-app:<sha>` from a prod-WIF auth context

Refs: liverty-music/specification#494