### PR TITLE
feat(infra): add posthogApiHost to frontend /config.json (dev + prod)

### DIFF
--- a/k8s/namespaces/frontend/overlays/dev/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/configmap.yaml
@@ -12,6 +12,7 @@ data:
       "zitadelOrgId": "371348346264093539",
       "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
+      "posthogApiHost": "https://eu.i.posthog.com",
       "previewArtistIds": [
         "019c8655-7a05-71ef-82b4-a4ac2494e29f",
         "019c8655-7a05-721d-b0a8-4c11724d5c90",

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -12,6 +12,7 @@ data:
       "zitadelOrgId": "373015514391249051",
       "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
+      "posthogApiHost": "https://eu.i.posthog.com",
       "previewArtistIds": [
         "019e3029-8044-75fc-a662-2ddfce51178e",
         "019e3029-8044-7603-b047-c713d5183f2c",


### PR DESCRIPTION
## Summary

Adds the PostHog Cloud EU API host to the frontend runtime config on both dev and prod overlays so the [`AnalyticsService`](https://github.com/liverty-music/frontend/blob/main/src/lib/analytics/analytics-service.ts) picks up the EU endpoint explicitly rather than relying on its hardcoded default.

```diff
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
+      "posthogApiHost": "https://eu.i.posthog.com",
       "previewArtistIds": [...]
```

## Why this is small (and why `posthogProjectKey` is NOT in this PR)

- The PostHog **project API key** is intentionally still absent from the ConfigMap. The frontend's [`AppConfig`](https://github.com/liverty-music/frontend/blob/main/src/config/app-config.ts) schema treats both `posthogApiHost` and `posthogProjectKey` as optional. Until the operator explicitly adds `posthogProjectKey` with a real value, `AnalyticsService` stays in nil-config debug-log mode and the analytics pipeline does not light up. This PR is operationally inert until that opt-in.
- The host endpoint is **public** — PostHog Cloud EU's ingestion URL is `https://eu.i.posthog.com` for every tenant. Storing it as a plain ConfigMap entry is correct and matches how `apiBaseUrl`, `zitadelIssuer`, and `vapidPublicKey` are already shaped.
- The project API key, when added, IS rotation-managed via GSM (`posthog-public-project-key` from PR #322). The frontend doesn't pull from K8s Secret today (the runtime config is a single ConfigMap mount); when the operator adds the key, they can either inline it into the ConfigMap or evolve the rendering pipeline to template it in from a Secret — that's a separate decision tracked outside this PR.

## Test plan

- [x] `make check` passes locally (biome + tsc + kustomize render + kube-linter + spot check)
- [x] `kubectl kustomize k8s/namespaces/frontend/overlays/dev` confirms the new field lands inside the `web-app-runtime-config` ConfigMap; same for prod.
- [ ] CI green (Pulumi preview should be a no-op on `src/**` — this PR touches K8s manifests only, dev ArgoCD will reconcile on merge).
- [ ] Manual: once operator adds `posthogProjectKey` to the ConfigMap (or via a follow-up Secret mount), navigate the dev frontend, observe events flowing to the PostHog Cloud EU dev project.

Refs: liverty-music/specification#532