### PR TITLE
fix(zitadel): resolve hosted-login 504 via InstanceHostHeaders

### DIFF
--- a/k8s/namespaces/zitadel/base/values.yaml
+++ b/k8s/namespaces/zitadel/base/values.yaml
@@ -79,6 +79,28 @@ zitadel:
     TLS:
       Enabled: false
 
+    # Instance resolution header chain. Zitadel v4.7.1+ resolves the virtual
+    # instance from InstanceHostHeaders (default [x-zitadel-instance-host]
+    # only) — it no longer reads the `Host` header. The Login V2 Pod calls the
+    # API at the cluster-internal Service over h2c (service.protocol: http2,
+    # appProtocol: kubernetes.io/h2c), so on the wire `:authority` = the dial
+    # target `zitadel-api` and the chart-generated `Host:<ExternalDomain>`
+    # does not survive HTTP/2. With no x-zitadel-instance-host sent, lookup
+    # falls back to `:authority`=zitadel-api → Errors.Instance.NotFound → the
+    # SSR render fails and the Gateway returns 504.
+    #
+    # The Login Pod already sends X-Zitadel-Public-Host=<ExternalDomain> (its
+    # CUSTOM_REQUEST_HEADERS), so adding x-zitadel-public-host to this chain
+    # lets internal calls resolve the instance via a header that is already on
+    # the wire. The default x-zitadel-instance-host is restated first because
+    # Zitadel overrides (not merges) the list. Browser→Gateway traffic sends
+    # neither header and keeps resolving via the `:authority` fallback
+    # (= <ExternalDomain>), so its behavior is unchanged. Header names are
+    # domain-independent, hence base (covers dev + prod).
+    InstanceHostHeaders:
+    - x-zitadel-instance-host
+    - x-zitadel-public-host
+
     Database:
       Postgres:
         Host: localhost


### PR DESCRIPTION
## 🔗 Related Issue
Closes: #327

## 📝 Summary of Changes

Adds `InstanceHostHeaders: [x-zitadel-instance-host, x-zitadel-public-host]` to `zitadel.configmapConfig` in `k8s/namespaces/zitadel/base/values.yaml` (one ConfigMap key, both overlays).

**Why:** Prod hosted login (`https://auth.liverty-music.app/ui/v2/login/login`) returns **HTTP 504** on every interactive sign-in/sign-up. The `zitadel-api` Pod (v4.14.0) rejects the Login V2 Pod's server-side (SSR) calls with `Errors.Instance.NotFound` (`instance_interceptor.go:100`, `instanceDomain zitadel-api, publicHostname auth.liverty-music.app`). The instance exists and resolves fine for browser→Gateway traffic — so this is **not** DB loss, a missing Custom Domain, or an `ExternalDomain` mismatch.

Root cause (two facts combine):
1. **Zitadel v4.7.1+ host-resolution change** ([zitadel/zitadel#11163](https://github.com/zitadel/zitadel/issues/11163)): instance lookup is driven by `InstanceHostHeaders`, default `[x-zitadel-instance-host]` only — the `Host` header is no longer read.
2. **h2c transport**: the `zitadel-api` Service is `protocol: http2` / `appProtocol: kubernetes.io/h2c`. On HTTP/2 the `:authority` equals the dial target (`zitadel-api`); the chart-generated `Host:<ExternalDomain>` does not survive. With no `x-zitadel-instance-host` sent, lookup falls back to `:authority` = `zitadel-api` → NotFound → SSR render fails → Gateway 504.

The Login Pod already sends `X-Zitadel-Public-Host=<ExternalDomain>` (the error line confirms `publicHostname` resolved). Adding it to the instance-host chain lets internal calls resolve via a header already on the wire. The default `x-zitadel-instance-host` is restated first because Zitadel **overrides** (not merges) the list. Browser→Gateway traffic is unaffected (sends neither header, keeps resolving via the `:authority` fallback = `<ExternalDomain>`).

⚠️ **Deployment note:** prod-affecting ConfigMap change. After merge → ArgoCD sync, it requires a rollout restart to take effect: `kubectl -n zitadel rollout restart deploy/zitadel-api` (both clusters). Request-parse config only — **no** `FirstInstance`/setup re-run.

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

> Delivered via ArgoCD/Kustomize (change is under `k8s/`, not `src/`), so **no Pulumi deployment** is triggered by this PR.

## 🔮 Pulumi Preview
N/A — Kubernetes manifest (Kustomize/Helm base values) change only; no Pulumi resources touched.

Local verification: prod + dev overlays render (`kustomize build --enable-helm`), `kube-linter` clean, rendered `zitadel-api-config-yaml` carries both header entries, and the chart-generated login `CUSTOM_REQUEST_HEADERS` / `ZITADEL_API_URL` are unchanged.

## 📦 State Changes
None. No `pulumi state mv` / `import` / destructive changes. Pure additive ConfigMap key; revert = remove the key → ArgoCD sync → rollout restart.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI. (N/A — no `src/` change; k8s render + kube-linter pass instead.)
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config. (No secrets involved.)

---
Spec: OpenSpec change `fix-zitadel-login-instance-resolution` (capability `zitadel-self-hosted-deployment`). Upstream: [zitadel/zitadel#11163](https://github.com/zitadel/zitadel/issues/11163), [zitadel/zitadel-charts#544](https://github.com/zitadel/zitadel-charts/issues/544).
