### PR TITLE
feat(infra): bump prod backend images v1.3.0 -> v1.3.1 (analytics rename)

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -42,7 +42,7 @@ namespace: backend
 #   on Deployments / CronJobs so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.0"
+    app.kubernetes.io/version: "1.3.1"
   includeSelectors: false
   includeTemplates: true
 
@@ -188,13 +188,13 @@ configMapGenerator:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server
-  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
+  newTag: v1.3.1  # commit b374f39448fb72d963be0dce3a6363c33094101e
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/consumer
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/consumer
-  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
+  newTag: v1.3.1  # commit b374f39448fb72d963be0dce3a6363c33094101e
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/concert-discovery
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/concert-discovery
-  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
+  newTag: v1.3.1  # commit b374f39448fb72d963be0dce3a6363c33094101e
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
-  newTag: v1.3.0  # commit 46201c726be9e1194a8b47376e89d0afe39e70e9
+  newTag: v1.3.1  # commit b374f39448fb72d963be0dce3a6363c33094101e


### PR DESCRIPTION
## Summary

Promotes the analytics-rename release ([backend v1.3.1](https://github.com/liverty-music/backend/releases/tag/v1.3.1) / [PR #321](https://github.com/liverty-music/backend/pull/321)) to prod.

v1.3.1 is a **pure rename release**: NATS stream \`PUSH\` → \`NOTIFICATION\`, subject \`PUSH.subscription_completed\` → \`NOTIFICATION.subscribed\`, and the backend analytics catalogue constants. The underlying Web Push transport surface (\`PushNotificationUseCase\`, \`webpush\` sender, RPC handler) is unchanged.

## Changes

- \`k8s/namespaces/backend/overlays/prod/kustomization.yaml\`
  - \`app.kubernetes.io/version\`: \`1.3.0\` → \`1.3.1\`
  - All four \`images:\` blocks (\`server\`, \`consumer\`, \`concert-discovery\`, \`artist-image-sync\`): \`newTag: v1.3.0\` → \`v1.3.1\` (commit \`b374f39\`)

## Verification

\`kubectl kustomize k8s/namespaces/backend/overlays/prod\` renders all four \`image:\` lines pointing at \`v1.3.1\` and the recommended-label \`app.kubernetes.io/version\` reflects \`1.3.1\`.

## Production-state notes

- The old \`PUSH\` JetStream in prod holds **0 messages** — orphaned by this rename but harmless to leave in place until manual cleanup (\`nats stream rm PUSH\`).
- Stream provisioning is idempotent: the new \`NOTIFICATION\` stream is created by the consumer pod on next startup; no manual seeding.
- No catalogue event has actually fired from the old \`PUSH\` subject in prod (KEDA gap + zero Web Push opt-ins), so no replay needed.

## Coordinated with

- Frontend [v1.3.4](https://github.com/liverty-music/frontend/releases/tag/v1.3.4) — separate prod bump PR follows in this repo once dev AR retag completes.

Refs: liverty-music/specification#532