### PR TITLE
chore(backend-prod): bump prod overlay to backend v1.0.1

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/version: "1.0.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.0.0  # commit 3bc2dada3c4cd06c218235eb7fe21ad638e29bf3
+  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1


### PR DESCRIPTION
## Summary

Ships the empty-venue-name skip fix (liverty-music/backend#299, released as v1.0.1) to the prod cluster. Updates all four `images:` block entries (server / consumer / concert-discovery / artist-image-sync) plus the `app.kubernetes.io/version` Recommended Label in lock-step, per the inline policy comment that bans drift between the two.

## Changes

`k8s/namespaces/backend/overlays/prod/kustomization.yaml`

| Field | Before | After |
|---|---|---|
| `images[*].newTag` | `v1.0.0` (commit `3bc2dada3c4cd06c218235eb7fe21ad638e29bf3`) | `v1.0.1` (commit `1acdd134aae3208912160e4d28660b55d9ea00e1`) |
| `labels.pairs.app.kubernetes.io/version` | `\"1.0.0\"` | `\"1.0.1\"` |

## What v1.0.1 ships

Single bug fix from liverty-music/backend#299:

> Gemini occasionally returns concert entries with `listed_venue_name=\"\"` (typically announced-but-venue-TBA tour dates). The previous code passed the empty string to Google Places, which returned 400 INVALID_ARGUMENT, and the watermill consumer retried the entire `CONCERT.discovered` batch 3× before routing it to the poison queue — losing all sibling concerts with valid venues. Now the empty-venue entry is skipped with a WARN log and the rest of the batch persists normally.

Observed live in prod on 2026-05-18 for the operator's first UVERworld follow: all 9 concert candidates were lost. After this overlay PR merges, the next discovery run for UVERworld (or any other affected artist) will correctly persist the valid concerts and skip only the TBA entry.

## Verification

- [x] `gcloud artifacts docker images list asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/... --filter='tags ~ v1.0.1'` returned all four images with the SHA + semver tag pair, confirming the backend release-event Deploy workflow already pushed them at 2026-05-18T19:43–19:45 JST.
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders all four prod backend images with `:v1.0.1`; no `:v1.0.0` references remain. `app.kubernetes.io/version` label resolves to `1.0.1` across every workload, Service, and CronJob.

## Rollout after merge

1. ArgoCD `backend` Application on prod reconciles (~3 min poll cycle).
2. server-app + consumer-app + cronjobs roll to `v1.0.1` images one at a time (replicas=1 each, so each is a brief restart).
3. Next manual follow OR daily 9 AM UTC `concert-discovery` cronjob exercises the new defensive skip path.

## Operator recovery for UVERworld

UVERworld currently has 0 prod `app.concerts` rows because the v1.0.0 consumer poison-queued the entire batch when Gemini returned an empty-venue entry. After ArgoCD reconciles this PR, the operator can recover via either path:
- Unfollow + re-follow UVERworld in the SPA — fires \"First follow detected\" → Gemini → new CONCERT.discovered → with v1.0.1 the empty entry is skipped and the other 8 concerts persist.
- Wait for tomorrow's 9 AM UTC cronjob — same effect, no operator action.

## Related

- Released here: liverty-music/backend@v1.0.1 (https://github.com/liverty-music/backend/releases/tag/v1.0.1)
- Surfaced during: liverty-music/specification#482 (§18.5 push notification e2e verification)
- Companion fix in this repo: liverty-music/cloud-provisioning#280 (KEDA activationLagThreshold)

## Test plan

- [ ] CI green (Lint + Pulumi prod preview — preview should show 0 src diff since this is k8s-only)
- [ ] `Claude review` Check Run green
- [ ] Reviewer sign-off