### PR TITLE
chore(frontend): bump prod image pin to v1.3.0

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.2.0  # commit 7e46667276b5c2e3825aaf85fe0f53de2defbd20
+  newTag: v1.3.0  # commit cde432bda3d28d451aaa60d29118daea9283f3f4


### PR DESCRIPTION
Refs: liverty-music/frontend#386

## Summary

Promote the discovery **bubble tap SE redesign + burst effect** to production.

- Pin `k8s/namespaces/frontend/overlays/prod` → `web-app:v1.3.0` (was v1.2.0).
- The v1.3.0 image was retagged into prod AR by the [v1.3.0 GitHub Release](https://github.com/liverty-music/frontend/releases/tag/v1.3.0) (release commit `cde432bd`).
- ArgoCD auto-syncs prod on merge.

Verified `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders `web-app:v1.3.0` cleanly.

Implementation: liverty-music/frontend#387 · spec: liverty-music/specification#549