### PR TITLE
chore(k8s): bump frontend prod overlay to v1.1.2

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.1.2"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.1.1  # commit 1ccec981b372346516e40eb5e3fa2efc9efb9459
+  newTag: v1.1.2  # commit 717a8b5fd4425ddac903308f87724e4ff8a56574


### PR DESCRIPTION
## Summary

- Pin frontend prod overlay to release \`v1.1.2\` (closes the language selector check-mark desync).
- \`app.kubernetes.io/version\`: \`1.1.1\` → \`1.1.2\`. Image \`newTag\`: \`v1.1.1\` → \`v1.1.2\`. Inline commit comment: \`717a8b5f\`.

Release notes: https://github.com/liverty-music/frontend/releases/tag/v1.1.2

Pairs with frontend PR #369 (refactor user state SSoT). After ArgoCD sync, the bundle hash on \`liverty-music.app\` flips to a new value and the selector reactivity bug is closed end-to-end.

## Test plan

- [x] \`kubectl kustomize k8s/namespaces/frontend/overlays/prod\` renders \`web-app:v1.1.2\` + version label \`1.1.2\`
- [ ] After merge: ArgoCD frontend Application syncs; \`liverty-music.app\` serves a new bundle hash (not \`index-ns7LHWry.js\`)
- [ ] Browser test: change language twice; selector check-mark moves correctly each time

Refs: #307