### PR TITLE
chore(k8s): bump frontend prod overlay to v1.1.1

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.1.0"
+    app.kubernetes.io/version: "1.1.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.1.0  # commit 1aba5e66ad2c879f9b7a45938b01b931cf826a72
+  newTag: v1.1.1  # commit 1ccec981b372346516e40eb5e3fa2efc9efb9459


### PR DESCRIPTION
## Summary

- Pin frontend prod overlay (`k8s/namespaces/frontend/overlays/prod`) to release `v1.1.1`:
  - `app.kubernetes.io/version` label: `1.1.0` → `1.1.1`
  - 1 image `newTag` (`web-app`): `v1.1.0` → `v1.1.1`, inline commit comment → `1ccec981`
- Release notes: https://github.com/liverty-music/frontend/releases/tag/v1.1.1

## Why

Frontend `v1.1.1` carries PR #366 — the user-facing surface of the persist-user-language change (consumes `User.preferred_language` proto field, runs the hydration-apply / backfill, etc.). Discovered during §7 prod recovery after #302 (backend overlay bump): backend v1.1.1 was returning `preferred_language='ja'` in Get responses but Settings still showed English on hard reload, because the live frontend bundle (`index-UTO8JpkH.js`, sha `1aba5e66`) pre-dates PR #366 and doesn't know the field exists.

Pairs with #302. Together these complete the prod rollout for the OpenSpec `persist-user-language` change (§7 — Prod recovery rollout).

## Test plan

- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders `web-app:v1.1.1` and version label `1.1.1`
- [ ] After merge: ArgoCD `frontend` Application syncs to the new revision
- [ ] `liverty-music.app` serves a new bundle hash (not `index-UTO8JpkH.js`)
- [ ] Affected prod account hard-reloads → Settings shows Japanese (DB-sourced) — original bug closed end-to-end

Refs: #303