### PR TITLE
feat(infra): bump prod frontend image v1.3.0 → v1.3.1 (CSP fix for PostHog)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.0  # commit cde432bda3d28d451aaa60d29118daea9283f3f4
+  newTag: v1.3.1  # commit 14302ed41ce4673cdb76a118e87ec3bed32f4ba6


### PR DESCRIPTION
## Summary

Ships the [CSP fix from frontend PR #388](https://github.com/liverty-music/frontend/pull/388) to production. `v1.3.1` (frontend commit `14302ed`) is identical to `v1.3.0` plus a single `index.html` edit that whitelists the PostHog Cloud EU domains in the Content-Security-Policy meta tag.

### Why this is needed

The browser console on https://liverty-music.app/my-artists (current `v1.3.0` build) shows:

```
Loading the script 'https://eu-assets.i.posthog.com/array/phc_.../config.js'
  violates 'script-src 'self' 'wasm-unsafe-eval' blob:'
Refused to connect to 'https://eu.i.posthog.com/e/?...' because it violates
  'connect-src 'self' https://*.zitadel.cloud https://*.liverty-music.app'
```

The analytics integration is otherwise fully wired (token in `/config.json`, AnalyticsService initialised, page.viewed call sites firing, deferred init via `requestIdleCallback`) — CSP was the only thing standing between the SDK and PostHog ingestion.

### Change in this PR

```diff
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.1"
   ...
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.0  # commit cde432bda3d28d451aaa60d29118daea9283f3f4
+  newTag: v1.3.1  # commit 14302ed41ce4673cdb76a118e87ec3bed32f4ba6
```

### Drive-by: label drift

`app.kubernetes.io/version` was at `"1.2.0"` even though the image was already `v1.3.0` — pre-existing drift from when v1.3.0 was first pin-bumped without updating the label. The kustomization comment explicitly says the label SHALL match the image tag, so realigning to `1.3.1` here.

## Prod-deploy ⚠️

This merge IS a production deployment: ArgoCD auto-syncs the new image tag → frontend pod rolls → nginx serves the updated `index.html` with the new CSP → next browser request loads the new policy → PostHog Cloud EU calls succeed.

### Blast radius

- The only diff between v1.3.0 and v1.3.1 is the CSP meta tag in `index.html`. No JS / TS / route / styles change.
- A broken CSP would block legitimate requests (e.g., zitadel calls). The new CSP keeps all existing whitelist entries verbatim and only adds PostHog domains.
- If somehow the CSP fix is wrong, rollback is trivial: revert this PR → ArgoCD restores v1.3.0 within ~1 min.

## Pre-merge checklist

- [x] frontend release v1.3.1 cut, CI retag dev→prod AR succeeded
- [x] `gcloud artifacts docker tags list … --filter=v1.3.1` confirms tag exists in prod AR
- [x] `make check` passes locally
- [ ] CI green
- [ ] Backend v1.3.0 already in prod (cloud-provisioning #329 merged earlier — provides the analytics-consumer that receives forwarded events)

## Post-merge verification

- [ ] ArgoCD `frontend` Application turns green on new revision
- [ ] `kubectl get deploy -n frontend web-app -o jsonpath='{...}'` confirms image `v1.3.1`
- [ ] Browser DevTools on https://liverty-music.app/my-artists: **no CSP violations** for posthog hosts
- [ ] PostHog `liverty-music-prod` project Activity tab: `$pageview` events arriving within ~1 minute of any browser navigation

This verification is **independent of the parallel Zitadel signup incident** — even without signup working, the frontend will emit `page.viewed` events on existing logged-out / cached-session paths.

Refs: liverty-music/specification#532