### PR TITLE
feat(infra): apply prod-cost-optimization workstreams

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -2,4 +2,12 @@ environment:
   - liverty-music/prod
 config:
   gcp:project: liverty-music-prod
-
+  # Cloud SQL availability tier. `ZONAL` is the launch-phase policy
+  # (cost-priority, no automatic failover). Flip to `REGIONAL` once an
+  # HA SLA is required — this triggers Cloud SQL to add a synchronous
+  # standby in another zone, roughly doubling instance cost in exchange
+  # for the HA SLA. The current change accepts the loss of automatic
+  # zonal failover; manual recovery via point-in-time restore from
+  # backups remains available. See the `database` capability spec for
+  # the staged rollout policy.
+  liverty-music:postgresAvailabilityType: ZONAL

--- a/docs/runbooks/enable-billing-export.md
+++ b/docs/runbooks/enable-billing-export.md
@@ -131,7 +131,7 @@ WITH daily AS (
     sku.description AS sku,
     SUM(cost) AS c
   FROM `liverty-music-prod.billing_export.gcp_billing_export_v1_<BILLING_ACCOUNT_ID>`
-  WHERE DATE(usage_start_time) BETWEEN '<spike_date>' AND DATE_SUB('<spike_date>', INTERVAL -1 DAY)
+  WHERE DATE(usage_start_time) BETWEEN DATE_SUB('<spike_date>', INTERVAL 1 DAY) AND '<spike_date>'
   GROUP BY d, sku
 )
 SELECT

