### PR TITLE
feat(infra): bump prod frontend image v1.3.3 -> v1.3.4 (analytics rename)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.3"
+    app.kubernetes.io/version: "1.3.4"
   includeSelectors: false
   includeTemplates: true
 
@@ -96,4 +96,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.3  # commit 9ad8d33993aad2182bdfc14d56343b7d91811051
+  newTag: v1.3.4  # commit 4f23d58c4d0ab392761388d2c4c6d3bf6a7fed6a


### PR DESCRIPTION
## Summary

Promotes the analytics-rename release ([frontend v1.3.4](https://github.com/liverty-music/frontend/releases/tag/v1.3.4) / [PR #392](https://github.com/liverty-music/frontend/pull/392)) to prod.

v1.3.4 is a **pure rename release**: \`Events.PushSubscriptionRequested\` → \`Events.NotificationRequested\` and the two paired event constants, with wire values rescoped under the notification domain (\`notification.requested\`, \`.opened\`, \`.dismissed\`). The underlying Web Push transport surface (\`notification-prompt\` component, \`push-service\`, service worker) is unchanged.

## Changes

- \`k8s/namespaces/frontend/overlays/prod/kustomization.yaml\`
  - \`app.kubernetes.io/version\`: \`1.3.3\` → \`1.3.4\`
  - \`images:\` block (\`web-app\`): \`newTag: v1.3.3\` → \`v1.3.4\` (commit \`4f23d58\`)

## Verification

\`kubectl kustomize k8s/namespaces/frontend/overlays/prod\` renders the rendered \`image:\` line at \`v1.3.4\` and the recommended-label \`app.kubernetes.io/version\` reflects \`1.3.4\`.

## Production-state notes

- The catalogue event \`push.subscription.requested\` shipped in v1.1.0 but **has never fired in prod** — \`notification-prompt\` only renders for authenticated users who have not yet opted in, and zero users have hit the prompt + clicked Enable since launch. Pure forward-looking rename; no PostHog property migration needed.

## Coordinated with

- Backend [v1.3.1](https://github.com/liverty-music/backend/releases/tag/v1.3.1) — [bump PR #334](https://github.com/liverty-music/cloud-provisioning/pull/334) in this repo.

Refs: liverty-music/specification#532