### PR TITLE
feat(infra): wire GCP_GEMINI_SEARCH_API_KEY for backend concert searcher

### DIFF
--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -29,11 +29,7 @@ spec:
   - secretKey: FANARTTV_API_KEY
     remoteRef:
       key: fanarttv-api-key
-  # Concert searcher's Gemini API direct key. Consumed as the
-  # `GCP_GEMINI_SEARCH_API_KEY` env var (envFrom secretRef → backend-secrets)
-  # by server-app, consumer-app, and the concert-discovery CronJob. REQUIRED
-  # post-backend-#303; `gemini.NewConcertSearcher` fails fast at construction
-  # if empty (no Vertex AI fallback exists for that workload).
+  # REQUIRED post-backend-#303; `gemini.NewConcertSearcher` fails fast when empty.
   - secretKey: GCP_GEMINI_SEARCH_API_KEY
     remoteRef:
       key: gemini-search-api-key

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -29,6 +29,14 @@ spec:
   - secretKey: FANARTTV_API_KEY
     remoteRef:
       key: fanarttv-api-key
+  # Concert searcher's Gemini API direct key. Consumed as the
+  # `GCP_GEMINI_SEARCH_API_KEY` env var (envFrom secretRef → backend-secrets)
+  # by server-app, consumer-app, and the concert-discovery CronJob. REQUIRED
+  # post-backend-#303; `gemini.NewConcertSearcher` fails fast at construction
+  # if empty (no Vertex AI fallback exists for that workload).
+  - secretKey: GCP_GEMINI_SEARCH_API_KEY
+    remoteRef:
+      key: gemini-search-api-key
   - secretKey: zitadel-machine-key-for-backend-app.json
     remoteRef:
       key: zitadel-machine-key-for-backend-app

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -27,6 +27,11 @@ export interface GcpArgs {
 	gcpConfig: GcpConfig
 	lastFmApiKey?: pulumi.Output<string>
 	fanartTvApiKey?: pulumi.Output<string>
+	/** Gemini API direct backend API key for the concert searcher workload.
+	 *  Stored in Secret Manager and synced into the `backend-secrets` K8s
+	 *  Secret via ExternalSecret. `gemini.NewConcertSearcher` REQUIRES this
+	 *  (no Vertex AI fallback as of backend #303). */
+	geminiSearchApiKey?: pulumi.Output<string>
 	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
 	postmarkConfig: PostmarkDnsConfig
@@ -99,6 +104,7 @@ export class Gcp {
 			gcpConfig,
 			lastFmApiKey,
 			fanartTvApiKey,
+			geminiSearchApiKey,
 			blockchainConfig,
 			cloudflareConfig,
 			postmarkConfig,
@@ -342,6 +348,14 @@ export class Gcp {
 								{
 									name: 'fanarttv-api-key',
 									value: fanartTvApiKey,
+								},
+							]
+						: []),
+					...(geminiSearchApiKey
+						? [
+								{
+									name: 'gemini-search-api-key',
+									value: geminiSearchApiKey,
 								},
 							]
 						: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ const githubConfig = config.requireObject('github') as GitHubConfig
 const gcpConfig = config.requireObject('gcp') as GcpConfig
 const lastFmApiKey = config.getSecret('lastFmApiKey')
 const fanartTvApiKey = config.getSecret('fanartTvApiKey')
+// Gemini API direct backend key for the concert searcher workload. REQUIRED
+// post-#303: the two-step grounded-extract pipeline needs URLContext +
+// TimeRangeFilter, which Vertex AI does not support. `gemini.NewConcertSearcher`
+// fails fast when the env var is empty, so this secret SHALL be set in every
+// stack where the backend workload runs (dev / prod).
+const geminiSearchApiKey = config.getSecret('geminiSearchApiKey')
 const blockchainConfig = config.getObject('blockchain') as
 	| BlockchainConfig
 	| undefined
@@ -139,6 +145,7 @@ const gcp = new Gcp({
 	gcpConfig,
 	lastFmApiKey,
 	fanartTvApiKey,
+	geminiSearchApiKey,
 	blockchainConfig,
 	cloudflareConfig,
 	postmarkConfig,


### PR DESCRIPTION
## 🔗 Related Issue

Refs: liverty-music/backend#308, liverty-music/backend#303

## 📝 Summary of Changes

Provision a new `gemini-search-api-key` Secret Manager secret and sync it into the existing `backend-secrets` K8s Secret as the `GCP_GEMINI_SEARCH_API_KEY` env var. Three Pulumi/Kustomize touchpoints:

- `src/index.ts` — read the value via `config.getSecret('geminiSearchApiKey')` (same shape as the existing `lastFmApiKey` / `fanartTvApiKey` reads) and pass it into `Gcp`.
- `src/gcp/index.ts` — extend `GcpArgs.geminiSearchApiKey` and add the `{ name: 'gemini-search-api-key', value: geminiSearchApiKey }` entry to the `secrets` array fed to `KubernetesComponent`, gated by the same `?:` pattern so a stack without the config value still applies cleanly.
- `k8s/namespaces/backend/base/server/external-secret.yaml` — add the matching `secretKey: GCP_GEMINI_SEARCH_API_KEY` ExternalSecret entry so the value lands in the K8s Secret under that exact name.

The server-app and consumer-app Deployments and the concert-discovery CronJob already mount `backend-secrets` via `envFrom: secretRef`, so the new env var becomes available in each container automatically — no Deployment / CronJob YAML change is needed.

## 🌍 Affected Stacks

- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

CI dev/prod previews ran green. Expected diff: one new `gcp:secretmanager:Secret` resource + one `gcp:secretmanager:SecretVersion` per stack, plus an IAM grant for the existing backend-app + ESO SAs. No destructive changes; existing secrets are untouched.

## 📦 State Changes

None. No `pulumi state mv` / `import` / replace.

## ❗ Background

liverty-music/backend#308 (commit `5bb3020`) is merged to backend `main`. It dropped the Vertex AI fallback for the concert-searcher workload and made `gemini.NewConcertSearcher` fail fast when its `APIKey` is empty (the two-step grounded-extract pipeline depends on URLContext + `GoogleSearch.TimeRangeFilter`, neither of which is supported on Vertex AI). The ConfigMap currently does NOT carry the key, so the backend rollout that follows will fail at `NewConcertSearcher` on first pod start. This PR is the unblocker.

## 🔐 Prerequisite — ESC config set BEFORE merge

Per the per-stack ESC env (`liverty-music/dev`, `liverty-music/prod`), set the secret value BEFORE this PR merges so the auto-triggered `pulumi up` creates the Secret Manager secret on the same deploy. Without it, the `?:` guard skips the entry, ESO tries to fetch a missing GCP secret on next refresh, and the **entire** `server-backend-secrets` ExternalSecret enters error state — blocking refresh of every other key in `backend-secrets` (LASTFM_API_KEY, BLOCKCHAIN_*, VAPID_PRIVATE_KEY, FANARTTV_API_KEY, Zitadel machine key).

Correct commands (ESC env, NOT `pulumi config set`):

```bash
# dev — value read via `config.getSecret('geminiSearchApiKey')` from project namespace
pulumi env set liverty-music/dev  pulumiConfig.geminiSearchApiKey --secret --string -f -
# prod
pulumi env set liverty-music/prod pulumiConfig.geminiSearchApiKey --secret --string -f -
```

**Status: both ESC envs are already populated** with their per-environment API keys (separate values for dev / prod, both distinct from the existing local-eval key). Verified via `pulumi env open liverty-music/{dev,prod} | jq '.pulumiConfig | keys'`.

## ✅ Checklist

- [x] `pulumi preview` passes locally or in CI. (dev + prod preview CI green)
- [x] No unintended destructive changes.
- [x] Secrets are managed via Pulumi ESC env (`pulumi env set ... --secret`).
- [x] ESC config set in dev + prod BEFORE merge (Issue 2 race mitigation).