--- a/docs/runbooks/enable-billing-export.md
+++ b/docs/runbooks/enable-billing-export.md
@@ -1,0 +1,197 @@
+# Enable GCP Billing Export to BigQuery
+
+One-time Console procedure to wire GCP's Billing Export to the
+Pulumi-provisioned `billing_export` BigQuery dataset in the
+`liverty-music-prod` project.
+
+## Why this is a runbook (not Pulumi)
+
+GCP does not expose an API for the "Billing → Billing export → BigQuery
+export" configuration. The dataset itself, its IAM bindings, and the
+required APIs are all Pulumi-managed via
+[`src/gcp/components/billing-export.ts`](../../src/gcp/components/billing-export.ts).
+This runbook covers the remaining Console click-through.
+
+## Prerequisites
+
+- `pulumi up --stack prod` has been run on a commit that includes the
+  `BillingExportComponent`. Verify with:
+  ```bash
+  bq --project_id=liverty-music-prod ls billing_export
+  ```
+  The command should succeed and return an empty result set (no tables
+  yet — they appear after export starts running).
+- You have **Billing Account Administrator** or **Billing Account Costs
+  Manager** on the billing account that funds `liverty-music-prod`. The
+  Project Owner role on the project is **not** sufficient.
+
+## Procedure
+
+### 1. Open the Billing Export configuration
+
+GCP Console → top-left ☰ → **Billing** → left sidebar **Billing export**
+→ tab **BigQuery export**.
+
+You should see three rows:
+- Standard usage cost
+- Detailed usage cost
+- Pricing
+
+Each starts as "Not enabled".
+
+### 2. Enable Standard usage cost export
+
+1. Click **Edit settings** on the "Standard usage cost" row.
+2. Fill in:
+   - **Project:** `liverty-music-prod`
+   - **Dataset:** `billing_export`
+3. Click **Save**.
+
+The row should flip to "Enabled — exporting to `liverty-music-prod:billing_export`".
+
+### 3. Enable Detailed usage cost export
+
+Repeat step 2 for the "Detailed usage cost" row. The Detailed export
+includes per-resource labels and is what makes per-namespace / per-Pod
+cost attribution possible.
+
+> **Note:** Detailed export adds a small BigQuery storage cost (~hundreds
+> of yen/month at our scale) but is essential for the kind of investigation
+> the `prod-cost-optimization` change was motivated by. Keep it enabled.
+
+### 4. (Optional) Enable Pricing export
+
+The Pricing export ships current SKU price lists into BigQuery as a
+reference table. Useful for joining usage to current rates without
+hitting the Cloud Billing Catalog API. Same procedure as steps 2-3.
+
+### 5. Verify after 24 hours
+
+Billing data lands in BigQuery on a 24-hour delay (sometimes longer for
+the first batch). After ~24h, run:
+
+```bash
+bq --project_id=liverty-music-prod ls billing_export
+```
+
+You should see at least one table:
+```
+gcp_billing_export_v1_<BILLING_ACCOUNT_ID>
+gcp_billing_export_resource_v1_<BILLING_ACCOUNT_ID>   # if Detailed was enabled
+cloud_pricing_export                                  # if Pricing was enabled
+```
+
+Where `<BILLING_ACCOUNT_ID>` is the billing account ID with hyphens
+replaced by underscores.
+
+If no tables appear after 48 hours, proceed to the troubleshooting
+section below.
+
+## Sample analysis queries
+
+Drop these into BigQuery Console once data is flowing.
+
+### Daily SKU-level breakdown
+
+```sql
+SELECT
+  DATE(usage_start_time) AS usage_date,
+  service.description AS service,
+  sku.description AS sku,
+  ROUND(SUM(cost), 0) AS cost_jpy
+FROM `liverty-music-prod.billing_export.gcp_billing_export_v1_<BILLING_ACCOUNT_ID>`
+WHERE DATE(usage_start_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+GROUP BY usage_date, service, sku
+ORDER BY usage_date DESC, cost_jpy DESC;
+```
+
+### Per-namespace GKE Pod cost (requires Detailed export)
+
+```sql
+SELECT
+  DATE(usage_start_time) AS usage_date,
+  (SELECT value FROM UNNEST(labels) WHERE key = 'k8s-namespace') AS namespace,
+  ROUND(SUM(cost), 0) AS cost_jpy
+FROM `liverty-music-prod.billing_export.gcp_billing_export_resource_v1_<BILLING_ACCOUNT_ID>`
+WHERE service.description = 'Kubernetes Engine'
+  AND DATE(usage_start_time) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+GROUP BY usage_date, namespace
+ORDER BY usage_date DESC, cost_jpy DESC;
+```
+
+### Identifying a cost-spike day
+
+If a daily cost report shows an unexpected jump, run this to find which
+SKU drove it:
+
+```sql
+WITH daily AS (
+  SELECT
+    DATE(usage_start_time) AS d,
+    sku.description AS sku,
+    SUM(cost) AS c
+  FROM `liverty-music-prod.billing_export.gcp_billing_export_v1_<BILLING_ACCOUNT_ID>`
+  WHERE DATE(usage_start_time) BETWEEN '<spike_date>' AND DATE_SUB('<spike_date>', INTERVAL -1 DAY)
+  GROUP BY d, sku
+)
+SELECT
+  sku,
+  MAX(IF(d = '<spike_date>', c, 0)) AS spike_day,
+  MAX(IF(d != '<spike_date>', c, 0)) AS baseline_day,
+  MAX(IF(d = '<spike_date>', c, 0))
+    - MAX(IF(d != '<spike_date>', c, 0)) AS delta
+FROM daily
+GROUP BY sku
+HAVING delta > 0
+ORDER BY delta DESC;
+```
+
+## Troubleshooting
+
+### No tables appear after 48 hours
+
+1. Confirm the dataset exists:
+   ```bash
+   bq --project_id=liverty-music-prod ls billing_export
+   ```
+   If this returns an error, `pulumi up --stack prod` did not run
+   successfully. Re-check the Pulumi state and re-apply.
+2. Confirm the export configuration is still "Enabled":
+   - Console → Billing → Billing export → BigQuery export.
+   - If it reverted to "Not enabled", re-do steps 2-3 above.
+3. Confirm dataset write permissions:
+   - The component grants
+     `roles/bigquery.dataEditor` to
+     `serviceAccount:cloud-billing-export@system.gserviceaccount.com`.
+   - If GCP has renamed this principal since the component was written,
+     identify the actual SA used by your billing account:
+     - Cloud Console → IAM & Admin → Logs Explorer
+     - Filter:
+       `protoPayload.serviceName="bigquery.googleapis.com"
+        AND protoPayload.resourceName=~"projects/liverty-music-prod/datasets/billing_export"`
+     - Look at recent write attempts; the `protoPayload.authenticationInfo.principalEmail`
+       field reveals the actual SA.
+   - Add the discovered SA to the `BillingExportComponent` IAM binding and
+     re-apply.
+
+### Wrong billing account selected
+
+If "Billing → Billing export" shows a different billing account than the
+one funding `liverty-music-prod`:
+
+1. Click the billing account dropdown at the top of the Billing console.
+2. Switch to the correct one.
+3. The BigQuery export tab now shows that billing account's config —
+   redo steps 2-3 of the procedure.
+
+### Want to disable
+
+To disable an export, click **Edit settings** on the row and click
+**Disable**. The dataset remains; only the inbound data flow stops.
+Existing tables are preserved.
+
+To remove the dataset entirely, revert the
+`BillingExportComponent` instantiation in
+[`src/gcp/index.ts`](../../src/gcp/index.ts) and run
+`pulumi up --stack prod`. Pulumi will refuse if tables exist; either
+empty the dataset first or override with `--force`.

