### PR TITLE
chore(k8s): bump backend prod overlay to v1.2.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.1.1"
+    app.kubernetes.io/version: "1.2.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
+  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
+  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
+  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.1.1  # commit aae5228de1b5bd3aaffda05ff4b5cb370c8f5855
+  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635


### PR DESCRIPTION
## Summary

Promote the backend prod overlay image pins `v1.1.1` → `v1.2.0` (commit `06d5c6f`) across all 4 workloads (server, consumer, concert-discovery, artist-image-sync) and the `app.kubernetes.io/version` label.

## Why

prod DB is already on the Series-hierarchy schema (migration `20260523145447`, applied via the auto-sync `backend-migrations` app when backend PR #305 merged), but the running images stayed at v1.1.1 — old-schema code crash-restarting (8×) and the v1.2.0 frontend's series/concert UI dark. The backend `v1.2.0` release is cut and promoted to prod AR. Merging this lets the prod `backend` ArgoCD app (auto-sync) roll out the matching code.

## Verification

- `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders all 4 images at `:v1.2.0`, label `1.2.0`.
- prod AR `:v1.2.0` digests are byte-identical to the validated dev images.

## Notes

- Forward-only: rollback to v1.1.1 re-creates the code/schema mismatch.
- v1.2.0 carries breaking changes but stays on v1 per pre-launch convention (matches frontend v1.2.0).

close: #318