### PR TITLE
fix(zitadel): route Login UI through cluster-internal Service URL (Phase 2)

### DIFF
--- a/docs/runbooks/dev-shutdown-restart.md
+++ b/docs/runbooks/dev-shutdown-restart.md
@@ -542,6 +542,29 @@ ENABLED version remains, and bounce the pod again.
 > improvement could be a Pulumi `Command` resource that runs this on
 > shutdown automatically, but that's out of scope for now.
 
+### B6b. Capture the new dev Zitadel instance id
+
+After the Cloud SQL wipe + re-bootstrap, Zitadel creates a **new instance with a new id** (same chicken-and-egg as `adminOrgIdMap[dev]` in §B4a, just one layer up). `instanceIdMap[dev]` in `src/zitadel/constants.ts` still holds the `__UNSET__` sentinel from the dev-shutdown era. Without this step, the next `pulumi up` would hit the `ZitadelInstanceCustomDomain` Dynamic Resource's fail-fast guard with:
+
+> `ZitadelInstanceCustomDomain: instanceId is the __UNSET__ sentinel. Run \`node scripts/discover-zitadel-instance-id.mjs --env=dev\` ...`
+
+Run the discovery script from `cloud-provisioning/`:
+
+```bash
+node scripts/discover-zitadel-instance-id.mjs --env=dev
+```
+
+The script signs a `pulumi-system` System User JWT using the private key in GSM (`zitadel-system-api-key`) and prints the captured id ready to paste:
+
+```
+[discover] paste this into src/zitadel/constants.ts (instanceIdMap):
+  dev: '<NEW_INSTANCE_ID>',
+```
+
+Update `instanceIdMap[dev]` in `src/zitadel/constants.ts`, commit, and let Pulumi proceed. The Dynamic Resource will then call `AddCustomDomain` to re-register `zitadel-api.zitadel.svc.cluster.local` against the new instance — same idempotent path the prod Phase 2 took.
+
+> **Prerequisite for this step**: the `pulumi-system` System User must already be loaded on the `zitadel-api` Pod. That happens automatically as part of B5's ArgoCD sync (the `external-secret-system-api-pub` ExternalSecret + the `ZITADEL_SYSTEMAPIUSERS` env on `deployment-api.yaml` are in base). Wait for `kubectl get pods -n zitadel -l component=api` to show 1/1 Ready before running the script.
+
 ### B7. End-to-end smoke
 
 ```bash

--- a/k8s/namespaces/zitadel/base/deployment-web.yaml
+++ b/k8s/namespaces/zitadel/base/deployment-web.yaml
@@ -57,28 +57,49 @@ spec:
         - containerPort: 3000
           name: http
         env:
-        # ZITADEL_API_URL must be the **public** issuer URL, not the
-        # cluster-internal Service URL. Zitadel v4 selects the virtual
-        # instance from the request's Host header and matches it against
-        # the configured InstanceDomains; the cluster-internal hostname
-        # `zitadel-api.zitadel.svc.cluster.local` is not in that list, so
-        # internal calls return HTTP 404 ("Failed to fetch security
-        # settings from API ... status:404").
+        # ZITADEL_API_URL is the **cluster-internal Service URL** of the
+        # Zitadel API. The prior public-issuer-URL design (where the Login
+        # UI Pod hairpinned through the public Gateway IP back into the
+        # same cluster) reliably hung Node's HTTP/1.1 Connect-RPC client
+        # for 30s at the GCP HTTPS LB / Google Front End record layer in
+        # prod, surfacing as `504 upstream request timeout` on every
+        # `/ui/v2/login/login?authRequest=...` and blocking all sign-in /
+        # sign-up. Direct `wget` from the same Pod to the same URL
+        # responded in ~120ms — the failure was specific to Node's HTTP
+        # client through the hairpin, the same class of fault Zitadel
+        # upstream PR #12022 documented on Cloud Run as "intermittent SSL
+        # routines::record layer failure errors that were tenant-consistent".
         #
-        # Setting the public URL here makes the login UI's outbound calls
-        # carry `Host: auth.dev.liverty-music.app`. The request still stays
-        # within the cluster: it goes Gateway → HTTPRoute (`/` catch-all
-        # rule) → `zitadel-api` Service → API container. The Gateway round-trip
-        # adds ~10ms but avoids any cluster-DNS rewrite hacks.
+        # The `Host` header for these calls is now
+        # `zitadel-api.zitadel.svc.cluster.local`. Zitadel v4 selects the
+        # virtual instance from the request's Host and matches it against
+        # the configured InstanceDomains, so the cluster-internal
+        # hostname is registered as an `InstanceCustomDomain` by the
+        # `ZitadelInstanceCustomDomain` Pulumi Dynamic Resource (see
+        # `src/zitadel/dynamic/instance-custom-domain.ts`). That
+        # registration requires `system.domain.write` (SYSTEM_OWNER),
+        # which is provided by the Pulumi-managed `pulumi-system` System
+        # User declared via `ZITADEL_SYSTEMAPIUSERS` env on the
+        # `zitadel-api` Pod.
         #
-        # An alternative (not used) is registering the internal hostname
-        # as an InstanceDomain via the API; deferred because that adds an
-        # imperative bootstrap step outside of Pulumi/Kustomize.
+        # The URL has no explicit port; the `zitadel-api` Service
+        # exposes `port: 80` → `targetPort: 8080`, so Node's HTTP client
+        # emits `Host: zitadel-api.zitadel.svc.cluster.local` (no `:80`
+        # — RFC 7230 §5.4 only includes the port when non-default), and
+        # the registered domain matches exactly regardless of how
+        # Zitadel handles port stripping.
+        #
+        # Plaintext HTTP is acceptable because traffic stays inside the
+        # GKE cluster network; the existing `TLS Terminated at Gateway,
+        # Cluster Traffic Unencrypted` requirement of the
+        # `zitadel-self-hosted-deployment` spec already permits
+        # unencrypted in-cluster hops.
         #
         # Refs:
