### PR TITLE
chore(k8s): bump backend prod overlay to v1.0.2 (first symmetric-retag cutover)

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.0.2"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
+  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
+  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
+  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.0.1  # commit 1acdd134aae3208912160e4d28660b55d9ea00e1
+  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57


### PR DESCRIPTION
## Summary

First prod cutover via the retag-promoted release path. Bumps the 4 backend Deployments (`server`, `consumer`, `concert-discovery`, `artist-image-sync`) plus the Recommended-Labels `app.kubernetes.io/version` from `1.0.1` → `1.0.2`, with the inline commit-SHA comment updated to the post-merge HEAD `4085276f6e79b9798aadde5f3286d30f7bb4ce57`.

Single PR covers all 4 Deployments so ArgoCD applies them in lock-step (per OpenSpec `backend-symmetric-retag` design D4: prod cutover uses one PR, not 4 staggered bumps — the 4 backend services share a release SemVer).

## Why

The backend retag flow went live with the `backend-symmetric-retag` OpenSpec change (specification PR liverty-music/specification#499, backend PR liverty-music/backend#301). Release `v1.0.2` is the first release cut on the new flow — the prod AR tags are byte-identical to the dev AR `:<sha>` tags exercised in dev, eliminating the dev/prod image divergence that the prior 4× docker build-push could introduce.

## Verified pre-bump

| Image | dev AR `:4085276f` digest = prod AR `:v1.0.2` digest |
|---|---|
| `server` | `sha256:9782714ae2e0c0e7bcf9bd0bd11eda4548075739008c487887d5c7001f337ac2` |
| `consumer` | `sha256:99b8025faa9b188d9d20bda387fc781c668b55ad6af44cb9b04b7f88b732c779` |
| `concert-discovery` | `sha256:09083e1a1b8d57e8ee7a1761194b76f840f664c27eaf3095930cd176d2a88d4c` |
| `artist-image-sync` | `sha256:88014394942f4e4b084959ed3ab48151bc99366483d827a154982ac63b373dff` |

Retag wall-clock: ~30 s for the 4 parallel `crane copy` matrix entries (vs ~6 min for the prior 4× sequential build-push).

## Test plan

- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders all 4 images as `:v1.0.2` and all `app.kubernetes.io/version` labels as bare `1.0.2` (no `v` prefix).
- [ ] CI lint passes.
- [ ] After merge → ArgoCD detects, syncs all 4 Deployments to `:v1.0.2` (and updates the version label).
- [ ] Prod health probe (task 4.6 of `backend-symmetric-retag`): `curl https://api.liverty-music.app/grpc.health.v1.Health/Check` returns `SERVING`.

Closes #291