### PR TITLE
feat(infra): wire PostHog Project token for prod + dev backend + frontend

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/consumer/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/consumer/configmap.env
@@ -11,6 +11,12 @@ DATABASE_MAX_IDLE_CONNS=1
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
+# Product Analytics — PostHog Cloud EU Project token for liverty-music-dev.
+# Public identifier (analogous to a Stripe publishable key); the same value
+# lives in the frontend dev /config.json. Different project from prod so
+# the two environments' event streams stay isolated in PostHog. Setup +
+# rationale documented at specification/docs/analytics/posthog-project-setup.md.
+POSTHOG_PROJECT_API_KEY=phc_tJe37LsNQskgKySDJRPfQwAZpqhM3RkH7MXDJKyb9wcU
 # OIDC (Zitadel domain for API calls)
 OIDC_ISSUER_URL=https://auth.dev.liverty-music.app
 # Telemetry

--- a/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/consumer/configmap.env
@@ -11,6 +11,11 @@ DATABASE_MAX_IDLE_CONNS=1
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # GCP
 GCP_PROJECT_ID=liverty-music-prod
+# Product Analytics — PostHog Cloud EU Project token for liverty-music-prod
+# (project ID 190464). Public identifier (analogous to a Stripe publishable
+# key); the same value lives in the frontend prod /config.json. Setup +
+# rationale documented at specification/docs/analytics/posthog-project-setup.md.
+POSTHOG_PROJECT_API_KEY=phc_CVzLNs8ys4zeczYv36Td3aYgBhzdnaMKUqKBT7tM8H4Q
 # OIDC (Zitadel domain for API calls)
 OIDC_ISSUER_URL=https://auth.liverty-music.app
 # Telemetry

--- a/k8s/namespaces/frontend/overlays/dev/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/configmap.yaml
@@ -13,6 +13,7 @@ data:
       "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
       "posthogApiHost": "https://eu.i.posthog.com",
+      "posthogProjectKey": "phc_tJe37LsNQskgKySDJRPfQwAZpqhM3RkH7MXDJKyb9wcU",
       "previewArtistIds": [
         "019c8655-7a05-71ef-82b4-a4ac2494e29f",
         "019c8655-7a05-721d-b0a8-4c11724d5c90",

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -13,6 +13,7 @@ data:
       "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
       "circuitBaseUrl": "/circuits/ticketcheck-v1",
       "posthogApiHost": "https://eu.i.posthog.com",
+      "posthogProjectKey": "phc_CVzLNs8ys4zeczYv36Td3aYgBhzdnaMKUqKBT7tM8H4Q",
       "previewArtistIds": [
         "019e3029-8044-75fc-a662-2ddfce51178e",
         "019e3029-8044-7603-b047-c713d5183f2c",


### PR DESCRIPTION
## Summary

Activates the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) integration in **production and development**. Adds the per-env PostHog Cloud EU Project token to both backend's analytics-consumer ConfigMap and frontend's runtime `/config.json` for each overlay.

| Env | Backend file | Frontend file | Token |
| --- | --- | --- | --- |
| **prod** | `k8s/namespaces/backend/overlays/prod/consumer/configmap.env` | `k8s/namespaces/frontend/overlays/prod/configmap.yaml` | `phc_CVzLNs8...` (liverty-music-prod, project ID 190464) |
| **dev** | `k8s/namespaces/backend/overlays/dev/consumer/configmap.env` | `k8s/namespaces/frontend/overlays/dev/configmap.yaml` | `phc_tJe37Ls...` (liverty-music-dev, separate project) |

Distinct tokens per env so the two environments' event streams stay fully isolated in PostHog. Both projects are in EU Cloud region.

Staging is intentionally deferred — that env doesn't exist on the cluster yet.

## Why direct ConfigMap (not GSM)

The Project token is a public identifier. PostHog labels it "Write-only key for use in client libraries. Safe to use in public apps." Analogous to a Stripe publishable key: it's embedded in the frontend bundle anyway, so routing it through GCP Secret Manager would add no security value — only complexity and rotation latency.

Only the **Personal** API Key (for definitions sync, when/if introduced) would warrant GSM routing.

## Prod-deploy ⚠️

This merge IS a production deployment:

- **Backend prod**: ArgoCD syncs the ConfigMap. If Reloader is configured on the consumer Deployment, the pod rolls automatically; otherwise a manual `kubectl rollout restart` is required to pick up the new env var.
- **Frontend prod**: The runtime-config ConfigMap is mounted into the nginx container. ArgoCD syncs the ConfigMap; the pod re-reads `/config.json` without restart (it's served on every request).
- **Dev**: Currently stopped per the cost-saving policy. Manifest changes are inert until dev runtime comes back online; the wiring is then in place.

## Blast radius

Bounded by the integration's nil-client tolerance + consent-gated identify (Batches 3a–3c):

- If the key value is wrong / typo'd → SDK falls back to log-only mode; no crash, no user-facing impact.
- If a transient PostHog outage → SDK retries on its own; events that fail to land are dropped silently.
- No new code paths in this PR — purely flipping a switch on already-deployed code.

Worst case: "no events appear in PostHog until the key is corrected." User-facing experience unchanged.

## Pre-merge checklist

- [ ] **Billing limits set in PostHog UI** for the **liverty-music-prod** project (Organization settings → Billing → Spending controls):
  - Product Analytics: hard cap **$20/month**
  - All other products (Session Replay, Feature Flags, Experiments, Surveys, Data Warehouse, Logs, PostHog AI, …): hard cap **$0**
  - (dev project billing limits can be set lazily, no production impact)
- [ ] All previous analytics PRs merged (14 PRs across backend / frontend / cloud-provisioning / specification — Batches 2b / 3a / 3b / 3c / publishers / Push / Entry)
- [x] `make check` passes locally
- [ ] CI green

## Post-merge verification

- [ ] Observe ArgoCD sync on `prod-frontend` and `prod-backend-consumer` Applications turn green
- [ ] Manual: trigger a user signup on https://liverty-music.app → confirm `user.created` event appears in PostHog `liverty-music-prod` project Activity within ~1 minute
- [ ] PostHog UI "Waiting for events" indicator turns green

Refs: liverty-music/specification#532