### PR TITLE
chore(infra): flip workloadEnabled=false on dev to shut down workload tier

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -2,9 +2,12 @@ environment:
   - liverty-music/dev
 config:
   gcp:project: liverty-music-dev
-  # To shut the dev workload tier down (~¥7,000/mo → ~¥300/mo), set
-  # `liverty-music:workloadEnabled: "false"` here in a separate PR
-  # AFTER completing the pre-merge gates documented in
-  # docs/runbooks/dev-shutdown-restart.md (k8s Gateway delete + admin
-  # Org unprotect). The feature code stays committed to main; only
-  # the flag flip triggers the destroy via auto `pulumi up`.
+  # Dev workload tier shut down to reduce idle cost from ~¥7,000/mo to
+  # ~¥300/mo. Path 2 design (#283): Cloud SQL is STOPped (not destroyed)
+  # so dev data survives the shutdown window; `zitadel-masterkey` GSM
+  # secret persists in Pulumi state so the same value decrypts existing
+  # rows on restart. The cluster + workload SAs + PSC endpoint +
+  # monitoring + Zitadel orchestrator + cluster-scoped IAM bindings are
+  # destroyed. See docs/runbooks/dev-shutdown-restart.md procedure B
+  # for the restart sequence.
+  liverty-music:workloadEnabled: "false"


### PR DESCRIPTION
## 🔗 Related

Refs #277, follow-up to merged #283 (Path 2 refactor).

## 📝 Summary

**Single-line YAML flip.** Sets `liverty-music:workloadEnabled: "false"` to trigger the dev workload-tier shutdown via the gates that the merged #283 refactor put in place.

This is the merge that **actually executes the destroy**. Restores: revert this PR, follow procedure B in [`docs/runbooks/dev-shutdown-restart.md`](../blob/main/docs/runbooks/dev-shutdown-restart.md).

## 🛡️ Pre-merge Gates — Completed Before Opening This PR

Per runbook procedure A:

- [x] **A1 pre-flight**: cluster RUNNING / Cloud SQL RUNNABLE / Gateway PROGRAMMED / no `blocks-shutdown` issues.
- [x] **A2 (expanded)**: `kubectl scale statefulset argocd-application-controller --replicas=0` → `kubectl delete gateway -n gateway external-gateway` → `kubectl delete httproute` on backend/frontend/zitadel namespaces → waited for GKE Gateway controller to clean up: 1 forwarding rule + 1 target-https-proxy + 1 url-map + 6 backend-services. No orphan health-checks.
- [x] **A4a**: `pulumi state unprotect 'urn:pulumi:dev::liverty-music::zitadel:index/org:Org::admin'`.
- [x] **A5b (race mitigation, since [#287](https://github.com/liverty-music/cloud-provisioning/issues/287) is still open)**: bulk `pulumi state delete` over 24 candidate Zitadel resources (`zitadel:index/*`, `pulumi:providers:zitadel`, Zitadel-namespaced `pulumi-nodejs:dynamic:Resource`). 16 successfully removed from state across 3 iterations. The remaining 8 (Provider + 2 Orgs + 2 MachineUsers + InstanceMember + MachineKey + PAT) have dependents that block clean state delete; they will destroy via API in the merge's `pulumi up` while the cluster is still alive — race window dramatically shorter than baseline.

## 🌍 Affected Stacks
- [x] Dev (destroying workload tier; Cloud SQL STOPped, not destroyed)
- [ ] Prod (untouched — `workloadEnabled` defaults to `true`; the `env !== 'dev' && !workloadEnabled` throw in `src/index.ts` is the safety net)

## 🔮 Pulumi Preview (Local)

```
- 111 to delete
~   2 to update
  113 unchanged
    0 errored
```

Updates:
- `gcp:sql:DatabaseInstance postgres-osaka ~settings` (activationPolicy: ALWAYS → NEVER, the actual STOP)
- `gcp:liverty-music:PostgresComponent postgres` arg metadata (subnetId / SA emails removed, workloadEnabled flipped)

Deletes touch only the **Guarded** tier from runbook §A5:
- `gcp:container:Cluster standard-cluster-osaka`, `NodePool spot-pool-osaka`, `Subnetwork cluster-subnet-osaka`
- `gcp:compute:ForwardingRule psc-endpoint-postgres-osaka`, `Address psc-endpoint-ip-postgres-osaka`
- `gcp:liverty-music:KubernetesComponent`, `MonitoringComponent`, `ZitadelMonitoringComponent`
- 8 remaining `zitadel:*` resources (Orgs, MachineUsers, MachineKey, PAT, InstanceMember, Provider) — destroyed via Zitadel API while cluster is up
- ~10 zitadel:liverty-music ComponentResource wrappers (state-only delete, no API calls)
- Cluster-SA Cloud SQL IAM users (`backend-app`, `zitadel`)
- ~6 monitoring policies + dashboard + notification channel
- K8s-managed GSM Secrets (postgres-admin-password, vapid-private-key, lastfm/fanart/blockchain API keys, zitadel-machine-key-for-backend-app, zitadel-login-pat) + their IAM bindings
- IAM bindings on the preserved `zitadel-masterkey` and `zitadel-machine-key-for-pulumi-admin` secrets (the Secret containers themselves stay)

Preserved (113 unchanged): GCP Project + Folders, VPC + DNS zones + Cloudflare records, Cert Manager `cert-map`, static IP (`api-gateway-static-ip`), Artifact Registry repos + IAM, Workload Identity Federation, GitHub repo bindings, cost budget, **Cloud SQL instance** + `liverty-music` and `zitadel` databases + postgres admin user, **`zitadel-masterkey`** Secret + Version, **`zitadel-machine-key-for-pulumi-admin`** Secret.

Stack outputs: `webFrontendClientId` and `productOrgId` flip to the `DEV_SHUTDOWN_workloadEnabled=false` sentinel — frontend CI consumers MUST detect this constant before treating the value as a real OIDC client id.

## ⚠️ Auto-deploy fires on this YAML change

The dev stack's Pulumi Cloud Deployment trigger paths include `Pulumi.dev.yaml` (verified via `pulumi deployment settings pull`). Merging this PR triggers `pulumi up` immediately.

## 💰 Cost effect

Steady-state dev cost: **~¥7,000/mo → ~¥300/mo (−96%)** once `pulumi up` completes.

## ✅ Checklist
- [x] `pulumi preview` clean locally (111 deletes / 2 updates / 0 errored)
- [x] All pre-merge gates completed (A1, A2 expanded, A4a, A5b)
- [x] Preserved set verified unchanged in preview