-        #   https://zitadel.com/docs/self-hosting/manage/custom-domain
+        #   OpenSpec change `route-login-v2-via-internal-zitadel-api`
+        #   Zitadel upstream PR #12022 (hairpin SSL fault context)
         - name: ZITADEL_API_URL
-          value: https://auth.dev.liverty-music.app
+          value: http://zitadel-api.zitadel.svc.cluster.local
         - name: NEXT_PUBLIC_BASE_PATH
           value: /ui/v2/login
         # Personal Access Token used by the Login V2 UI Next.js server to

--- a/k8s/namespaces/zitadel/overlays/prod/deployment-web-patch.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/deployment-web-patch.yaml
@@ -3,11 +3,15 @@
 # spot-pool nodeSelector. PDB minAvailable=1 from base is relaxed in
 # pdb-patch.yaml.
 #
-# Also overrides ZITADEL_API_URL to the prod public URL. Base hardcodes the
-# dev URL; without this patch, prod's Login UI would call the dev domain,
-# producing HTTP 404 (the cluster-internal hostname is not in prod's
-# InstanceDomains list) → Login SSR 500. Same env-leak-from-base pattern
-# as the HTTPRoute hostname (design D1).
+# `ZITADEL_API_URL` is intentionally NOT patched here. Per OpenSpec change
+# `route-login-v2-via-internal-zitadel-api`, the base manifest sets the
+# value to the cluster-internal Service URL
+# (`http://zitadel-api.zitadel.svc.cluster.local`), which is
+# environment-agnostic — both dev and prod resolve the Service in their
+# own cluster's DNS. The prior public-URL override that lived here was
+# only necessary because the base value used to be hardcoded to the dev
+# domain; with the base value now internal, no per-env override is
+# needed.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,8 +22,3 @@ spec:
     spec:
       nodeSelector:
         cloud.google.com/gke-spot: "true"
