### PR TITLE
chore(frontend): cut prod over to v1.0.2 (first retag-promoted release)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.0.1  # commit 9fafbcec8875c98d3031ed1c64956a2e81ac68d6
+  newTag: v1.0.2  # commit ec3fe3868ac528c3b80ef761c2b1ee819b3de9fe


### PR DESCRIPTION
## Summary

Cuts prod frontend over from `v1.0.1` → `v1.0.2` — the first release promoted via the dev-AR → prod-AR retag flow (`promote-prod-image-via-retag`). ArgoCD will sync on merge and roll the prod `web-app` Deployment to the byte-identical image already in service on dev.

## Why this is the right next step

- The original v1.0.0 prod Sev-1 was the blank-screen regression caused by `@aurelia/vite-plugin@2.0.0-rc.1` literal `mode === 'production'` template stripping. v1.0.1 fixed it via the runtime-config refactor; v1.0.2 is the first release to *also* validate that the retag promotion mechanism works end-to-end.
- The image is **already in prod AR** (retagged by [frontend release-event run #26026465158](https://github.com/liverty-music/frontend/actions/runs/26026465158)). This PR is the manifest-side cutover — the registry side is already settled.
- Dev / prod AR digests match byte-for-byte:

  ```
  sha256:3e9a66d12b4f528f51d1201ff786561070f54ae7592a13333c0a1bd372e5ddf0

  dev /frontend/web-app:ec3fe386…   ← built by dev push run #26026326800
  prod/frontend/web-app:v1.0.2      ← retagged by release event run #26026465158
  prod/frontend/web-app:ec3fe386…   ← retagged by release event run #26026465158
  ```

## What changes

Three lines, in lock-step (the runbook's `v`-prefix gotcha — different conventions for AR tags vs Recommended Labels):

```diff
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
 ...
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.0.1  # commit 9fafbcec8875c98d3031ed1c64956a2e81ac68d6
+  newTag: v1.0.2  # commit ec3fe3868ac528c3b80ef761c2b1ee819b3de9fe
```

No ConfigMap changes — per-env values are mounted from `web-app-runtime-config` and are unchanged across this bump.

## Pre-merge verification (local)

```bash
$ kubectl kustomize k8s/namespaces/frontend/overlays/prod | grep -E 'image:.*web-app|app\.kubernetes\.io/version' | sort -u
app.kubernetes.io/version: 1.0.2
      - image: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app:v1.0.2
    app.kubernetes.io/version: 1.0.2

$ kubectl kustomize k8s/namespaces/frontend/overlays/prod | grep -E 'app\.kubernetes\.io/version: "?v' && echo "FAIL" || echo "OK: label values are bare semver"
OK: label values are bare semver
```

Both checks pass.

## Post-merge verification (after ArgoCD syncs)

- `curl -s -o /dev/null -w "%{http_code}\n" https://liverty-music.app/` → `200`
- `curl -s https://liverty-music.app/config.json | jq .environment` → `"prod"`
- Optional manual smoke: `gh workflow run "Deploy Frontend" --repo liverty-music/frontend -f smoke_url=https://liverty-music.app`

## OpenSpec cross-refs

This PR completes task §4.4 of [`promote-prod-image-via-retag`](https://github.com/liverty-music/specification/tree/main/openspec/changes/promote-prod-image-via-retag/tasks.md). After ArgoCD sync + post-deploy smoke pass, §4.5 + §4.6 tick off and the change is ready for the archive PR.

Companion PRs landing in parallel:
- [liverty-music/specification#496](https://github.com/liverty-music/specification/pull/496) — corrects the delta artifacts for the actual tool that shipped (`crane copy`).
- [liverty-music/cloud-provisioning#285](https://github.com/liverty-music/cloud-provisioning/pull/285) — corrects this runbook's retag section to match.

Refs: liverty-music/specification#494
