### PR TITLE
chore(k8s): bump backend prod overlay to v1.1.1

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
+  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
+  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
+  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.1.0  # commit 87fdd23f4c21b58e60999109054a9700cb72ee83
+  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855


### PR DESCRIPTION
## Summary

- Pin prod backend overlay (`k8s/namespaces/backend/overlays/prod`) to backend release `v1.1.1`:
  - `app.kubernetes.io/version` label: `1.1.0` → `1.1.1`
  - 4 image `newTag` (server / consumer / concert-discovery / artist-image-sync): `v1.1.0` → `v1.1.1`
  - Inline commit comment updated to `aae5228d`
- Backend release notes: https://github.com/liverty-music/backend/releases/tag/v1.1.1

## Why this is the unblocking step

`v1.1.1` carries:
- **PR #304** (persist-user-language) — proto field, `UpdatePreferredLanguage` RPC, mapper, Atlas migration that NULLs legacy `preferred_language` rows.
- **PR #307** (corrective) — extends `sql.NullString` scan discipline to `country` / `time_zone`, fixes `userUseCase.Create` retry to surface non-NotFound errors truthfully. Closes the 2026-05-23 prod incident where v1.1.0 crashed every `Get` for legacy rows.

Until ArgoCD syncs this overlay, prod stays on v1.1.0 and the affected operator-owned test accounts cannot hydrate. After sync, frontend hydration self-heals via the existing backfill path.

Tracking: OpenSpec `liverty-music/specification#persist-user-language` §7 (Prod recovery rollout).

## Test plan

- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders 4 images at `:v1.1.1` and version label `1.1.1`
- [ ] After merge: ArgoCD `backend` Application syncs to the new revision
- [ ] `kubectl describe deployment/server-app -n backend --context=<prod>` shows `Image: ...:v1.1.1`
- [ ] One affected prod account signs in; hydration succeeds (no `not_found` / `already_exists`); next hard reload preserves the language

Refs: #301