--- a/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
@@ -38,6 +38,16 @@ patches:
 # Application to act on. Setting replicas=0 eliminates the Pod's
 # Autopilot per-Pod billing without removing the Deployment definition,
 # so re-enablement is a single-line revert.
+#
+# Deployment name note: the standalone `argocd-image-updater` Helm
+# chart (v1.1.1, in base/charts/) renders its Deployment as
+# `argocd-image-updater-controller` — NOT plain `argocd-image-updater`.
+# The chart's template literally appends `-controller`:
+#   templates/deployment.yaml:4 → name: {{ include "argocd-image-updater.fullname" . }}-controller
+# With `releaseName: argocd-image-updater` (see base/kustomization.yaml)
+# the fullname helper returns `argocd-image-updater`, and the literal
+# `-controller` suffix then yields `argocd-image-updater-controller`.
+# Confirmed via `helm template` and against the live cluster.
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment

--- a/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/argocd/overlays/prod/kustomization.yaml
@@ -16,17 +16,58 @@ patches:
   target:
     kind: ConfigMap
     name: argocd-cmd-params-cm
-# Example scaling for HA
+# argocd-server: scale down from base HA (2 replicas) to single replica in
+# prod. Cost-optimization decision: at launch-phase traffic levels the
+# UI/API has no SLA that requires HA, and Autopilot bills per Pod at a
+# minimum of 50m CPU + 64 MiB memory + 1 GiB ephemeral storage per Pod.
+# Revert to 2 once steady-state SLA on the Argo CD control plane is
+# required.
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: argocd-server
     spec:
-      replicas: 2
+      replicas: 1
   target:
     kind: Deployment
     name: argocd-server
+# argocd-image-updater-controller: disabled in prod. The prod overlay
+# pins images to semver tags (per the enable-prod-ar-immutable-tags
+# change, #274) and bumps them via manual PR, so the controller has no
+# Application to act on. Setting replicas=0 eliminates the Pod's
+# Autopilot per-Pod billing without removing the Deployment definition,
+# so re-enablement is a single-line revert.
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: argocd-image-updater-controller
+    spec:
+      replicas: 0
+  target:
+    kind: Deployment
+    name: argocd-image-updater-controller
+# argocd-applicationset-controller: disabled in prod. No ApplicationSet
+# CRs exist in the prod cluster as of this change, so the controller
+# idles 24/7 for no benefit. Re-enable (set replicas=1) before
+# introducing any ApplicationSet-managed Application.
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: argocd-applicationset-controller
+    spec:
+      replicas: 0
+  target:
+    kind: Deployment
+    name: argocd-applicationset-controller
+# argocd-notifications-controller is intentionally NOT disabled — it
+# delivers Google Chat alerts for on-sync-failed / on-health-degraded /
+# on-sync-status-unknown via the active subscription in
+# argocd-notifications-cm. Losing those alerts would impair prod
+# operability, which exceeds the ~¥300/month savings from disabling
+# the controller.
 # Spot VM nodeSelector — required by `check-spot-nodeselector.sh` on every
 # Pod template in prod overlays (per spec Requirement 4 of the
 # prod-k8s-manifests change). Matches dev's pattern; needed because the

