### PR TITLE
feat(infra): bump prod frontend image v1.3.1 → v1.3.2 (CSP fix, actually shipped)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.3.2"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.1  # commit 14302ed41ce4673cdb76a118e87ec3bed32f4ba6
+  newTag: v1.3.2  # commit 5e0b7a7bb17c148358b839a195b8a4ba723b64e5


### PR DESCRIPTION
## Summary

Bumps the prod frontend image from `v1.3.1` to `v1.3.2`. This finally ships the CSP whitelist for PostHog Cloud EU — v1.3.1 turned out to be a no-op retag of v1.3.0 (same digest) due to a CI build-vs-inherit bug now fixed by [frontend PR #389](https://github.com/liverty-music/frontend/pull/389).

### Why v1.3.1 didn't work

The frontend `push-image.yaml` workflow's "Decide build vs inherit" regex didn't list `index.html` as build-relevant. PR #388 changed only `index.html` (CSP meta tag), so the workflow chose `inherit` and retagged the parent (`cde432bd`, v1.3.0 source) image as the v1.3.1 dev tag. Both `v1.3.0` and `v1.3.1` in prod AR ended up pointing to `sha256:80af0bf...` — bit-for-bit identical.

PR #389 added `^index\.html$` to the regex. The merge of #389 (commit `5e0b7a7`) re-triggered the workflow (workflow file changed → build-relevant) → fresh dev AR image at `sha256:ea09de4...`. v1.3.2 retags that.

### Verified before opening this PR

```
prod AR v1.3.0 → sha256:80af0bf...
prod AR v1.3.1 → sha256:80af0bf...  ← no-op retag
prod AR v1.3.2 → sha256:ea09de4...  ← genuinely new
```

### Change in this PR

```diff
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.1"
+    app.kubernetes.io/version: "1.3.2"

 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
-  newTag: v1.3.1  # commit 14302ed41ce4673cdb76a118e87ec3bed32f4ba6
+  newTag: v1.3.2  # commit 5e0b7a7bb17c148358b839a195b8a4ba723b64e5
```

## Prod-deploy ⚠️

ArgoCD auto-syncs the new image tag → frontend pod rolls v1.3.1 → v1.3.2 → Caddy serves `index.html` with the updated CSP → browser unblocks PostHog requests → AnalyticsService (running in prod since v1.3.0) starts delivering `page.viewed` and other catalogue events to the `liverty-music-prod` PostHog project.

### Blast radius

Diff between v1.3.1 and v1.3.2 images is the `index.html` CSP meta tag and the workflow yaml inside the build context (but the latter isn't served). No JS / TS / route / styles change. Rollback = revert this PR → ArgoCD restores v1.3.1 in ~1 min.

## Pre-merge checklist

- [x] frontend release v1.3.2 cut, CI retag dev→prod AR succeeded (48s)
- [x] `gcloud artifacts docker tags list … --filter=v1.3.2` confirms genuinely new digest `ea09de4`
- [x] `make check` passes locally
- [ ] CI green on this PR

## Post-merge verification

- [ ] ArgoCD `frontend` Application turns green on new revision
- [ ] `kubectl get pod -n frontend -o jsonpath=...` confirms image `v1.3.2`
- [ ] `curl https://liverty-music.app/index.html | grep posthog` returns 2 hits (one per directive)
- [ ] Browser DevTools on https://liverty-music.app/my-artists shows NO CSP violations for posthog hosts
- [ ] PostHog `liverty-music-prod` project Activity: `$pageview` events arriving

Refs: liverty-music/specification#532