### PR TITLE
feat(infra): bump prod frontend image to v1.3.3 (settings layout fix)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.2"
+    app.kubernetes.io/version: "1.3.3"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.2  # commit 5e0b7a7bb17c148358b839a195b8a4ba723b64e5
+  newTag: v1.3.3  # commit 9ad8d33993aad2182bdfc14d56343b7d91811051


### PR DESCRIPTION
## Description

Promote frontend **v1.3.3** to production. Re-pins the prod AR image tag and the `app.kubernetes.io/version` label in lock-step for the `frontend` prod overlay.

v1.3.3 ships the Settings page layout fix: the first preferences card was clipped behind the fixed page header. `main` is re-aligned with the house scroll pattern (`overflow: hidden` shell + inner `.settings-scroll` container) plus CUBE composition cleanup. Frontend-only CSS/HTML.

## Changes

- `k8s/namespaces/frontend/overlays/prod/kustomization.yaml`
  - `images[0].newTag`: `v1.3.2` → `v1.3.3` (commit `9ad8d33`)
  - `app.kubernetes.io/version`: `1.3.2` → `1.3.3`

## Verification

- `kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders cleanly; image resolves to `…/liverty-music-prod/frontend/web-app:v1.3.3` and the version label to `1.3.3`.
- prod AR image `v1.3.3` was published by the frontend release Deploy workflow (`build-and-push: success`).
- (Local `make lint-k8s` couldn't fully run — the unrelated `argocd` helm overlay needs `helm` tooling not installed locally; CI validates with full tooling.)

## Rollout

ArgoCD auto-syncs the prod frontend Application on merge.

## Related

- Release: liverty-music/frontend v1.3.3
- Tracking issue: liverty-music/frontend#390
