### PR TITLE
fix(infra): correct billing-export service account name

### DIFF
--- a/docs/runbooks/enable-billing-export.md
+++ b/docs/runbooks/enable-billing-export.md
@@ -162,16 +162,19 @@ ORDER BY delta DESC;
 3. Confirm dataset write permissions:
    - The component grants
      `roles/bigquery.dataEditor` to
-     `serviceAccount:cloud-billing-export@system.gserviceaccount.com`.
+     `serviceAccount:billing-export-bigquery@system.gserviceaccount.com`.
    - If GCP has renamed this principal since the component was written,
-     identify the actual SA used by your billing account:
-     - Cloud Console → IAM & Admin → Logs Explorer
-     - Filter:
+     identify the actual SA by inspecting the dataset's effective ACL
+     immediately after a Console-side enable attempt:
+     - `bq --project_id=liverty-music-prod show --format=prettyjson billing_export | jq '.access'`
+     - The `OWNER` or `WRITER` entries added by the Console reveal the
+       current Google-managed billing-export service account.
+     - Alternatively, Cloud Console → IAM & Admin → Logs Explorer, filter
        `protoPayload.serviceName="bigquery.googleapis.com"
         AND protoPayload.resourceName=~"projects/liverty-music-prod/datasets/billing_export"`
-     - Look at recent write attempts; the `protoPayload.authenticationInfo.principalEmail`
-       field reveals the actual SA.
-   - Add the discovered SA to the `BillingExportComponent` IAM binding and
+       and read `protoPayload.authenticationInfo.principalEmail` on recent
+       write attempts.
+   - Update the `BillingExportComponent` IAM binding member to match and
      re-apply.
 
 ### Wrong billing account selected

--- a/src/gcp/components/billing-export.ts
+++ b/src/gcp/components/billing-export.ts
@@ -88,19 +88,24 @@ export class BillingExportComponent extends pulumi.ComponentResource {
 		//   (b) the Console enable step succeeds on the first attempt
 		//       without a permission-grant intermediate failure.
 		//
-		// The service account identifier `cloud-billing-export@system.
-		// gserviceaccount.com` is documented at
-		// https://cloud.google.com/billing/docs/how-to/export-data-bigquery-setup
-		// — if a future GCP change renames this principal, the runbook's
-		// troubleshooting section walks through identifying the actual
-		// SA from the Cloud Billing audit logs.
+		// The service account identifier `billing-export-bigquery@system.
+		// gserviceaccount.com` is what GCP's Console actually grants on the
+		// dataset when an operator enables Standard / Detailed / Pricing
+		// export — confirmed empirically by inspecting dataset ACLs after a
+		// Console-side enable. (The earlier guess of
+		// `cloud-billing-export@system.gserviceaccount.com` resolved to a
+		// non-existent principal, so the Pulumi binding was a silent no-op
+		// before this fix.) If a future GCP change renames this principal,
+		// the runbook's troubleshooting section walks through identifying
+		// the actual SA from the dataset's effective ACL or Cloud Logging
+		// audit trail.
 		new gcp.bigquery.DatasetIamMember(
 			'billing-export-writer',
 			{
 				datasetId: this.dataset.datasetId,
 				project: project.projectId,
 				role: 'roles/bigquery.dataEditor',
-				member: 'serviceAccount:cloud-billing-export@system.gserviceaccount.com',
+				member: 'serviceAccount:billing-export-bigquery@system.gserviceaccount.com',
 			},
 			{ parent: this },
 		)


### PR DESCRIPTION
## Summary

- Replace `cloud-billing-export@system.gserviceaccount.com` with the empirically-verified `billing-export-bigquery@system.gserviceaccount.com` in `BillingExportComponent` and the runbook troubleshooting section.
- Follow-up to PR #312 (prod-cost-optimization). The original identifier was a guess that resolved to a non-existent principal — the Pulumi IAM binding was a silent no-op. Console-side enable still worked because the Console grants its own SA independently.

## How was the actual SA name confirmed?

During the Console-side billing export enable performed after PR #312 merged, the dataset's effective ACL was inspected:

```
$ bq --project_id=liverty-music-prod show billing_export
Owners:
  billing-export-bigquery@system.gserviceaccount.com   ← Console-granted
  projectOwners
  pulumi-cloud@liverty-music-prod.iam.gserviceaccount.com
```

GCP's Console grants OWNER (not just `roles/bigquery.dataEditor`) to this principal during the export enable flow. The principal name is `billing-export-bigquery@system.gserviceaccount.com`, not `cloud-billing-export@...`.

## Net effect

- `pulumi up` now writes an IAM binding to a real principal.
- Drift detection works: if an operator manually revokes the Console-granted access, `pulumi preview` will surface the diff.
- No additional binding cycle on the live dataset since the correct SA is already an Owner via the Console-side grant.

## Test plan

- [ ] `pulumi preview --stack prod` shows the `DatasetIamMember` resource diff (member changes from `cloud-billing-export@...` to `billing-export-bigquery@...`).
- [ ] After `pulumi up`, `bq show billing_export | jq '.access[] | select(.role == \"roles/bigquery.dataEditor\")'` returns the new SA binding.

Refs: #527