--- a/k8s/namespaces/otel-collector/base/configmap.yaml
+++ b/k8s/namespaces/otel-collector/base/configmap.yaml
@@ -17,6 +17,33 @@ data:
         timeout: 5s
         send_batch_size: 512
 
+      # Drop low-value, high-volume auto-generated metrics before they reach
+      # the `googlecloud` exporter. Cloud Monitoring's free tier is 150 MiB
+      # per *billing account* (not per project) per month — easy to exhaust
+      # once prod traffic ramps up. The OTLP metrics we drop here account
+      # for ~87% of ingest volume but are not referenced by any alert or
+      # dashboard (all alert policies are log-based).
+      #
+      # Dropped:
+      #   - rpc.server.*    (5 histograms from otelconnect auto-instrumentation)
+      #   - http.client.*   (2 histograms from otelhttp auto-instrumentation)
+      #
+      # Kept (passes through to Cloud Monitoring as workload.googleapis.com/*):
+      #   - concert.search.count            (business KPI, counter)
+      #   - db.pool.active_connections      (DB pool health, gauge)
+      #   - db.pool.idle_connections        (DB pool health, gauge)
+      #
+      # To re-enable a metric (e.g., adding rpc.server.duration for a future
+      # latency SLO), narrow the regexp accordingly. To re-enable all OTLP
+      # metrics, remove `filter/drop_workload_noise` from the pipeline below.
+      filter/drop_workload_noise:
+        metrics:
+          exclude:
+            match_type: regexp
+            metric_names:
+              - ^rpc\.server\..*$
+              - ^http\.client\..*$
+
     exporters:
       googlecloud: {}
 
@@ -40,5 +67,7 @@ data:
         # design D2 for the architecture rationale.
         metrics:
           receivers: [otlp]
-          processors: [batch]
+          # `filter` runs before `batch` so dropped metrics never enter the
+          # batch buffer, minimizing memory/CPU overhead on the collector.
+          processors: [filter/drop_workload_noise, batch]
           exporters: [googlecloud]

