### PR TITLE
feat(infra): add 6 missing KEDA triggers to consumer-app ScaledObject

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -42,3 +42,51 @@ spec:
       consumer: "USER_created"
       lagThreshold: "1"
       activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "USER"
+      consumer: "USER_preferred_language_updated"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ARTIST"
+      consumer: "ARTIST_followed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ARTIST"
+      consumer: "ARTIST_unfollowed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "NOTIFICATION"
+      consumer: "NOTIFICATION_subscribed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ENTRY"
+      consumer: "ENTRY_zk_proof_verified"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ENTRY"
+      consumer: "ENTRY_zk_proof_rejected"
+      lagThreshold: "1"
+      activationLagThreshold: "0"


### PR DESCRIPTION
## Summary

\`consumer-app\` subscribes to **10 NATS subjects** via watermill (one durable consumer per subject), but KEDA was only watching **4** of them. The remaining 6 had no scaling trigger — messages on those subjects would sit unprocessed in the stream until something else hit one of the watched 4.

This PR adds the 6 missing triggers so KEDA can scale \`consumer-app\` for **any** subscribed subject, not just the original four.

## Triggers added

| Stream | Consumer | Why |
| --- | --- | --- |
| \`USER\` | \`USER_preferred_language_updated\` | locale-change analytics |
| \`ARTIST\` | \`ARTIST_followed\` | follow funnel (paired with FE intent) |
| \`ARTIST\` | \`ARTIST_unfollowed\` | engagement-loss analytics |
| \`NOTIFICATION\` | \`NOTIFICATION_subscribed\` | paired with FE \`notification.requested\` (rename release v1.3.1) |
| \`ENTRY\` | \`ENTRY_zk_proof_verified\` | operations KPI — time-sensitive at venue gates |
| \`ENTRY\` | \`ENTRY_zk_proof_rejected\` | check-in failure analytics |

Combined with the existing 4 triggers (\`CONCERT_discovered\`, \`CONCERT_created\`, \`ARTIST_created\`, \`USER_created\`), KEDA now watches all 10 durable consumers that watermill creates.

## Bootstrap chicken-and-egg

Right now, only the original 4 durable consumers physically exist in prod NATS — the 6 new triggers reference consumers that have not been created yet (\`consumer-app\` has been at \`replicas=0\` since launch, so watermill has never subscribed to those subjects, so the durables were never registered with JetStream).

**This is self-resolving on next scale-up**:

1. A message arrives at one of the existing 4 watched consumers (e.g., a signup hits \`USER.created\`).
2. KEDA scales \`consumer-app\` from 0 → 1.
3. On startup, watermill subscribes to all 10 subjects; JetStream creates the 6 missing durable consumers as a side effect.
4. From then on, all 10 KEDA triggers are useful.

Until then, KEDA's metric queries for the missing 6 consumers return \"consumer not found\" errors, which KEDA treats as \`lag=0\` — no false scaling, no impact on existing triggers.

\`POISON.queue\` is intentionally excluded — it is a dead-letter queue processed only by ops, not part of the normal scale-up loop.

## Verification

\`kubectl kustomize k8s/namespaces/backend/overlays/prod\` renders the \`consumer-app\` ScaledObject with 10 \`nats-jetstream\` triggers. \`make lint-k8s\` clean.

Refs: liverty-music/specification#532