### PR TITLE
docs(runbooks): correct retag-section tool name (crane, not gcloud-tags-add)

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -138,7 +138,7 @@ The escape hatch SHALL NOT be used for routine ops (failed rebuilds, typos, "wan
 
 ## Retag failure recovery (frontend, post-`promote-prod-image-via-retag`)
 
-After the `promote-prod-image-via-retag` change lands, the frontend release path no longer runs `docker build` — it resolves the dev AR digest for `github.sha` and copies it to prod AR via `gcloud artifacts docker tags add`. This section covers the three failure modes specific to the retag flow.
+After the `promote-prod-image-via-retag` change lands (live as of 2026-05-18), the frontend release path no longer runs `docker build` — it resolves the dev AR digest for `github.sha` and copies it to prod AR via `crane copy` (from `google/go-containerregistry`, installed by `imjasonh/setup-crane`). The proposal's original choice of `gcloud artifacts docker tags add` was inverted during implementation: the gcloud command only renames tags **within a single repository** despite its argument shape, so cross-project copy fails with `Image <src-FQDN> does not match image <dst-FQDN>`. See `openspec/changes/promote-prod-image-via-retag/design.md` D1 (post-archive: `openspec/specs/prod-image-pipeline/spec.md`) for the full post-mortem. This section covers the three failure modes specific to the retag flow.
 
 ### Failure: dev AR `:<sha>` does not exist
 
@@ -161,7 +161,7 @@ Either the dev build for this commit failed, or the release was cut on a non-mai
 
 ### Failure: cross-project IAM grant revoked accidentally
 
-**Symptom**: the "Resolve dev AR digest" workflow step fails immediately with a `PERMISSION_DENIED` from `gcloud artifacts docker images describe`, or the `gcloud artifacts docker tags add` step fails with a 403.
+**Symptom**: the "Resolve dev AR digest" workflow step fails immediately with a `PERMISSION_DENIED` from `gcloud artifacts docker images describe`, or a "Promote dev AR digest to prod AR" step fails with a 403 from `crane copy` (typically surfaced as `DENIED: Permission "artifactregistry.repositories.uploadArtifacts" denied`).
 
 **Cause**: the `prod-ci-frontend-ar-reader` resource (`gcp.artifactregistry.RepositoryIamMember`) was removed from dev project IAM. Most likely a manual `gcloud artifacts repositories remove-iam-policy-binding` invocation, or a `pulumi destroy` that targeted the resource.
 
@@ -172,10 +172,10 @@ Either the dev build for this commit failed, or the release was cut on a non-mai
 
 ### Failure: immutable-tag re-publish rejected (HTTP 409)
 
-**Symptom**: the `gcloud artifacts docker tags add ... :vX.Y.Z` step fails with `tags.add: ALREADY_EXISTS` / HTTP 409 / "tag already exists".
+**Symptom**: a "Promote dev AR digest to prod AR" step fails with HTTP 409 from `crane copy`, surfaced as `ALREADY_EXISTS: name 'projects/liverty-music-prod/.../tags/vX.Y.Z' already exists` (or equivalent AR error).
 
 **Cause**: this is the `prod-image-tag-immutability` capability working as designed. The `:vX.Y.Z` tag was already published in a previous release event and points at a different digest; AR refuses to re-point it. Most likely the operator:
-- Deleted the GitHub Release for `vX.Y.Z`, made a code change, and re-cut the release with the same tag name (the dev rebuild produced a new SHA → new digest → conflict on tag-add).
+- Deleted the GitHub Release for `vX.Y.Z`, made a code change, and re-cut the release with the same tag name (the new dev SHA → new digest → conflict on `crane copy`).
 - Or, less commonly, the same commit was rebuilt non-deterministically and now has two distinct dev AR digests.
 
 **Recovery**:

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -161,7 +161,7 @@ Either the dev build for this commit failed, or the release was cut on a non-mai
 
 ### Failure: cross-project IAM grant revoked accidentally
 
-**Symptom**: the "Resolve dev AR digest" workflow step fails immediately with a `PERMISSION_DENIED` from `gcloud artifacts docker images describe`, or a "Promote dev AR digest to prod AR" step fails with a 403 from `crane copy` (typically surfaced as `DENIED: Permission "artifactregistry.repositories.uploadArtifacts" denied`).
+**Symptom**: the "Resolve dev AR digest" workflow step fails immediately with a `PERMISSION_DENIED` from `gcloud artifacts docker images describe`, or a "Promote dev AR digest to prod AR" step fails with a 403 from `crane copy` while reading the dev AR source image (typically surfaced as `DENIED: Permission "artifactregistry.repositories.downloadArtifacts" denied on resource "projects/liverty-music-dev/…"`). Note: this is a **read-side** failure against dev AR — the binding `prod-ci-frontend-ar-reader` grants `roles/artifactregistry.reader` on the dev `frontend` AR repo. An `uploadArtifacts` denial on prod AR would indicate a different, separate failure (prod CI SA missing writer on prod AR) outside the scope of this binding.
 
 **Cause**: the `prod-ci-frontend-ar-reader` resource (`gcp.artifactregistry.RepositoryIamMember`) was removed from dev project IAM. Most likely a manual `gcloud artifacts repositories remove-iam-policy-binding` invocation, or a `pulumi destroy` that targeted the resource.
 


### PR DESCRIPTION
## Summary

Corrects the retag-failure-recovery section of `docs/runbooks/prod-image-tag-pinning.md` to reflect the tool that actually shipped (`crane copy`) instead of the one originally specified (`gcloud artifacts docker tags add`). Confined to the section added by #282 — no other parts of the runbook change.

## Why

The retag section was written against the original `promote-prod-image-via-retag` design D1, which picked `gcloud artifacts docker tags add` as the copy primitive. That choice was inverted during implementation when the gcloud command turned out to only rename tags **within a single repository** (cross-project copy fails with `Image <src-FQDN> does not match image <dst-FQDN>`, verified live in [frontend run #26025105562](https://github.com/liverty-music/frontend/actions/runs/26025105562)).

The actual tool that shipped is `crane copy` (via [frontend#363](https://github.com/liverty-music/frontend/pull/363)). v1.0.2 promoted successfully on the third release attempt; dev / prod AR digests now match byte-for-byte (`sha256:3e9a66d12b4f…`).

Companion spec PR with the full post-mortem: [liverty-music/specification#496](https://github.com/liverty-music/specification/pull/496).

## What changes

Three edits, all in the "Retag failure recovery (frontend, post-`promote-prod-image-via-retag`)" section:

1. **Intro paragraph** — replace gcloud-tags-add with `crane copy` and add a one-sentence pointer to `design.md` D1 so a future operator landing here understands why the runbook's tool name doesn't match what they read in the proposal.
2. **"Cross-project IAM grant revoked accidentally" symptom** — update the failure surface from `gcloud artifacts docker tags add` 403 to `crane copy` 403 with the actual AR error string (`DENIED: Permission "artifactregistry.repositories.uploadArtifacts" denied`).
3. **"Immutable-tag re-publish rejected (HTTP 409)" symptom** — update from gcloud-tags-add `ALREADY_EXISTS` to the `crane copy` equivalent (`ALREADY_EXISTS: name 'projects/liverty-music-prod/.../tags/vX.Y.Z' already exists`).

## What stays as-is

Every other `gcloud artifacts docker tags add` reference in this file is about manual operator surface that the `prod-image-tag-immutability` capability needs to reject — that's the correct command name for those examples (lines 13, 77, 106, 110, 133 — escape-hatch procedure + AR-rejection enforcement). Those references are intentional and not touched.

## Testing

- N/A (documentation only).
- The retag flow itself is validated end-to-end: v1.0.2 promoted to prod AR with `sha256:3e9a66d12b4f528f51d1201ff786561070f54ae7592a13333c0a1bd372e5ddf0` (byte-identical to dev AR `:ec3fe386…`).

Refs: liverty-music/specification#494