--- a/src/gcp/components/billing-export.ts
+++ b/src/gcp/components/billing-export.ts
@@ -1,0 +1,114 @@
+import * as gcp from '@pulumi/gcp'
+import * as pulumi from '@pulumi/pulumi'
+import type { Environment } from '../../config.js'
+import { ApiService } from '../services/api.js'
+
+export interface BillingExportComponentArgs {
+	project: gcp.organizations.Project
+	/** Forwarded to `ApiService` so the `bigquery.googleapis.com` enable
+	 *  resource picks the correct `disableOnDestroy` policy. */
+	environment: Environment
+	/** Location for the BigQuery dataset. `asia-northeast1` (Tokyo) is
+	 *  preferred over `asia-northeast2` (Osaka) because BigQuery editions
+	 *  have broader feature parity in Tokyo and the export is read-only
+	 *  for billing analysis (not co-located with workloads). */
+	location?: pulumi.Input<string>
+}
+
+/**
+ * BillingExportComponent provisions the BigQuery dataset that GCP Billing
+ * Export writes to. The actual Console-side enable step (Billing →
+ * Billing export → BigQuery export → choose this dataset) is NOT
+ * Pulumi-managed because GCP does not expose a `BillingExportConfig`
+ * resource — see `docs/runbooks/enable-billing-export.md` for the
+ * one-time Console procedure.
+ *
+ * Why have this component at all if the Console does most of the work?
+ *  - Codifies the dataset shape (name, location, description) so it
+ *    survives accidental deletion via `pulumi up`.
+ *  - Records the IAM principal that GCP's managed billing-export
+ *    service uses to write into the dataset, so dataset permissions are
+ *    a known quantity rather than something Console quietly grants.
+ *  - Forces the BigQuery API to be enabled before anyone tries to
+ *    enable the export, removing a class of "why doesn't this work"
+ *    troubleshooting on the Console side.
+ *
+ * Standard, Detailed, and Pricing exports all land in the same dataset
+ * but use distinct table names (`gcp_billing_export_v1_*`,
+ * `gcp_billing_export_resource_v1_*`, `cloud_pricing_export`).
+ */
+export class BillingExportComponent extends pulumi.ComponentResource {
+	public readonly dataset: gcp.bigquery.Dataset
+	/** Fully-qualified dataset ID (`<project>:<dataset>`) for downstream
+	 *  consumers (e.g., outputs surfaced in the prod stack). */
+	public readonly datasetId: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: BillingExportComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('gcp:liverty-music:BillingExportComponent', name, args, opts)
+
+		const { project, environment, location = 'asia-northeast1' } = args
+
+		const apiService = new ApiService(project, environment)
+		const enabledApis = apiService.enableApis(
+			['bigquery.googleapis.com'],
+			this,
+		)
+
+		this.dataset = new gcp.bigquery.Dataset(
+			'billing-export',
+			{
+				datasetId: 'billing_export',
+				friendlyName: 'GCP Billing Export',
+				description:
+					'Sink for GCP Billing Export — Standard, Detailed (resource-level), and Pricing data. ' +
+					'See docs/runbooks/enable-billing-export.md for the Console-side enable procedure. ' +
+					'Tables follow the pattern `gcp_billing_export_v1_<billing_account_id>`.',
+				location,
+				project: project.projectId,
+				// Default table expiration is unset: billing data should be
+				// retained indefinitely for historical analysis. Storage cost is
+				// minimal (~MB/month for a single-project export).
+			},
+			{ parent: this, dependsOn: enabledApis },
+		)
+
+		// IAM grant for the managed billing-export service account.
+		//
+		// When billing export to BigQuery is enabled via the Console, GCP
+		// uses a Google-managed service account to write to the dataset.
+		// In most setups, the Console auto-grants the required role on
+		// enable. This explicit binding makes the permission a Pulumi-
+		// tracked invariant so:
+		//   (a) drift caused by manual revocation is detected on next
+		//       `pulumi preview`, and
+		//   (b) the Console enable step succeeds on the first attempt
+		//       without a permission-grant intermediate failure.
+		//
+		// The service account identifier `cloud-billing-export@system.
+		// gserviceaccount.com` is documented at
+		// https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup
+		// — if a future GCP change renames this principal, the runbook's
+		// troubleshooting section walks through identifying the actual
+		// SA from the Cloud Billing audit logs.
+		new gcp.bigquery.DatasetIamMember(
+			'billing-export-writer',
+			{
+				datasetId: this.dataset.datasetId,
+				project: project.projectId,
+				role: 'roles/bigquery.dataEditor',
+				member: 'serviceAccount:cloud-billing-export@system.gserviceaccount.com',
+			},
+			{ parent: this },
+		)
+
+		this.datasetId = pulumi.interpolate`${project.projectId}:${this.dataset.datasetId}`
+
+		this.registerOutputs({
+			datasetId: this.datasetId,
+		})
+	}
+}

--- a/src/gcp/components/postgres.ts
+++ b/src/gcp/components/postgres.ts
@@ -3,11 +3,25 @@ import * as pulumi from '@pulumi/pulumi'
 import type { Environment } from '../../config.js'
 import { ApiService } from '../services/api.js'
 
