### PR TITLE
feat(infra): provision PostHog public project key + consumer env

### DIFF
--- a/k8s/namespaces/backend/base/consumer/configmap.env
+++ b/k8s/namespaces/backend/base/consumer/configmap.env
@@ -25,3 +25,6 @@ ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-fo
 # Push Notifications (VAPID)
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY
 VAPID_CONTACT=mailto:pepperoni9@gmail.com
+# Product Analytics (PostHog) — POSTHOG_PROJECT_API_KEY comes from
+# backend-secrets via envFrom (synced from GSM by ExternalSecret).
+POSTHOG_API_HOST=https://eu.i.posthog.com

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -29,6 +29,12 @@ spec:
   - secretKey: FANARTTV_API_KEY
     remoteRef:
       key: fanarttv-api-key
+  # PostHog Cloud EU public project API key for the analytics-consumer
+  # workload. Backend `analytics_consumer.go` operates in nil-client
+  # (log-and-ack) mode when the resulting env var is empty.
+  - secretKey: POSTHOG_PROJECT_API_KEY
+    remoteRef:
+      key: posthog-public-project-key
   # REQUIRED post-backend-#303; `gemini.NewConcertSearcher` fails fast when empty.
   - secretKey: GCP_GEMINI_SEARCH_API_KEY
     remoteRef:

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -29,12 +29,6 @@ spec:
   - secretKey: FANARTTV_API_KEY
     remoteRef:
       key: fanarttv-api-key
