### PR TITLE
chore(k8s): bump frontend prod overlay to v1.2.0

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.1.2"
+    app.kubernetes.io/version: "1.2.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.1.2  # commit 717a8b5fd4425ddac903308f87724e4ff8a56574
+  newTag: v1.2.0  # commit 7e46667276b5c2e3825aaf85fe0f53de2defbd20


### PR DESCRIPTION
## Description

Promote `liverty-music/frontend` **v1.2.0** to prod by pinning the prod overlay image and `app.kubernetes.io/version` label. ArgoCD prod (auto-sync) rolls it out on merge.

## Changes

`k8s/namespaces/frontend/overlays/prod/kustomization.yaml`:
- `images[web-app].newTag`: `v1.1.2` → `v1.2.0` (commit `7e46667276b5c2e3825aaf85fe0f53de2defbd20`)
- `app.kubernetes.io/version` label: `1.1.2` → `1.2.0` (lock-step)

The v1.2.0 release retagged the dev-AR digest for `7e46667` into prod AR (`liverty-music-prod/frontend/web-app:v1.2.0`) via `crane copy` — digest-equivalent to the dev-exercised image.

## What ships
- discovery bubble-tap sound + tactile feedback (frontend PR #374)
- Series-hierarchy Concert proto consumption + concert/dashboard/import-ticket fixes unreleased since v1.1.2

## Verification
- `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders `web-app:v1.2.0`, version label `1.2.0`, apex hostname `liverty-music.app`.

## Note
Prod backend is v1.1.1 (May-21 schema); the Series-hierarchy proto delta is additive and the frontend guards for absent series data, so no break pre-launch. Series-aware UI fully lights up once prod backend is bumped to a ≥ May-24 schema.

close: #316