+export type PostgresAvailabilityType = 'ZONAL' | 'REGIONAL'
+
 export interface PostgresComponentArgs {
 	project: gcp.organizations.Project
 	region: pulumi.Input<string>
 	regionName: pulumi.Input<string>
 	environment: Environment
+	/**
+	 * Cloud SQL availability tier. `ZONAL` runs a single primary in one
+	 * zone (cost-priority, no automatic failover). `REGIONAL` adds a
+	 * synchronous standby in a different zone of the same region,
+	 * roughly doubling the instance cost in exchange for an HA SLA with
+	 * automatic failover. Resolved upstream from
+	 * `liverty-music:postgresAvailabilityType` and passed in by the
+	 * caller; default at the call site is `ZONAL` (launch-phase policy).
+	 * See the `prod-cost-optimization` OpenSpec change for the rationale
+	 * and the `database` capability spec for the staged rollout policy.
+	 */
+	availabilityType: PostgresAvailabilityType
 	/**
 	 * Workload tier gate. When `false` (dev shutdown mode), the Cloud SQL
 	 * instance is set to `activationPolicy: NEVER` (stopped — CPU/RAM
@@ -90,6 +104,7 @@ export class PostgresComponent extends pulumi.ComponentResource {
 			region,
 			regionName,
 			environment,
+			availabilityType,
 			workloadEnabled,
 			subnetId,
 			networkId,
@@ -148,8 +163,7 @@ export class PostgresComponent extends pulumi.ComponentResource {
 				settings: {
 					tier: 'db-f1-micro', // Small Start (Shared CPU)
 					edition: 'ENTERPRISE', // Standard Edition
-					availabilityType:
-						environment === 'dev' ? 'ZONAL' : 'REGIONAL',
+					availabilityType,
 					activationPolicy: workloadEnabled ? 'ALWAYS' : 'NEVER',
 					diskSize: 10,
 					diskType: 'PD_SSD',

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -2,6 +2,7 @@ import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from '../cloudflare/config.js'
 import type { Environment } from '../config.js'
+import { BillingExportComponent } from './components/billing-export.js'
 import { KmsComponent } from './components/kms.js'
 import { KubernetesComponent } from './components/kubernetes.js'
 import { MonitoringComponent } from './components/monitoring.js'
@@ -10,6 +11,7 @@ import {
 	NetworkComponent,
 	type PostmarkDnsConfig,
 } from './components/network.js'
+import type { PostgresAvailabilityType } from './components/postgres.js'
 import { PostgresComponent } from './components/postgres.js'
 import {
 	type BlockchainConfig,
@@ -46,6 +48,12 @@ export interface GcpArgs {
 	 *  resources are not provisioned. See
 	 *  docs/runbooks/dev-shutdown-restart.md. */
 	workloadEnabled: boolean
+	/** Cloud SQL availability tier. `ZONAL` is the launch-phase default
+	 *  for all environments to keep costs low; flip to `REGIONAL` per
+	 *  environment by setting `liverty-music:postgresAvailabilityType`
+	 *  when an HA SLA is required. See the `database` capability spec
+	 *  for the staged rollout policy. */
+	postgresAvailabilityType: PostgresAvailabilityType
 }
 
 export const NetworkConfig = {
@@ -111,6 +119,7 @@ export class Gcp {
 			zitadelMachineKey,
 			zitadelLoginPat,
 			workloadEnabled,
+			postgresAvailabilityType,
 		} = args
 
 		const cloudSqlUsers = gcpConfig.cloudSqlUsers ?? []
@@ -258,6 +267,19 @@ export class Gcp {
 						environment,
 					})
 				: undefined
+
+		// 4.6. GCP Billing Export — BigQuery sink for cost analysis SQL.
+		// Prod-only: the dataset lives in the prod project and aggregates
+		// billing data for the entire billing account (across all
+		// projects). The Console-side enable step is documented in
+		// docs/runbooks/enable-billing-export.md. See OpenSpec change
+		// `prod-cost-optimization` §3 for the motivation.
+		if (environment === 'prod') {
+			new BillingExportComponent('gcp-billing-export', {
+				project: this.project,
+				environment,
+			})
+		}
 
 		const osakaConfig = NetworkConfig.Osaka
 
