### PR TITLE
infra(github): drop 'Claude review' from requiredStatusCheckContexts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.BACKEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Frontend Repository
@@ -197,7 +197,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.FRONTEND,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Specification Repository
@@ -207,10 +207,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.SPECIFICATION,
 	environment: env,
 	variables: sharedVariables,
-	// Pilot repo for the Claude review Check Run gate introduced by
-	// OpenSpec change `claude-review-check-run`. All four repos now
-	// require `Claude review` after the specification pilot graduated.
-	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
+	requiredStatusCheckContexts: ['CI Success'],
 })
 
 // Cloud Provisioning Repository
@@ -220,7 +217,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.CLOUD_PROVISIONING,
 	environment: env,
 	variables: sharedVariables,
-	requiredStatusCheckContexts: ['CI Success', 'Claude review'],
+	requiredStatusCheckContexts: ['CI Success'],
 	requireUpToDateBranch: true,
 })
 


### PR DESCRIPTION
## Summary

Drop `'Claude review'` from `requiredStatusCheckContexts` on all four liverty-music repos (`backend`, `frontend`, `specification`, `cloud-provisioning`). Only `'CI Success'` remains as the required status check.

## Why

Companion change to [liverty-music/.github#7](https://github.com/liverty-music/.github/pull/7), which strips the Check Run creation logic from the reusable Claude review workflow. After both PRs land + `pulumi up -s prod` is applied:
- `Claude review` Check Run no longer exists
- No PR is blocked by a missing/failed Claude review check
- Claude continues to post inline review comments as advisory-only

The full context (four iterations of workarounds, the `pull_request_review_thread` trigger empirically being broken, and the decision to align with the official `pr-review-comprehensive.yml` pattern) is documented in [.github#7's description](https://github.com/liverty-music/.github/pull/7) and the OpenSpec change `honor-thread-resolution-in-claude-review-check` (being rewritten).

## Deployment ordering (CRITICAL)

1. **Merge this PR first**, then **manually run `pulumi up -s prod`** to remove the required check from branch protection.
2. Confirm via `gh api repos/liverty-music/<repo>/branches/main/protection` that `Claude review` is gone from `required_status_checks.contexts` on all four repos.
3. Only AFTER step 2 confirmed, merge [.github#7](https://github.com/liverty-music/.github/pull/7).

If step 3 happens before step 2, currently-open PRs will be permanently blocked: the required `Claude review` Check Run won't be created on future workflow runs, so it can never turn green.

## Test plan

- [ ] `make lint-ts` passes locally (verified ✓)
- [ ] Pulumi preview shows only the `required_status_checks.contexts` change (no unexpected resource modifications)
- [ ] User runs `pulumi up -s prod` after merge
- [ ] Verify `gh api repos/liverty-music/specification/branches/main/protection --jq '.required_status_checks.contexts'` returns only `["CI Success"]`

Refs: liverty-music/specification#525