### PR TITLE
feat(infra): bump prod backend images v1.2.0 → v1.3.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
+  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
+  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
+  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.2.0  # commit 06d5c6f2b48836db7c182f01d07248dd9fb90635
+  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9


### PR DESCRIPTION
## Summary

Activates the [introduce-analytics-tool](https://github.com/liverty-music/specification/tree/main/openspec/changes/introduce-analytics-tool) integration in **production** by moving the prod backend image pins from v1.2.0 → v1.3.0 (backend commit `46201c7`, PR #320 merge).

Pairs with the [v1.3.0 GitHub Release](https://github.com/liverty-music/backend/releases/tag/v1.3.0) that has already retagged the dev AR images into prod AR under the v1.3.0 tag.

| Image | From | To |
| --- | --- | --- |
| `backend/server` | v1.2.0 | v1.3.0 |
| `backend/consumer` | v1.2.0 | v1.3.0 |
| `backend/concert-discovery` | v1.2.0 | v1.3.0 |
| `backend/artist-image-sync` | v1.2.0 | v1.3.0 |
| `app.kubernetes.io/version` label | "1.2.0" | "1.3.0" |

## What v1.3.0 brings into prod that v1.2.0 lacks

| PR | Capability |
| --- | --- |
| [#316](https://github.com/liverty-music/backend/pull/316) | analytics-consumer worker — `HandleUserCreated` + `forward-user-created-to-analytics` subscription. **This is the first handler in consumer-app that actually forwards to PostHog.** v1.2.0 had the ConfigMap entry from cloud-provisioning #326 but no code reading it. |
| [#317](https://github.com/liverty-music/backend/pull/317) | Publishers + Handle methods for `artist.follow.completed`, `artist.unfollow.completed`, `account.preferred_language.updated` |
| [#319](https://github.com/liverty-music/backend/pull/319) | PUSH JetStream stream + `push.subscription.completed` |
| [#320](https://github.com/liverty-music/backend/pull/320) | ENTRY JetStream stream + `entry.zk_proof.verified` / `entry.zk_proof.rejected` |

## Prod-deploy ⚠️

This merge IS a production deployment:

- ArgoCD picks up the new image refs → consumer-app + server-app + cronjob workloads roll to v1.3.0
- consumer-app first-boot calls `EnsureStreams` → **PUSH and ENTRY JetStream streams will be created in NATS** as a side effect on the first v1.3.0 startup
- `EnsureStreams` is idempotent (no-op for existing CONCERT/VENUE/ARTIST/USER streams)

### Blast radius

- The new server-app code is mostly additive (new publish call sites on existing API endpoints). Existing endpoints behave identically, with one new side effect each (publish to NATS post-success). Publish failures are non-fatal in every changed usecase — the persistence already committed, publish errors only get logged.
- consumer-app handler additions are pure-functional with nil-client tolerance — if PostHog is down or misconfigured, events are log-and-ack'd without crashing.

### Known limitation

KEDA's current ScaledObject only has triggers for `USER_created`, `ARTIST_created`, `CONCERT_*`. The new consumer-app subscriptions (`USER_preferred_language_updated`, `ARTIST_followed/unfollowed`, `PUSH_subscription_completed`, `ENTRY_zk_proof_verified/rejected`) **won't directly wake the consumer from zero** — they'll drain on the next time any existing-trigger event fires.

A follow-up PR will extend the KEDA triggers. For today, `user.created` alone gives complete first-event verification.

## Pre-merge checklist

- [x] Backend release v1.3.0 cut + CI retag dev→prod AR succeeded
- [x] `gcloud artifacts docker tags list … --filter=v1.3.0` confirms the tag exists in prod AR
- [x] `make check` passes locally (lint + render + kube-linter + spot)
- [ ] CI green
- [ ] cloud-provisioning PR #326 already merged (PostHog Project token in ConfigMap)

## Post-merge verification

- [ ] Observe ArgoCD `backend` Application turn green on new revision
- [ ] `kubectl get pods -n backend -l app=consumer` shows v1.3.0 image pulled
- [ ] consumer-app startup logs show `Running router handlers count: 12` (was 6 in v1.2.0) — 6 existing + 6 new forward-*-to-analytics
- [ ] `kubectl exec -n nats nats-0 -c nats -- wget -qO- "http://localhost:8222/jsz?streams=true"` shows PUSH and ENTRY streams created
- [ ] Manual: trigger a user signup on https://liverty-music.app → `user.created` event appears in PostHog `liverty-music-prod` project Activity within ~1 minute

Refs: liverty-music/specification#532