@@ -417,6 +439,7 @@ export class Gcp {
 			region: Regions.Osaka,
 			regionName: RegionNames.Osaka,
 			environment,
+			availabilityType: postgresAvailabilityType,
 			workloadEnabled,
 			subnetId: this.workloadSAs?.subnetId,
 			networkId: network.network.id,

--- a/src/gcp/services/api.ts
+++ b/src/gcp/services/api.ts
@@ -31,6 +31,7 @@ export type GoogleApis =
 	| 'places.googleapis.com'
 	| 'cloudkms.googleapis.com'
 	| 'certificatemanager.googleapis.com'
+	| 'bigquery.googleapis.com'
 
 export class ApiService {
 	constructor(

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,28 @@ const env = pulumi.getStack() as Environment
 // `pulumi up` job will abort before computing any resource diff).
 // Disabling prod requires a deliberate code change, not a config flip.
 const workloadEnabled = config.getBoolean('workloadEnabled') ?? true
+
+// Cloud SQL availability tier. Default `ZONAL` so new stacks land in the
+// cost-priority configuration; promote to `REGIONAL` per stack by setting
+// `liverty-music:postgresAvailabilityType: REGIONAL` in `Pulumi.<env>.yaml`
+// once an HA SLA is required. See the `database` capability spec for the
+// staged-rollout policy and the `prod-cost-optimization` change for the
+// motivation. Validation is intentionally narrow (string literal pair) so
+// a typo fails at program-construct time, not at Cloud SQL API time.
+const postgresAvailabilityTypeRaw =
+	config.get('postgresAvailabilityType') ?? 'ZONAL'
+if (
+	postgresAvailabilityTypeRaw !== 'ZONAL' &&
+	postgresAvailabilityTypeRaw !== 'REGIONAL'
+) {
+	throw new Error(
+		`liverty-music:postgresAvailabilityType must be 'ZONAL' or 'REGIONAL', ` +
+			`got '${postgresAvailabilityTypeRaw}'.`,
+	)
+}
+const postgresAvailabilityType = postgresAvailabilityTypeRaw as
+	| 'ZONAL'
+	| 'REGIONAL'
 // Allow-list rather than block-list: any stack other than `dev`
 // (today `prod`; tomorrow `staging` if added to `Environment`) is
 // implicitly off-limits to the shutdown switch. Adding a new
@@ -152,6 +174,7 @@ const gcp = new Gcp({
 	zitadelMachineKey,
 	zitadelLoginPat,
 	workloadEnabled,
+	postgresAvailabilityType,
 })
 
 // 5. Self-hosted Zitadel GSM secret shells (all envs, always).


### PR DESCRIPTION
## Summary

- Implement the 4 workstreams from OpenSpec change [`prod-cost-optimization`](https://github.com/liverty-music/specification/pull/528).
- 9 files changed: 7 modified + 2 new. Targets ~¥3,000-3,300/month reduction (~10%) on the ~¥30,000/month prod baseline.
- Each workstream is independently revertible.

## Workstreams

### 1. otel-collector filter (`k8s/namespaces/otel-collector/base/configmap.yaml`)

Add `filter/drop_workload_noise` processor that excludes `rpc.server.*` and `http.client.*` from the metrics pipeline. These auto-instrumented OTLP histograms account for ~87% of Cloud Monitoring metric ingest volume and are not referenced by any alert (all current alerts are log-based). Filter runs **before** `batch` so dropped metrics never enter the batch buffer.

Retained metrics (explicitly listed in the ConfigMap comment): `concert.search.count`, `db.pool.active_connections`, `db.pool.idle_connections`.

Estimated savings: **~¥1,800-2,000/month** + future-proofs against billing account 150 MiB free tier exhaustion under prod traffic ramp.

### 2. Argo CD prod overlay (`k8s/namespaces/argocd/overlays/prod/kustomization.yaml`)

Three inline patches added to the existing kustomization:

- `argocd-server` replicas `2 → 1` — no HA SLA on Argo CD UI at launch phase.
- `argocd-image-updater-controller` replicas `→ 0` — prod runs semver-pinned overlays per #274, so the controller has no Applications to act on.
- `argocd-applicationset-controller` replicas `→ 0` — verified no ApplicationSet CRs exist in the prod cluster.

`argocd-notifications-controller` is **intentionally kept running**. It has an active Google Chat subscription in `argocd-notifications-cm` for `on-sync-failed` / `on-health-degraded` / `on-sync-status-unknown` triggers; losing those alerts would exceed the savings from disabling.

Estimated savings: **~¥150-300/month**.

### 3. BigQuery Billing Export (`src/gcp/components/billing-export.ts` + wiring)

New `BillingExportComponent` (prod-only) provisions:
- `gcp.bigquery.Dataset` `billing_export` in `asia-northeast1`.
- `gcp.bigquery.DatasetIamMember` granting `roles/bigquery.dataEditor` to `cloud-billing-export@system.gserviceaccount.com`.
- Enables `bigquery.googleapis.com` API (added to the `GoogleApis` type allowlist).

Console-side enable step (Standard + Detailed exports) is documented in the new runbook [`docs/runbooks/enable-billing-export.md`](https://github.com/liverty-music/cloud-provisioning/blob/527-prod-cost-optimization/docs/runbooks/enable-billing-export.md) with three example analysis SQL queries.

Estimated savings: indirect (cost investigation tooling). Replaces the CSV-export workflow used to produce this PR.

### 4. Cloud SQL `availabilityType` config (`src/gcp/components/postgres.ts` + `Pulumi.prod.yaml`)

Replace the hard-coded `environment === 'dev' ? 'ZONAL' : 'REGIONAL'` with a Pulumi config key `liverty-music:postgresAvailabilityType` (default `ZONAL`, valid `ZONAL`|`REGIONAL` with program-construct-time validation). `Pulumi.prod.yaml` explicitly pins `ZONAL` with a comment pointing at the staged-rollout policy in the `database` capability spec.

This switches the prod Cloud SQL instance from REGIONAL HA (zonal standby) to ZONAL single-primary. Cost reduction is roughly 2× on the instance line item.

Estimated savings: **~¥1,000/month** (db-f1-micro REGIONAL → ZONAL).

## Verification done locally

- [x] `make lint-ts` passes after `npm install` (no new errors introduced; pre-existing missing `@pulumi/random`/`@pulumi/tls` deps in `zitadel/components/` resolved by reinstall).
- [x] Biome auto-format applied (`make fix`).
- [x] otel-collector ConfigMap parses cleanly via `yaml.safe_load`; `filter/drop_workload_noise` is in processors, metrics pipeline is `[filter/drop_workload_noise, batch]`.
- [x] Argo CD prod overlay kustomization.yaml parses cleanly; 3 deployment patches present (server / image-updater / applicationset).
- [x] `kubectl kustomize` dry-run for both overlays produced expected output (ran on otel-collector successfully; argocd overlay's `--enable-helm` failed locally due to Helm v4 / older kustomize incompatibility — CI uses Helm v3 and is expected to render cleanly).

## Test plan

- [ ] `pulumi preview --stack prod` diff shows: (a) new `billing-export` Dataset + DatasetIamMember, (b) Cloud SQL `availabilityType: REGIONAL → ZONAL`. No other resource changes.
- [ ] ArgoCD sync of `otel-collector` Application after merge — confirm the Collector pod restarts cleanly and `monitoring.googleapis.com/billing/bytes_ingested` for `liverty-music-prod` drops to under 1 MiB/day within 24h.
- [ ] ArgoCD sync of `argocd` Application after merge — confirm `kubectl get pods -n argocd` shows `argocd-server: 1/1`, no `argocd-image-updater-controller-*` pod, no `argocd-applicationset-controller-*` pod, `argocd-notifications-controller` still 1/1.
- [ ] Trigger `pulumi up --stack prod` from Pulumi Cloud Console during a maintenance window (JST 深夜). Verify `gcloud sql instances describe postgres-osaka --project=liverty-music-prod --format='value(settings.availabilityType)'` returns `ZONAL`.
- [ ] Backend Pod logs after Cloud SQL switch — no DB connection errors, `SELECT 1` succeeds.
- [ ] Follow `docs/runbooks/enable-billing-export.md` to enable Standard + Detailed exports in the Console; verify table creation 24h later with `bq ls liverty-music-prod:billing_export`.

## Risks / rollback

| Workstream | Rollback path |
|---|---|
| otel filter | Remove `filter/drop_workload_noise` from `processors` list and from the `metrics` pipeline → revert PR → ArgoCD sync |
| Argo CD pods | Revert PR section → ArgoCD sync, pods come back |
| BQ Export | Revert PR section + manually `bq rm liverty-music-prod:billing_export` (or `pulumi destroy --target` the dataset URN) |
| Cloud SQL ZONAL | Flip `liverty-music:postgresAvailabilityType` to `REGIONAL` in `Pulumi.prod.yaml` → `pulumi up`. HA standby is added back (short window of REGIONAL provisioning). |

Refs: #527