-      containers:
-      - name: web
-        env:
-        - name: ZITADEL_API_URL
-          value: https://auth.liverty-music.app

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,15 @@ import {
 	GitHubRepositoryComponent,
 	RepositoryName,
 } from './github/index.js'
-import { SecretsComponent, Zitadel } from './zitadel/index.js'
+import { ZitadelInstanceCustomDomain } from './zitadel/dynamic/index.js'
+import {
+	instanceIdMap,
+	SecretsComponent,
+	SYSTEM_API_USER_NAME,
+	ZITADEL_API_INTERNAL_HOST,
+	Zitadel,
+	zitadelDomainMap,
+} from './zitadel/index.js'
 
 const brandId = 'liverty-music'
 const displayName = 'Liverty Music'
@@ -160,27 +168,55 @@ const gcp = new Gcp({
 // `gcp.workloadSAs` (cluster Workload Identity SAs) is optional and gates
 // only the IAM bindings inside `SecretsComponent`; the Secret + Version
 // resources are created regardless.
-// Phase 1 of `route-login-v2-via-internal-zitadel-api`: the
-// `SecretsComponent` now also creates `zitadel-system-api-key`
-// (private, PreservedTier) and `zitadel-system-api-pub` (public, for ESO),
-// the RSA-2048 key pair backing the `pulumi-system` Zitadel System API
-// user. The API container's `ZITADEL_SYSTEMAPIUSERS` env (set in
-// `k8s/namespaces/zitadel/base/deployment-api.yaml`) references the
-// public half via an ESO-projected file mount.
-//
-// Phase 2 will capture this component's `systemApiPrivateKeyPem` /
-// `systemApiPrivateSecretVersion` outputs by re-binding the constructor
-// result, and feed them to a `ZitadelInstanceCustomDomain` Dynamic
-// Resource that registers `zitadel-api.zitadel.svc.cluster.local` as the
-// instance's `Host` target so the Login UI Pod's outbound API calls can
-// avoid the public LB hairpin entirely. That step is deferred so the
-// API Pod has time to roll with the new env before Pulumi signs its
-// first System User JWT — Pulumi cannot track Pod rollout (ArgoCD's
-// plane), so the two-PR sequencing is the operational gate.
-new SecretsComponent('zitadel-secrets', {
+const zitadelSecrets = new SecretsComponent('zitadel-secrets', {
 	project: gcp.project,
 	workloadSAs: gcp.workloadSAs,
 })
+
+// Register the cluster-internal hostname as an InstanceCustomDomain so
+// Login V2 UI's outbound Connect-RPC calls can target the in-cluster
+// Service URL (`http://zitadel-api.zitadel.svc.cluster.local`) instead
+// of the public LB hairpin — the public-URL path 30s-timed-out on
+// Node's HTTP client through GCP HTTPS LB (see OpenSpec change
+// `route-login-v2-via-internal-zitadel-api`).
+//
+// The Dynamic Resource signs a System User JWT directly using Node
+// `crypto` and POSTs to `instance.v2.InstanceService/AddCustomDomain`
+// because `@pulumiverse/zitadel@0.2.0` exposes neither the resource
+// nor a `system_api` provider auth block. The System User
+// (`pulumi-system`) is declared via `ZITADEL_SYSTEMAPIUSERS` on the
+// `zitadel-api` Pod, provisioned by Phase 1.
+//
+// Skipped when `workloadEnabled=false`: the `zitadel-api` Pod is
+// destroyed in dev shutdown mode so there is no API to talk to. The
+// Dynamic Resource will recreate the registration on next `pulumi up`
+// once workloads are back up; idempotent via 409 AlreadyExists handling
+// inside the resource.
+//
+// `dependsOn` the System User private key SecretVersion to guarantee
+// the SecretVersion is materialised in GSM before the Dynamic
+// Resource's `create` callback reads it.
+const zitadelInstanceInternalDomain =
+	workloadEnabled && zitadel !== undefined
+		? new ZitadelInstanceCustomDomain(
+				'zitadel-api-internal',
+				{
+					domain: zitadelDomainMap[env],
+					systemUserName: SYSTEM_API_USER_NAME,
+					privateKeyPem: zitadelSecrets.systemApiPrivateKeyPem,
+					instanceId: instanceIdMap[env],
+					customDomain: ZITADEL_API_INTERNAL_HOST,
+				},
+				{
+					dependsOn: [zitadelSecrets.systemApiPrivateSecretVersion],
+				},
+			)
+		: undefined
+
+// Surfaced as a Pulumi export so the stack-level state record holds
+// the composite id (`<instanceId>/<customDomain>`) for ops debugging.
+export const zitadelApiInternalDomainId =
+	zitadelInstanceInternalDomain?.registeredId
 
 // 3. GitHub Repository Environments (All Environments)
 const sharedVariables = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,21 @@ const zitadelInstanceInternalDomain =
 				},
 				{
 					dependsOn: [zitadelSecrets.systemApiPrivateSecretVersion],
+					// `protect: true` because a `pulumi destroy` on this
+					// resource calls `RemoveCustomDomain` against the
+					// Zitadel instance — which immediately breaks every
+					// Login UI Pod's outbound API call (the cluster-internal
+					// hostname no longer matches any InstanceCustomDomain
+					// → HTTP 404 instance-not-found). The `workloadEnabled
+					// && zitadel !== undefined` guard prevents accidental
+					// teardown via a config flip, but a future refactor
+					// that removes this `new ZitadelInstanceCustomDomain`
+					// block in src/ would still slip past that guard.
+					// `protect: true` makes the destroy intent explicit:
+					// the operator must remove `protect` (or call
+					// `pulumi state delete`) before Pulumi will tear it
+					// down.
+					protect: true,
 				},
 			)
 		: undefined

--- a/src/zitadel/constants.ts
+++ b/src/zitadel/constants.ts
@@ -123,8 +123,23 @@ export const adminOrgIdMap: Record<Environment, string> = {
  * Introduced by OpenSpec change `route-login-v2-via-internal-zitadel-api`.
  */
 export const instanceIdMap: Record<Environment, string> = {
+	// dev is currently shut down (`liverty-music:workloadEnabled: "false"` in
+	// Pulumi.dev.yaml). The dev Zitadel instance is destroyed, so there is
+	// no instance id to discover. The `__UNSET__` sentinel is harmless
+	// here because the `ZitadelInstanceCustomDomain` resource is gated on
+	// `workloadEnabled && zitadel !== undefined` in `src/index.ts` and
+	// is NOT instantiated when workloads are disabled. When dev is brought
+	// back up (procedure B in docs/runbooks/dev-shutdown-restart.md), the
+	// operator MUST run `node scripts/discover-zitadel-instance-id.mjs
+	// --env=dev` and commit the captured id here BEFORE the next
+	// `pulumi up` would otherwise hit the Dynamic Resource's fail-fast
+	// guard.
 	dev: '__UNSET__',
-	prod: '__UNSET__',
+	// Captured 2026-05-20 after Phase 1 deployed on prod and the
+	// `pulumi-system` System User was loaded on the `zitadel-api` Pod.
+	// Verified via
+	// `node scripts/discover-zitadel-instance-id.mjs --env=prod`.
+	prod: '372892288692519067',
 }
 
 /**

--- a/src/zitadel/dynamic/__tests__/instance-custom-domain.test.ts
+++ b/src/zitadel/dynamic/__tests__/instance-custom-domain.test.ts
@@ -233,12 +233,13 @@ describe('instanceCustomDomainProvider.read', () => {
 		expect(result.props).toBe(state)
 	})
 
-	it('returns empty result when the domain has been deleted out-of-band', async () => {
+	it('returns empty result (no id, no props) when the domain has been deleted out-of-band — signals Pulumi to schedule recreation', async () => {
 		mockedCall.mockResolvedValueOnce({
 			statusCode: 200,
 			body: JSON.stringify({ customDomains: [{ domain: 'other' }] }),
 		})
 		const result = await provider.read('id', state)
+		expect(result.id).toBeUndefined()
 		expect(result.props).toBeUndefined()
 	})
 

--- a/src/zitadel/dynamic/instance-custom-domain.ts
+++ b/src/zitadel/dynamic/instance-custom-domain.ts
@@ -148,7 +148,13 @@ export const instanceCustomDomainProvider: pulumi.dynamic.ResourceProvider = {
 				state.customDomain.toLowerCase(),
 		)
 		if (!found) {
-			return { id }
+			// Pulumi dynamic-resource Read semantics: omitting both `id` and
+			// `props` signals "resource gone, schedule recreation". Returning
+			// `{ id }` (with id but no props) is ambiguous — Pulumi may treat
+			// it as "still exists, no changes". So when the domain is absent
+			// from ListCustomDomains (deleted out-of-band via Console / API),
+			// return `{}` to trigger drift detection + re-create on next up.
+			return {}
 		}
 		return { id, props: state }
 	},


### PR DESCRIPTION
Phase 2 of the `route-login-v2-via-internal-zitadel-api` OpenSpec change. Completes the fix prepared in #294. Closes #293.

## Summary

- `instanceIdMap.prod = '372892288692519067'` — captured 2026-05-20 via `scripts/discover-zitadel-instance-id.mjs --env=prod` after Phase 1 landed.
- `ZitadelInstanceCustomDomain` wired up in `src/index.ts`, gated on `workloadEnabled && zitadel !== undefined`. dev stays a no-op until restart.
- `ZITADEL_API_URL` flipped to `http://zitadel-api.zitadel.svc.cluster.local` (port-less; Service is `port: 80` → `targetPort: 8080`, so Node emits Host without `:port`).
- Prod overlay drops the per-env URL override (the new value is environment-agnostic).

## How this unblocks the prod login bug

On apply, the Dynamic Resource calls `instance.v2.InstanceService/AddCustomDomain` with the System User JWT signed by the Phase-1-provisioned private key. Once the registration lands, ArgoCD rolls `zitadel-web` (Reloader picks up the env change) to point its outbound API calls at the internal Service URL. The Pixel-class 30s timeout on `/ui/v2/login/login` should be gone because the Login UI no longer hairpins through the public LB.

## Test plan

- [x] `make lint-ts` clean
- [x] `npx vitest run` passes (72 tests including the 19 for `ZitadelInstanceCustomDomain`)
- [x] `kubectl kustomize` of dev + prod overlays both produce `ZITADEL_API_URL: http://zitadel-api.zitadel.svc.cluster.local`
- [ ] `pulumi preview` on dev shows no changes (dev `workloadEnabled: false`, Dynamic Resource gated off)
- [ ] `pulumi preview` on prod shows a single `+ create` for `urn:pulumi:prod::liverty-music::custom:resource:ZitadelInstanceCustomDomain::zitadel-api-internal`
- [ ] `pulumi up` on prod (manual via Pulumi Cloud) lands cleanly
- [ ] After apply, `wget -O- https://auth.liverty-music.app/.../ListCustomDomains` (with admin token) shows the new entry
- [ ] ArgoCD rolls `zitadel-web` Pod with the new `ZITADEL_API_URL`
- [ ] Repro: `/oauth/v2/authorize?prompt=create` → `/ui/v2/login/login?authRequest=...` returns 302 to `/ui/v2/login/register?...` instead of 504 in <1s
- [ ] Pixel-UA sign-up E2E captures clean HAR

Refs: #293