### PR TITLE
chore(prod): bump backend + frontend to v1.1.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.1.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
+  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
+  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
+  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.0.2  # commit 4085276f6e79b9798aadde5f3286d30f7bb4ce57
+  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.0.2"
+    app.kubernetes.io/version: "1.1.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.0.2  # commit ec3fe3868ac528c3b80ef761c2b1ee819b3de9fe
+  newTag: v1.1.0  # commit 1aba5e66ad2c879f9b7a45938b01b931cf826a72


### PR DESCRIPTION
## Summary

Promote the `refine-hype-and-help-sheets` bundle (per `liverty-music/specification#505`) to prod by bumping the prod overlay image tags. The `crane copy` retag from the release-publish workflows in both backend and frontend already populated `:v1.1.0` in prod AR; this PR points the prod kustomize overlays at the new tags so ArgoCD will sync the prod Deployments.

### Image tag changes

| Component | Image | From | To | Source commit |
|---|---|---|---|---|
| backend | server | `v1.0.2` | `v1.1.0` | `87fdd23` |
| backend | consumer | `v1.0.2` | `v1.1.0` | `87fdd23` |
| backend | concert-discovery | `v1.0.2` | `v1.1.0` | `87fdd23` |
| backend | artist-image-sync | `v1.0.2` | `v1.1.0` | `87fdd23` |
| frontend | web-app | `v1.0.2` | `v1.1.0` | `1aba5e6` |

Also bumps `app.kubernetes.io/version: "1.0.2" → "1.1.0"` on both overlays to keep the recommended label in lock-step with the image tags (per the inline comment policy in each `kustomization.yaml`).

## Cross-repo upstream

- liverty-music/backend#302 — Atlas migration + `entity.DefaultHype` + INSERT-passes-default
- liverty-music/specification#506 — proposal + design + 5 spec deltas (archived in #509)
- liverty-music/frontend#365 — UI, i18n, behaviour changes
- liverty-music/backend Release v1.1.0 — https://github.com/liverty-music/backend/releases/tag/v1.1.0
- liverty-music/frontend Release v1.1.0 — https://github.com/liverty-music/frontend/releases/tag/v1.1.0

## DB migration timing note

The Atlas DDL `ALTER TABLE followed_artists ALTER COLUMN hype SET DEFAULT 'nearby'` was applied to **prod Cloud SQL on 2026-05-20**, because the `backend-migrations` ArgoCD Application (`k8s/argocd-apps/prod/backend-migrations.yaml`) tracks `liverty-music/backend.git@main`. Since then, prod has been in a transient state: DB DEFAULT = `nearby` but the running backend image (v1.0.2) was still issuing `INSERT (user_id, artist_id)` without the `hype` column. The new follow rows have been getting `hype=nearby` by DB default — which is consistent with the intended end state — but the backend Go code only catches up in v1.1.0 (this PR's promotion target).

## Test plan

- [x] `kustomize build k8s/namespaces/backend/overlays/prod/` renders without error
- [x] `kustomize build k8s/namespaces/frontend/overlays/prod/` renders without error
- [ ] `make check` (lint + tsc + kustomize render + kube-linter) passes in CI
- [ ] (Post-merge) ArgoCD prod `backend` Application syncs and rolls the new image
- [ ] (Post-merge) ArgoCD prod `frontend` Application syncs and rolls the new image
- [ ] (Post-merge) Hard-reload `https://liverty-music.app` shows the new UI (multi-section help sheet, 3-col hype grid, signup banner without `X`, `Hype（熱量）について` title in JA)

Refs liverty-music/specification#505
Refs liverty-music/backend#302
Refs liverty-music/frontend#365