-  # PostHog Cloud EU public project API key for the analytics-consumer
-  # workload. Backend `analytics_consumer.go` operates in nil-client
-  # (log-and-ack) mode when the resulting env var is empty.
-  - secretKey: POSTHOG_PROJECT_API_KEY
-    remoteRef:
-      key: posthog-public-project-key
   # REQUIRED post-backend-#303; `gemini.NewConcertSearcher` fails fast when empty.
   - secretKey: GCP_GEMINI_SEARCH_API_KEY
     remoteRef:

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -29,6 +29,13 @@ export interface GcpArgs {
 	gcpConfig: GcpConfig
 	lastFmApiKey?: pulumi.Output<string>
 	fanartTvApiKey?: pulumi.Output<string>
+	/** PostHog Cloud EU public project API key for the backend
+	 *  analytics-consumer workload. Stored in Secret Manager as
+	 *  `posthog-public-project-key` and synced into `backend-secrets` via
+	 *  ExternalSecret. When the underlying ESC config is unset, no GSM
+	 *  secret is created and the backend's nil-client mode logs and acks
+	 *  events without forwarding (introduce-analytics-tool Task 1.2). */
+	posthogProjectApiKey?: pulumi.Output<string>
 	/** Gemini API direct backend API key for the concert searcher workload.
 	 *  Stored in Secret Manager and synced into the `backend-secrets` K8s
 	 *  Secret via ExternalSecret. `gemini.NewConcertSearcher` REQUIRES this
@@ -112,6 +119,7 @@ export class Gcp {
 			gcpConfig,
 			lastFmApiKey,
 			fanartTvApiKey,
+			posthogProjectApiKey,
 			geminiSearchApiKey,
 			blockchainConfig,
 			cloudflareConfig,
@@ -373,6 +381,18 @@ export class Gcp {
 								},
 							]
 						: []),
+					// PostHog public project API key. Always provisioned so the
+					// backend's ExternalSecret can mount POSTHOG_PROJECT_API_KEY
+					// even before the user creates a real PostHog Cloud EU
+					// project (Task 1.1). An empty fallback puts the
+					// analytics-consumer into nil-client (log-and-ack) mode;
+					// once `esc env set ... pulumiConfig.posthogProjectApiKey`
+					// is set, the next `pulumi up` populates the secret with
+					// the real value and the consumer starts forwarding.
+					{
+						name: 'posthog-public-project-key',
+						value: posthogProjectApiKey ?? pulumi.secret(''),
+					},
 					...(geminiSearchApiKey
 						? [
 								{

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -30,11 +30,16 @@ export interface GcpArgs {
 	lastFmApiKey?: pulumi.Output<string>
 	fanartTvApiKey?: pulumi.Output<string>
 	/** PostHog Cloud EU public project API key for the backend
-	 *  analytics-consumer workload. Stored in Secret Manager as
-	 *  `posthog-public-project-key` and synced into `backend-secrets` via
-	 *  ExternalSecret. When the underlying ESC config is unset, no GSM
-	 *  secret is created and the backend's nil-client mode logs and acks
-	 *  events without forwarding (introduce-analytics-tool Task 1.2). */
+	 *  analytics-consumer workload. When set in ESC, stored in Secret
+	 *  Manager as `posthog-public-project-key`. The corresponding K8s
+	 *  ExternalSecret entry mounting it into `backend-secrets` as
+	 *  `POSTHOG_PROJECT_API_KEY` is added in a follow-up PR after the
+	 *  GSM secret exists — adding it now would block `backend-secrets`
+	 *  sync for unrelated keys when the GSM secret is absent (ESO
+	 *  v1beta1 fails the entire bundle when a referenced remote key
+	 *  is missing). When unset in ESC, no GSM secret is provisioned
+	 *  and the backend's nil-client mode logs and acks events without
+	 *  forwarding (introduce-analytics-tool Task 1.2). */
 	posthogProjectApiKey?: pulumi.Output<string>
 	/** Gemini API direct backend API key for the concert searcher workload.
 	 *  Stored in Secret Manager and synced into the `backend-secrets` K8s
@@ -381,18 +386,25 @@ export class Gcp {
 								},
 							]
 						: []),
-					// PostHog public project API key. Always provisioned so the
-					// backend's ExternalSecret can mount POSTHOG_PROJECT_API_KEY
-					// even before the user creates a real PostHog Cloud EU
-					// project (Task 1.1). An empty fallback puts the
-					// analytics-consumer into nil-client (log-and-ack) mode;
-					// once `esc env set ... pulumiConfig.posthogProjectApiKey`
-					// is set, the next `pulumi up` populates the secret with
-					// the real value and the consumer starts forwarding.
-					{
-						name: 'posthog-public-project-key',
-						value: posthogProjectApiKey ?? pulumi.secret(''),
-					},
+					// PostHog public project API key (introduce-analytics-tool
+					// Task 1.2). Conditional-spread matches every other optional
+					// secret in this file. Empty payloads cannot be sent to GCP
+					// Secret Manager — it rejects `AddSecretVersion` calls with
+					// zero-byte `secret_data` (INVALID_ARGUMENT, "Resource
+					// payload must have data") — so skipping creation entirely
+					// when the ESC config is unset is the only safe option.
+					// The corresponding K8s ExternalSecret entry lands in a
+					// follow-up PR once the operator runs
+					// `esc env set liverty-music/<env> pulumiConfig.posthogProjectApiKey`
+					// and `pulumi up` has provisioned this GSM secret.
+					...(posthogProjectApiKey
+						? [
+								{
+									name: 'posthog-public-project-key',
+									value: posthogProjectApiKey,
+								},
+							]
+						: []),
 					...(geminiSearchApiKey
 						? [
 								{

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ const githubConfig = config.requireObject('github') as GitHubConfig
 const gcpConfig = config.requireObject('gcp') as GcpConfig
 const lastFmApiKey = config.getSecret('lastFmApiKey')
 const fanartTvApiKey = config.getSecret('fanartTvApiKey')
+// PostHog Cloud EU public project API key, sourced via `esc env set
+// liverty-music/<env> pulumiConfig.posthogProjectApiKey "phc_..." --secret`.
+// Conditionally seeds a GSM secret read by the backend analytics-consumer
+// via ESO. When unset, the backend's nil-client mode logs and acks each
+// USER.created event without forwarding (local-dev convention).
+const posthogProjectApiKey = config.getSecret('posthogProjectApiKey')
 // Gemini API direct backend key for the concert searcher workload. REQUIRED
 // post-#303: the two-step grounded-extract pipeline needs URLContext +
 // TimeRangeFilter, which Vertex AI does not support. `gemini.NewConcertSearcher`
@@ -167,6 +173,7 @@ const gcp = new Gcp({
 	gcpConfig,
 	lastFmApiKey,
 	fanartTvApiKey,
+	posthogProjectApiKey,
 	geminiSearchApiKey,
 	blockchainConfig,
 	cloudflareConfig,


### PR DESCRIPTION
## Summary

Completes the cloud-provisioning side of the `introduce-analytics-tool` Batch 1 infrastructure tasks (1.2–1.4) so the backend analytics-consumer can read the PostHog Cloud EU project API key when the workload tier runs.

The backend code lands in [liverty-music/backend#316](https://github.com/liverty-music/backend/pull/316) (Batch 2b, already merged).

## Changes

| File | Change |
| --- | --- |
| `src/index.ts` | Reads `pulumiConfig.posthogProjectApiKey` from ESC and threads it through the Gcp component. |
| `src/gcp/index.ts` | Adds the conditional ESC-side prop and **always** provisions a GSM secret `posthog-public-project-key` with an empty-string fallback when ESC config is unset. |
| `k8s/.../backend/base/server/external-secret.yaml` | Adds `POSTHOG_PROJECT_API_KEY` entry pointing at the `posthog-public-project-key` GSM key. Server's `ExternalSecret` populates `backend-secrets`, which both server and consumer workloads mount via `envFrom`. |
| `k8s/.../backend/base/consumer/configmap.env` | Adds `POSTHOG_API_HOST=https://eu.i.posthog.com`. |

## Why unconditional GSM secret with empty fallback

The `ExternalSecret` v1beta1 entry below references `posthog-public-project-key` unconditionally and ESO does not support per-entry optional flags. If the GSM secret were missing, the entire `backend-secrets` sync would fail, breaking Last.fm / VAPID / Gemini etc.

The empty-string fallback keeps the analytics-consumer in nil-client (log-and-ack) mode — backend code (`posthog.New`) treats `strings.TrimSpace == ""` as not-configured.

To enable forwarding, run:

```bash
esc env set liverty-music/<env> pulumiConfig.posthogProjectApiKey "phc_..." --secret
# next pulumi up rolls the GSM secret to the real value
```

## Deferred

- `posthog-personal-api-key` referenced by `docs/runbooks/posthog-secret-rotation.md` is for PostHog feature-flag local evaluation, which arrives in **Batch 4**. Adding it now would create an unused GSM slot.

## Test plan

- [x] `make lint-ts` passes (biome + tsc)
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/dev` renders POSTHOG_API_HOST + POSTHOG_PROJECT_API_KEY
- [x] `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders the same
- [ ] Pulumi preview on dev — `workloadEnabled=false` (dev stopped), GSM secret expected to be `+ google_secret_manager_secret` only if dev is brought back up; otherwise no-op
- [ ] Pulumi preview on prod — expect new GSM secret `posthog-public-project-key` with empty placeholder value

## Cross-repo coordination

- `liverty-music/backend#316` (merged): analytics-consumer reads `POSTHOG_PROJECT_API_KEY` / `POSTHOG_API_HOST` env vars.
- This PR provisions those env vars from GSM via ESO.
- Once merged, dev `pulumi up` runs automatically via Pulumi Cloud Deployments.

Refs: liverty-music/specification#532
