### PR TITLE
feat(ci): automate prod kustomize pin-bump via repository_dispatch

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -1,0 +1,299 @@
+name: Bump Prod Pin
+
+# Automated prod kustomize pin-bump (OpenSpec change `automate-prod-pin-bump`,
+# tracking issue liverty-music/specification#553).
+#
+# Replaces the manual "open a pin-bump PR in cloud-provisioning" gate. After a
+# backend/frontend Release retags the dev-AR digest into prod AR, the release
+# workflow emits a `repository_dispatch` (type `bump-prod-pin`) carrying
+# `{ component, tag, sha }`. This workflow validates the payload, confirms the
+# prod-AR image actually exists (provenance gate), rewrites the prod overlay's
+# `newTag` + `app.kubernetes.io/version` label in lock-step, validates with
+# `kustomize build`, then pushes straight to `main` as `github-actions[bot]`.
+# ArgoCD's existing auto-sync rolls it out. No PR.
+#
+# See docs/runbooks/prod-image-tag-pinning.md for the operator-facing flow,
+# the manual-recovery path, and the `git revert` rollback.
+
+on:
+  # Automated path: emitted by backend `deploy.yml` / frontend
+  # `push-image.yaml` after a successful prod-AR retag. Runs unattended.
+  repository_dispatch:
+    types: [bump-prod-pin]
+  # Manual recovery path for a dropped/lost dispatch. Admin-gated via the
+  # `prod-pin` Environment (see the conditional `environment:` below) so it
+  # cannot be used to force an unreviewed prod change.
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component to bump (backend or frontend)'
+        required: true
+        type: choice
+        options:
+          - backend
+          - frontend
+      tag:
+        description: 'Release tag to pin (vX.Y.Z)'
+        required: true
+        type: string
+      sha:
+        description: 'Source commit SHA (recorded in the inline newTag trailer)'
+        required: true
+        type: string
+
+# Serialize all bumps: a backend and a frontend release can land within
+# seconds of each other. `cancel-in-progress: false` means a queued bump
+# waits for the running one rather than being dropped; the fetch-rebase-retry
+# loop around the push handles the (conflict-free, disjoint-file) interleave.
+concurrency:
+  group: bump-prod-pin
+  cancel-in-progress: false
+
+env:
+  REGION: asia-northeast2
+  PROD_PROJECT_ID: liverty-music-prod
+  # Standing tracking issue for the bump-automation (every bump commit refs it
+  # for provenance — the per-release "why" is the Release itself).
+  TRACKING_ISSUE: liverty-music/specification#553
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # Conditional environment (OpenSpec design D8): the required-reviewer rule
+    # on the `prod-pin` Environment fires for EVERY job that references it
+    # (Environment protection rules have no trigger-type filter). Binding it
+    # unconditionally would also stall the automated `repository_dispatch`
+    # path on admin approval. So bind it ONLY on the manual trigger:
+    #   - workflow_dispatch -> `prod-pin` -> pauses for admin approval
+    #   - repository_dispatch -> '' (empty) -> runs unattended
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'prod-pin' || '' }}
+    permissions:
+      # Push the bump commit to `main` with the built-in token (the
+      # `github-actions[bot]` actor, which branch protection lets bypass).
+      contents: write
+      # Federate to the prod CI service account for the `crane manifest`
+      # provenance check against prod AR.
+      id-token: write
+    steps:
+      # ----------------------------------------------------------------------
+      # 1.2 Parse + validate the payload (from either trigger).
+      # ----------------------------------------------------------------------
+      - name: Resolve and validate payload
+        id: payload
+        env:
+          # repository_dispatch carries client_payload.*; workflow_dispatch
+          # carries inputs.*. Coalesce to a single env var each.
+          COMPONENT: ${{ github.event.client_payload.component || inputs.component }}
+          TAG: ${{ github.event.client_payload.tag || inputs.tag }}
+          SHA: ${{ github.event.client_payload.sha || inputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "Trigger: ${{ github.event_name }}; component=${COMPONENT} tag=${TAG} sha=${SHA}"
+
+          case "${COMPONENT}" in
+            backend|frontend) ;;
+            *)
+              echo "::error::Invalid component '${COMPONENT}' — must be 'backend' or 'frontend'."
+              exit 1
+              ;;
+          esac
+
+          if ! echo "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid tag '${TAG}' — must match ^v[0-9]+\.[0-9]+\.[0-9]+$ (e.g. v1.4.0)."
+            exit 1
+          fi
+
+          if [ -z "${SHA}" ]; then
+            echo "::error::Empty sha — the source commit SHA is required for the inline newTag trailer."
+            exit 1
+          fi
+
+          # Bare semver (no leading `v`) for the app.kubernetes.io/version label.
+          BARE="${TAG#v}"
+
+          {
+            echo "component=${COMPONENT}"
+            echo "tag=${TAG}"
+            echo "sha=${SHA}"
+            echo "bare=${BARE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history + token retained so the fetch-rebase-retry push loop
+          # can rebase on a concurrent bump and push back to main.
+          fetch-depth: 0
+          persist-credentials: true
+
+      # ----------------------------------------------------------------------
+      # 1.2a Provenance gate — fail-closed BEFORE any edit. The prod-AR image
+      # at `:<tag>` exists only if the release retag actually wrote it, so this
+      # one check simultaneously confirms the tag names a genuine release, that
+      # this component's retag completed, and rejects the silent-downgrade and
+      # bogus-tag paths. Applies to both triggers.
+      # ----------------------------------------------------------------------
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          # Repository-level vars (not environment-scoped) so they resolve on
+          # the empty-environment `repository_dispatch` path. Provisioned by
+          # Pulumi on the prod stack — see cloud-provisioning/src/github/.
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for prod AR
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      # SHA-pinned: this action installs `crane`, which here runs with prod-AR
+      # read credentials. SHA of v0.4 matches the backend/frontend release
+      # workflows' pinning.
+      - name: Install crane
+        uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e # v0.4
+
+      - name: Verify prod-AR image provenance
+        id: provenance
+        env:
+          COMPONENT: ${{ steps.payload.outputs.component }}
+          TAG: ${{ steps.payload.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "${COMPONENT}" = "backend" ]; then
+            images="server consumer concert-discovery artist-image-sync"
+          else
+            images="web-app"
+          fi
+          base="${REGION}-docker.pkg.dev/${PROD_PROJECT_ID}/${COMPONENT}"
+          for img in ${images}; do
+            ref="${base}/${img}:${TAG}"
+            echo "Checking provenance: ${ref}"
+            if ! crane manifest "${ref}" > /dev/null 2>crane_err.txt; then
+              echo "::error::Provenance gate FAILED — prod-AR image not found: ${ref}. The release retag for '${COMPONENT}' has not produced this tag (or it was removed). Refusing to pin a non-existent image. crane stderr: $(cat crane_err.txt)"
+              exit 1
+            fi
+          done
+          echo "All ${COMPONENT} images exist in prod AR at ${TAG}."
+
+      # ----------------------------------------------------------------------
+      # 1.4 Idempotency guard — if every target newTag already equals the
+      # release tag, exit 0 without committing (handles dispatch redelivery /
+      # manual re-run).
+      # ----------------------------------------------------------------------
+      - name: Idempotency check
+        id: idem
+        env:
+          COMPONENT: ${{ steps.payload.outputs.component }}
+          TAG: ${{ steps.payload.outputs.tag }}
+        run: |
+          set -euo pipefail
+          file="k8s/namespaces/${COMPONENT}/overlays/prod/kustomization.yaml"
+          # Distinct set of current newTag values across all image entries.
+          current="$(yq '.images[].newTag' "$file" | sort -u)"
+          if [ "${current}" = "${TAG}" ]; then
+            echo "All newTag values already equal ${TAG}; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ----------------------------------------------------------------------
+      # 1.3 yq edit — rewrite every images[].newTag + its inline `# commit
+      # <sha>` trailer and the app.kubernetes.io/version label, in lock-step.
+      # ----------------------------------------------------------------------
+      - name: Edit prod overlay
+        if: steps.idem.outputs.skip != 'true'
+        env:
+          COMPONENT: ${{ steps.payload.outputs.component }}
+          TAG: ${{ steps.payload.outputs.tag }}
+          SHA: ${{ steps.payload.outputs.sha }}
+          BARE: ${{ steps.payload.outputs.bare }}
+        run: |
+          set -euo pipefail
+          file="k8s/namespaces/${COMPONENT}/overlays/prod/kustomization.yaml"
+          # newTag for every image entry (4 for backend, 1 for frontend).
+          TAG="${TAG}" yq -i '.images[].newTag = strenv(TAG)' "$file"
+          # Inline source-commit trailer after each newTag.
+          COMMENT="commit ${SHA}" yq -i '.images[].newTag line_comment = strenv(COMMENT)' "$file"
+          # Bare-semver version label (single labels entry holds the pair).
+          BARE="${BARE}" yq -i '(.labels[].pairs."app.kubernetes.io/version") = strenv(BARE)' "$file"
+          echo "----- edited ${file} -----"
+          yq '{"images": .images, "labels": .labels}' "$file"
+
+      # ----------------------------------------------------------------------
+      # 1.5 Validation gate — `kustomize build` the edited overlay. A non-zero
+      # build aborts before push, keeping `main` always-syncable. (No helmCharts
+      # in the backend/frontend bases, so plain build suffices.)
+      # ----------------------------------------------------------------------
+      - name: Install Kustomize
+        if: steps.idem.outputs.skip != 'true'
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Validate overlay renders
+        if: steps.idem.outputs.skip != 'true'
+        env:
+          COMPONENT: ${{ steps.payload.outputs.component }}
+        run: |
+          set -euo pipefail
+          kustomize build "k8s/namespaces/${COMPONENT}/overlays/prod" > /dev/null
+          echo "kustomize build of the ${COMPONENT} prod overlay succeeded."
+
+      # ----------------------------------------------------------------------
+      # 1.6 + 1.7 Commit as github-actions[bot] and push to main with a
+      # fetch-rebase-retry loop (≤5 attempts). No PR.
+      # ----------------------------------------------------------------------
+      - name: Commit and push to main
+        if: steps.idem.outputs.skip != 'true'
+        env:
+          COMPONENT: ${{ steps.payload.outputs.component }}
+          TAG: ${{ steps.payload.outputs.tag }}
+          SHA: ${{ steps.payload.outputs.sha }}
+          BARE: ${{ steps.payload.outputs.bare }}
+        run: |
+          set -euo pipefail
+          file="k8s/namespaces/${COMPONENT}/overlays/prod/kustomization.yaml"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Defensive: if no net diff (e.g. label/comment already matched),
+          # skip the commit rather than create an empty one.
+          if git diff --quiet -- "$file"; then
+            echo "No net change after edit; skipping commit."
+            exit 0
+          fi
+
+          git add "$file"
+          # Build the commit message in a file to avoid heredoc indentation
+          # leaking YAML/shell indent into the body.
+          {
+            printf 'feat(prod): pin %s prod overlay to %s\n\n' "${COMPONENT}" "${TAG}"
+            printf 'Automated prod kustomize pin-bump: a %s Release (%s) retagged its\n' "${COMPONENT}" "${TAG}"
+            printf 'dev-AR digest into prod AR, so this moves the prod overlay image pin\n'
+            printf 'and app.kubernetes.io/version label to that release in lock-step.\n'
+            printf 'ArgoCD auto-syncs the rollout. Replaces the former manual pin-bump PR\n'
+            printf '(OpenSpec change automate-prod-pin-bump).\n\n'
+            printf 'component: %s\n' "${COMPONENT}"
+            printf 'tag: %s\n' "${TAG}"
+            printf 'version label: %s\n' "${BARE}"
+            printf 'source sha: %s\n\n' "${SHA}"
+            printf 'Refs: %s\n' "${TRACKING_ISSUE}"
+          } > /tmp/bump-commit-msg.txt
+          git commit -F /tmp/bump-commit-msg.txt
+
+          # Fetch-rebase-retry: a concurrent bump touches a DIFFERENT overlay
+          # file, so the rebase is conflict-free; the retry simply re-applies
+          # this commit on top of the other's. ≤5 attempts.
+          for attempt in $(seq 1 5); do
+            if git push origin HEAD:main; then
+              echo "Pushed on attempt ${attempt}/5."
+              exit 0
+            fi
+            echo "Push rejected on attempt ${attempt}/5; fetching + rebasing onto origin/main..."
+            git fetch origin main
+            git rebase origin/main
+          done
+          echo "::error::Failed to push the pin-bump to main after 5 rebase-retry attempts."
+          exit 1

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -24,44 +24,47 @@ See `openspec/changes/archive/<date>-enable-prod-ar-immutable-tags/design.md` de
 
 ## Operator workflow: cutting a release
 
+As of OpenSpec change `automate-prod-pin-bump` (tracking issue
+liverty-music/specification#553), the prod pin-bump is **fully automated**.
+Cutting the GitHub Release is the only human action; there is no longer a
+manual pin-bump PR. The chain is:
+
+```
+GH Release (backend/frontend)
+  → release workflow retags dev-AR digest → prod AR (:vX.Y.Z + :<sha>)
+  → release workflow emits repository_dispatch (bump-prod-pin) → cloud-provisioning
+  → bump-prod-pin.yml: validate payload → provenance gate (crane manifest)
+                       → yq edit newTag + version label → kustomize build
+                       → commit + push to main as github-actions[bot]
+  → ArgoCD auto-syncs the prod overlay → Pods roll
+```
+
 ### 1. Build + publish prod image (in `liverty-music/backend` or `liverty-music/frontend`)
 
 1. Merge release-bound PRs to `main`.
 2. From the GitHub UI: **Releases → Draft a new release → Tag = `v1.0.1`** (next patch) → Publish.
-3. GitHub Actions (`deploy.yml` for backend, `push-image.yaml` for frontend) fires on the `release: published` event:
+3. The release workflow (`deploy.yml` for backend, `push-image.yaml` for frontend) fires on `release: published`:
    - Authenticates to prod via Workload Identity Federation (`github-actions@liverty-music-prod.iam`).
-   - Builds the image.
-   - Pushes with **two tags**: `:v1.0.1` and `:<commit-sha>`.
-4. Wait for both pushes to succeed. Verify via:
-   ```bash
-   gcloud artifacts docker images list \
-     asia-northeast2-docker.pkg.dev/liverty-music-prod/backend \
-     --include-tags --filter='package~server' --limit=5
-   ```
-   The new digest SHOULD appear with both `:v1.0.1` and the SHA as tags.
+   - Retags the dev-AR digest for `github.sha` into prod AR under `:v1.0.1` and `:<commit-sha>` (`crane copy`, no rebuild).
+   - On retag success, the `dispatch-prod-pin` job emits a `repository_dispatch` (`event_type: bump-prod-pin`, `client_payload: { component, tag, sha }`) to `cloud-provisioning` via a short-lived GitHub App token.
+   - For the backend 4-image matrix, the dispatch is gated on **all 4** entries succeeding (`needs.build-and-push.result == 'success'` with `fail-fast: false`), so a partial retag never bumps the pin.
 
-### 2. Bump the prod kustomize overlay (in `liverty-music/cloud-provisioning`)
+### 2. Automated pin-bump (no manual action)
 
-1. Open a PR on `cloud-provisioning` updating both:
-   - `k8s/namespaces/backend/overlays/prod/kustomization.yaml` — bump `newTag: v1.0.0` → `newTag: v1.0.1` for all four backend images, AND bump the corresponding inline comment SHA. Also bump the `labels:` block's `app.kubernetes.io/version: "1.0.1"`.
-   - `k8s/namespaces/frontend/overlays/prod/kustomization.yaml` — bump `newTag:` + comment + `app.kubernetes.io/version` for `web-app` if frontend was part of the release.
+`bump-prod-pin.yml` in `cloud-provisioning` receives the dispatch and, for the named component:
 
-   ⚠️ **`v`-prefix gotcha**: `newTag:` SHALL use the `v` prefix (`v1.0.1`) because that's the AR-side tag convention. `app.kubernetes.io/version:` SHALL be the bare semver (`"1.0.1"`, no `v`) because that's the Kubernetes Recommended Labels convention. Two different conventions in two adjacent fields of the same overlay — common bump-time mistake. The verification step below catches it.
+1. Validates the payload (`component ∈ {backend, frontend}`, `tag` matches `^v[0-9]+\.[0-9]+\.[0-9]+$`).
+2. **Provenance gate** — `crane manifest` every prod-AR image at `:tag` (4 for backend, 1 for frontend). A missing image **aborts before any edit** (fail-closed), rejecting bogus/stale tags and the silent-downgrade path.
+3. Idempotency — if every `newTag` already equals `tag`, exits 0 without committing.
+4. `yq` edit — rewrites every `images[].newTag` + its inline `# commit <sha>` trailer and the `app.kubernetes.io/version` label (bare semver, no `v`) in lock-step. The two-conventions `v`-prefix gotcha is handled in code: `newTag` keeps the `v`, the label strips it.
+5. `kustomize build` of the edited prod overlay — a non-zero build **aborts before push** (replaces the CI gate the manual PR provided).
+6. Commits as `github-actions[bot]` and pushes straight to `main` (fetch-rebase-retry, ≤5 attempts; `concurrency` serialized). No PR.
 
-2. Run locally before pushing:
-   ```bash
-   # Check every rendered image carries the new semver tag
-   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E 'image:.*:v[0-9]+\.[0-9]+\.[0-9]+'
-
-   # Check every label has a bare-semver value (no `v` prefix slip)
-   kubectl kustomize k8s/namespaces/backend/overlays/prod | grep -E 'app\.kubernetes\.io/version: "?v' && echo "FAIL: v-prefix in label value" || echo "OK: label values are bare semver"
-   ```
-   Confirm every rendered image carries `:v1.0.1` and every label is `app.kubernetes.io/version: "1.0.1"` (no `"v1.0.1"`).
-3. Open PR, get review, merge.
+To watch it: `gh run list --repo liverty-music/cloud-provisioning --workflow bump-prod-pin.yml --limit 5`.
 
 ### 3. ArgoCD reconciles
 
-ArgoCD detects the cloud-provisioning `main` change and rolls the prod Deployments / CronJobs with the new `image:` reference and `app.kubernetes.io/version` label. Pods restart; image bytes resolve via the AR tag → digest lookup.
+ArgoCD detects the `cloud-provisioning:main` bump commit and rolls the prod Deployments / CronJobs with the new `image:` reference and `app.kubernetes.io/version` label. Pods restart; image bytes resolve via the AR tag → digest lookup.
 
 ### 4. Verify
 
@@ -70,7 +73,45 @@ kubectl --context=gke_liverty-music-prod_asia-northeast2_autopilot-cluster-osaka
     -n backend get deploy,cronjob -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[*].image}{"\n"}{end}'
 ```
 
-All images SHALL end with `:v1.0.1`.
+All images SHALL end with `:v1.0.1`. For frontend, also run the prod smoke:
+`gh workflow run push-image.yaml --repo liverty-music/frontend -f smoke_url=https://liverty-music.app`.
+
+## Manual recovery: `workflow_dispatch` fallback (admin-only)
+
+If a dispatch is dropped (e.g. a transient GitHub outage between the release
+workflow and `cloud-provisioning`), the bump never lands. Recover by running
+`bump-prod-pin.yml` manually with the same payload:
+
+```bash
+gh workflow run bump-prod-pin.yml --repo liverty-music/cloud-provisioning \
+  -f component=backend -f tag=v1.0.1 -f sha=<release-commit-sha>
+```
+
+This path is **admin-gated**: `workflow_dispatch` runs bind the `prod-pin`
+GitHub Environment (via the conditional `environment:` expression), which has a
+required-reviewer rule, so the run pauses for admin approval before the bump
+executes. The automated `repository_dispatch` path resolves the environment to
+empty and runs unattended. The provenance gate applies identically, so even an
+approved manual run cannot pin a tag whose prod image does not exist.
+
+This is a privileged recovery operation, **not** a routine path — use it only
+to replay a genuinely-dropped dispatch.
+
+## Rollback (`git revert`)
+
+To roll prod back to the prior version, `git revert` the bump commit on
+`cloud-provisioning:main`:
+
+```bash
+git -C cloud-provisioning revert <bump-commit-sha>   # restores the prior newTag + label
+git -C cloud-provisioning push origin main           # (requires the human up-to-date/PR path)
+```
+
+The prior version's tag is already in prod AR (immutable, locked), so ArgoCD
+re-syncs to the locked prior digest with no registry-side action. Note that a
+human revert push obeys branch protection (PR + up-to-date), unlike the bot's
+bypass — so open a one-line revert PR if pushing as a human. See also the
+"Rollback to a prior version" subsection below.
 
 ## AR rejection behavior
 
@@ -90,6 +131,83 @@ unexpected http response 409: ... tag already exists in immutable repository ...
 ```
 
 This is **expected and desired** when the policy is working. A 409 on a tag push attempt means "this tag is already locked at the current digest; you cannot silently overwrite it".
+
+## Automation setup (one-time)
+
+The `automate-prod-pin-bump` pipeline depends on four pieces of GitHub
+configuration. The Pulumi-managed pieces live in `src/github/` and apply on a
+prod `pulumi up`; the rest are documented here because they require an
+out-of-band credential or a setting GitHub does not expose to this provider
+version.
+
+### 1. Cross-repo dispatch credential (GitHub App) — backend + frontend
+
+The release workflows trigger `repository_dispatch` against `cloud-provisioning`
+with a **GitHub App installation token** (short-lived, auditable) rather than a
+long-lived PAT. The `POST /repos/{owner}/{repo}/dispatches` API requires
+`Contents: write` (no narrower scope exists), so the security boundary is NOT
+the token scope — it is branch protection (see §2): the token cannot push to
+`cloud-provisioning:main` because only `github-actions[bot]` bypasses, so its
+reach is limited to non-`main` refs ArgoCD does not track.
+
+One-time setup:
+1. Create a GitHub App in the `liverty-music` org (Settings → Developer settings
+   → GitHub Apps → New). Permissions: **Repository → Contents: Read and write**
+   (the documented minimum for the dispatches API). No webhook needed.
+2. Install it on **`cloud-provisioning` only** (scope the installation).
+3. Generate a private key; note the App ID.
+4. Store the App ID and private key in Pulumi ESC so they are wired as the
+   backend + frontend `prod` environment secrets `PROD_PIN_DISPATCH_APP_ID` /
+   `PROD_PIN_DISPATCH_APP_PRIVATE_KEY` (consumed by the `dispatch-prod-pin` job
+   via `actions/create-github-app-token`):
+   ```bash
+   esc env set liverty-music/prod pulumiConfig.github.prodPinDispatchAppId "<app-id>"
+   esc env set liverty-music/prod pulumiConfig.github.prodPinDispatchAppPrivateKey "$(cat app-private-key.pem)" --secret
+   ```
+   Then run a prod `pulumi up`; `GitHubRepositoryComponent` creates the two
+   environment secrets on backend + frontend (no-op if the config is absent).
+5. **Verify the reach is bounded**: confirm a token minted by this App CANNOT
+   push to `cloud-provisioning:main` (branch protection denies it) — only its
+   `repository_dispatch` trigger should succeed.
+
+### 2. `cloud-provisioning:main` branch-protection bypass for the bot
+
+`bump-prod-pin.yml` pushes the validated bump straight to `main` as
+`github-actions[bot]` using the built-in `GITHUB_TOKEN`. For that push to be
+accepted, `github-actions[bot]` MUST be a **bypass actor** on the `main`
+protection, covering BOTH the pull-request requirement AND the "require branches
+up to date" check.
+
+This is **IaC-managed** in `src/github/components/repository.ts`: for
+cloud-provisioning prod, the `main` protection is expressed as a
+`github.RepositoryRuleset` (not the classic `github.BranchProtection`) with the
+GitHub Actions integration (`slug: github-actions`, resolved via the
+`getGithubApp` data source) as an `always` **bypass actor**. Classic branch
+protection has no per-actor bypass for the strict (up-to-date) status check —
+only a ruleset `bypassActors` entry can grant it — which is why
+cloud-provisioning's protection uses a ruleset while the other repos stay on
+classic `BranchProtection`. The ruleset replicates the prior rules (PR required,
+0 approvals; strict `CI Success`; no force-push; no deletion) and applies to
+everyone except the single Actions-app bypass actor; **no human and no PAT** is
+added.
+
+> **Migration note.** A prod `pulumi up` will **delete** the classic
+> `cloud-provisioning-protection` `BranchProtection` and **create** the
+> `cloud-provisioning-main-ruleset`. Review the `pulumi preview` diff before
+> applying; the swap is a replace, so `main` is briefly governed by whichever
+> of the two exists during the apply — apply attended.
+
+Verify after apply: a bot push from `bump-prod-pin.yml` lands on `main` without
+a PR; a human direct push to `main` is still rejected (PR + up-to-date required).
+
+### 3. `prod-pin` GitHub Environment (admin reviewer) — cloud-provisioning
+
+The `workflow_dispatch` manual fallback is gated behind the `prod-pin`
+Environment with a required-reviewer (admin) rule, bound **only** on the manual
+trigger via the conditional `environment:` expression in `bump-prod-pin.yml`.
+This Environment is Pulumi-managed in `src/github/` (created on the prod stack);
+the required reviewer is the org admin. Verify by test: a `workflow_dispatch`
+run pauses for approval; a `repository_dispatch` run does NOT.
 
 ## Recovery procedures
 

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -182,9 +182,14 @@ configMapGenerator:
 # dev-AR `:latest` reference dynamically. Prod uses explicit semver
 # pinning; dev AR repos stay mutable so Image Updater can rewrite tags.
 #
-# Bumping on release: cut a new GH Release (e.g., v1.0.1) on backend.
-# GHA pushes both `:v1.0.1` and `:<new-sha>` to prod AR. Open a PR here
-# updating `newTag:` + comment for all four entries to the new values.
+# Bumping on release: this block is now CI-written, not hand-edited.
+# Cutting a GH Release (e.g., v1.0.1) on backend retags the dev-AR digest
+# into prod AR, then emits a `repository_dispatch` to this repo's
+# `.github/workflows/bump-prod-pin.yml`, which rewrites all four `newTag:`
+# + their inline `# commit <sha>` trailers AND the `app.kubernetes.io/version`
+# label above (in lock-step) and pushes straight to main. ArgoCD auto-syncs.
+# No manual pin-bump PR. See docs/runbooks/prod-image-tag-pinning.md
+# (OpenSpec change automate-prod-pin-bump).
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/server
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/server

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -90,9 +90,14 @@ patches:
 # the dev-AR `:latest` reference dynamically. Prod uses explicit semver
 # pinning; dev AR repos stay mutable so Image Updater can rewrite tags.
 #
-# Bumping on release: cut a new GH Release (e.g., v1.0.1) on frontend.
-# GHA pushes both `:v1.0.1` and `:<new-sha>` to prod AR. Open a PR here
-# updating `newTag:` + comment to the new values.
+# Bumping on release: this block is now CI-written, not hand-edited.
+# Cutting a GH Release (e.g., v1.0.1) on frontend retags the dev-AR digest
+# into prod AR, then emits a `repository_dispatch` to this repo's
+# `.github/workflows/bump-prod-pin.yml`, which rewrites the `web-app`
+# `newTag:` + its inline `# commit <sha>` trailer AND the
+# `app.kubernetes.io/version` label above (in lock-step) and pushes straight
+# to main. ArgoCD auto-syncs. No manual pin-bump PR. See
+# docs/runbooks/prod-image-tag-pinning.md (OpenSpec change automate-prod-pin-bump).
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app

--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -17,6 +17,34 @@ export interface GitHubRepositoryComponentArgs {
 	 * (e.g., Pulumi removing resources added by a recently merged PR).
 	 */
 	requireUpToDateBranch?: boolean
+	/**
+	 * Repository-level Actions variables (not environment-scoped). Used by
+	 * workflows that run without an `environment:` binding — e.g.
+	 * `bump-prod-pin.yml`'s `repository_dispatch` path, whose conditional
+	 * environment resolves to empty, so it cannot read environment variables.
+	 * See OpenSpec change `automate-prod-pin-bump`.
+	 */
+	repositoryVariables?: Record<string, pulumi.Input<string>>
+	/**
+	 * When set, create a `prod-pin` GitHub Environment whose required reviewer
+	 * is this GitHub username (admin). Gates the `bump-prod-pin.yml`
+	 * `workflow_dispatch` manual-recovery path behind admin approval; the
+	 * automated `repository_dispatch` path does not enter the environment.
+	 * See OpenSpec change `automate-prod-pin-bump` design D8.
+	 */
+	pinBumpReviewerUsername?: string
+	/**
+	 * When true, the prod `main` protection is expressed as a
+	 * `github.RepositoryRuleset` (replacing the classic `BranchProtection`)
+	 * with the GitHub Actions integration as an `always` bypass actor. This is
+	 * the only mechanism that lets `github-actions[bot]` push the automated
+	 * pin-bump straight to `main` past BOTH the PR requirement AND the
+	 * strict "up-to-date" status check (classic protection cannot bypass the
+	 * strict check per-actor). See OpenSpec change `automate-prod-pin-bump`
+	 * D8 / spec "cloud-provisioning branch protection SHALL allow the bot to
+	 * bypass". The bypass is scoped to the Actions app only — no human/PAT.
+	 */
+	mainBranchBotBypass?: boolean
 }
 
 export class GitHubRepositoryComponent extends pulumi.ComponentResource {
@@ -44,6 +72,9 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 			secrets,
 			requiredStatusCheckContexts,
 			requireUpToDateBranch,
+			repositoryVariables,
+			pinBumpReviewerUsername,
+			mainBranchBotBypass,
 		} = args
 
 		// Use a new provider instance to ensure we can use it in any stack
@@ -147,60 +178,185 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 			}
 		}
 
+		// Repository-level Actions variables (not environment-scoped). The
+		// `bump-prod-pin.yml` workflow's `repository_dispatch` path runs with an
+		// empty `environment:`, so it reads the prod WIF provider + SA from here
+		// rather than from environment variables.
+		if (repositoryVariables) {
+			for (const [key, value] of Object.entries(repositoryVariables)) {
+				new github.ActionsVariable(
+					`${repositoryName}-repo-var-${key}`,
+					{
+						repository: repositoryName,
+						variableName: key,
+						value: value,
+					},
+					{ provider, parent: this },
+				)
+			}
+		}
+
+		// `prod-pin` Environment with a required-reviewer (admin) rule. Gates
+		// the `bump-prod-pin.yml` manual `workflow_dispatch` recovery path; the
+		// automated `repository_dispatch` path resolves the environment to empty
+		// and never enters it (OpenSpec change `automate-prod-pin-bump` D8).
+		if (pinBumpReviewerUsername) {
+			const reviewer = github.getUserOutput(
+				{ username: pinBumpReviewerUsername },
+				{ provider },
+			)
+			new github.RepositoryEnvironment(
+				`${repositoryName}-prod-pin`,
+				{
+					repository: repositoryName,
+					environment: 'prod-pin',
+					reviewers: [
+						{
+							// `github_user.id` is the numeric user ID as a string;
+							// the reviewers API expects a number.
+							users: [reviewer.id.apply((id) => Number(id))],
+						},
+					],
+				},
+				{ provider, parent: this },
+			)
+		}
+
 		this.registerOutputs({
 			environment: this.environment,
 			variables: this.variables,
 			secrets: this.secrets,
 		})
 
-		// Apply Branch Protection (Prod Only to avoid stack conflicts)
+		// Apply main-branch protection (Prod Only to avoid stack conflicts).
 		if (environment === 'prod') {
-			new github.BranchProtection(
-				`${repositoryName}-protection`,
-				{
-					repositoryId: repositoryName,
-					pattern: 'main',
-					enforceAdmins: true,
-					allowsDeletions: false,
-					allowsForcePushes: false,
-					requiredLinearHistory: false,
-					requireConversationResolution: false,
-					// Require status checks to pass before merging (if specified)
-					// Note: Gemini Review is intentionally excluded from all repositories
-					...(requiredStatusCheckContexts &&
-					requiredStatusCheckContexts.length > 0
-						? {
-								requiredStatusChecks: [
-									{
-										strict: requireUpToDateBranch ?? false,
-										contexts: requiredStatusCheckContexts,
-									},
-								],
-							}
-						: requireUpToDateBranch
+			if (mainBranchBotBypass) {
+				// Ruleset form (automate-prod-pin-bump): `bump-prod-pin.yml` pushes
+				// the prod pin-bump straight to `cloud-provisioning:main` as
+				// `github-actions[bot]`, which needs a bypass for BOTH the PR
+				// requirement AND the strict "up-to-date" status check. Classic
+				// `BranchProtection` has no per-actor bypass for the strict check —
+				// only a `RepositoryRuleset` `bypassActors` entry can grant it. We
+				// therefore express the protection as a ruleset (it replaces the
+				// classic protection rather than stacking with it: the two are
+				// evaluated together, so leaving classic protection in place would
+				// still block the bot). The bypass is scoped to the GitHub Actions
+				// integration only — no human, no PAT (spec: "cloud-provisioning
+				// branch protection SHALL allow the bot to bypass").
+				//
+				// The Actions app id (slug `github-actions`) is resolved via the
+				// provider data source rather than hardcoded, so the bypass actor
+				// stays correct without a magic number. `actorId` is a number; the
+				// data source returns the id as a string.
+				const actionsApp = github.getGithubAppOutput(
+					{ slug: 'github-actions' },
+					{ provider },
+				)
+				new github.RepositoryRuleset(
+					`${repositoryName}-main-ruleset`,
+					{
+						name: `${repositoryName}-main`,
+						repository: repositoryName,
+						target: 'branch',
+						enforcement: 'active',
+						conditions: {
+							refName: {
+								includes: ['~DEFAULT_BRANCH'],
+								excludes: [],
+							},
+						},
+						bypassActors: [
+							{
+								actorId: actionsApp.id.apply((id) =>
+									Number(id),
+								),
+								actorType: 'Integration',
+								// `always`: bypass on direct pushes too, not just PRs —
+								// the bot pushes the bump directly, no PR.
+								bypassMode: 'always',
+							},
+						],
+						rules: {
+							// Require PRs to merge (blocks direct pushes for non-bypass
+							// actors); 0 approvals mirrors the classic config.
+							pullRequest: {
+								requiredApprovingReviewCount: 0,
+								dismissStaleReviewsOnPush: false,
+								requireCodeOwnerReview: false,
+								requireLastPushApproval: false,
+							},
+							// Block force-push and deletion (classic: allowsForcePushes
+							// / allowsDeletions = false).
+							nonFastForward: true,
+							deletion: true,
+							// Strict "require branches up to date" status check.
+							...(requiredStatusCheckContexts &&
+							requiredStatusCheckContexts.length > 0
+								? {
+										requiredStatusChecks: {
+											requiredChecks:
+												requiredStatusCheckContexts.map(
+													(context) => ({ context }),
+												),
+											strictRequiredStatusChecksPolicy:
+												requireUpToDateBranch ?? false,
+										},
+									}
+								: {}),
+						},
+					},
+					{ provider, parent: this },
+				)
+			} else {
+				new github.BranchProtection(
+					`${repositoryName}-protection`,
+					{
+						repositoryId: repositoryName,
+						pattern: 'main',
+						enforceAdmins: true,
+						allowsDeletions: false,
+						allowsForcePushes: false,
+						requiredLinearHistory: false,
+						requireConversationResolution: false,
+						// Require status checks to pass before merging (if specified)
+						// Note: Gemini Review is intentionally excluded from all repositories
+						...(requiredStatusCheckContexts &&
+						requiredStatusCheckContexts.length > 0
 							? {
 									requiredStatusChecks: [
 										{
-											strict: true,
-											contexts: [],
+											strict:
+												requireUpToDateBranch ?? false,
+											contexts:
+												requiredStatusCheckContexts,
 										},
 									],
 								}
-							: {}),
-					// Require pull requests before merging (blocks direct pushes)
-					requiredPullRequestReviews: [
-						{
-							dismissStaleReviews: false,
-							restrictDismissals: false,
-							requiredApprovingReviewCount: 0,
-							requireCodeOwnerReviews: false,
-						},
-					],
-					// Block direct pushes to main branch (empty array = no one can push directly)
-					restrictPushes: [],
-				},
-				{ provider, parent: this },
-			)
+							: requireUpToDateBranch
+								? {
+										requiredStatusChecks: [
+											{
+												strict: true,
+												contexts: [],
+											},
+										],
+									}
+								: {}),
+						// Require pull requests before merging (blocks direct pushes)
+						requiredPullRequestReviews: [
+							{
+								dismissStaleReviews: false,
+								restrictDismissals: false,
+								requiredApprovingReviewCount: 0,
+								requireCodeOwnerReviews: false,
+							},
+						],
+						// Block direct pushes to main branch (empty array = no one can push directly)
+						restrictPushes: [],
+					},
+					{ provider, parent: this },
+				)
+			}
 		}
 	}
 }

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -5,6 +5,15 @@ export interface GitHubConfig {
 	geminiApiKey?: string
 	anthropicApiKey?: string
 	claudeCodeOauthToken?: string
+	// GitHub App credential used by the backend/frontend release workflows to
+	// trigger the cross-repo `bump-prod-pin` `repository_dispatch`. Wired as
+	// the `PROD_PIN_DISPATCH_APP_ID` / `PROD_PIN_DISPATCH_APP_PRIVATE_KEY`
+	// secrets on the backend + frontend `prod` environments. Optional: when
+	// unset (e.g. dev stack, or before the App is created) no secret is
+	// provisioned. See OpenSpec change `automate-prod-pin-bump` and
+	// docs/runbooks/prod-image-tag-pinning.md "Automation setup".
+	prodPinDispatchAppId?: string
+	prodPinDispatchAppPrivateKey?: string
 }
 
 export interface BufConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,25 @@ const sharedVariables = {
 	SERVICE_ACCOUNT: gcp.githubActionsSAEmail,
 }
 
+// Cross-repo dispatch credential (GitHub App) for the `automate-prod-pin-bump`
+// release path. Wired onto the backend + frontend `prod` environments so the
+// `dispatch-prod-pin` job can mint an installation token (scoped to
+// cloud-provisioning) and POST the `bump-prod-pin` `repository_dispatch`.
+// Prod-only and optional: absent until the App is created and its credential
+// is set in ESC (`pulumiConfig.github.prodPinDispatchAppId` /
+// `...PrivateKey`). See docs/runbooks/prod-image-tag-pinning.md "Automation
+// setup" §1.
+const prodPinDispatchSecrets =
+	env === 'prod' &&
+	githubConfig.prodPinDispatchAppId &&
+	githubConfig.prodPinDispatchAppPrivateKey
+		? {
+				PROD_PIN_DISPATCH_APP_ID: githubConfig.prodPinDispatchAppId,
+				PROD_PIN_DISPATCH_APP_PRIVATE_KEY:
+					githubConfig.prodPinDispatchAppPrivateKey,
+			}
+		: undefined
+
 // Backend Repository
 new GitHubRepositoryComponent({
 	brandId,
@@ -217,6 +236,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.BACKEND,
 	environment: env,
 	variables: sharedVariables,
+	secrets: prodPinDispatchSecrets,
 	requiredStatusCheckContexts: ['CI Success'],
 })
 
@@ -227,6 +247,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.FRONTEND,
 	environment: env,
 	variables: sharedVariables,
+	secrets: prodPinDispatchSecrets,
 	requiredStatusCheckContexts: ['CI Success'],
 })
 
@@ -249,6 +270,25 @@ new GitHubRepositoryComponent({
 	variables: sharedVariables,
 	requiredStatusCheckContexts: ['CI Success'],
 	requireUpToDateBranch: true,
+	// Prod-only (repo-level vars are repo-global, so only one stack may own
+	// them): the `bump-prod-pin.yml` `repository_dispatch` path runs with an
+	// empty `environment:` and reads the prod WIF provider + SA from these
+	// repository-level variables to authenticate `crane` for the provenance
+	// gate against prod AR.
+	repositoryVariables:
+		env === 'prod'
+			? {
+					WORKLOAD_IDENTITY_PROVIDER:
+						gcp.githubWorkloadIdentityProvider,
+					SERVICE_ACCOUNT: gcp.githubActionsSAEmail,
+				}
+			: undefined,
+	// Admin-reviewer gate for the `bump-prod-pin.yml` manual recovery path.
+	pinBumpReviewerUsername: env === 'prod' ? 'pannpers' : undefined,
+	// Express prod `main` protection as a ruleset so `github-actions[bot]` can
+	// bypass it to push the automated pin-bump (the only mechanism that bypasses
+	// the strict up-to-date check). Bypass scoped to the Actions app only.
+	mainBranchBotBypass: true,
 })
 
 // Export common resources


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553 (kept open — operational verification still pending; do not auto-close)

## 📝 Summary of Changes
Automates the prod kustomize pin-bump, removing the manual pin-bump PR from the prod rollout path. A backend/frontend Release retags into prod AR and emits a `bump-prod-pin` `repository_dispatch`; this repo now reacts to it.

- **New `.github/workflows/bump-prod-pin.yml`**: validates the `{component,tag,sha}` payload → fail-closed `crane manifest` provenance gate against prod AR → idempotency guard → `yq` rewrite of `images[].newTag` + `# commit <sha>` trailers + `app.kubernetes.io/version` label (lock-step) → `kustomize build` validation → commit + push to `main` as `github-actions[bot]` (fetch-rebase-retry, `concurrency` serialized). No PR. Admin-gated `workflow_dispatch` recovery path via a conditional `prod-pin` environment.
- **Pulumi (`src/github/`, `src/index.ts`)**: prod `main` protection for this repo is now a `RepositoryRuleset` with the GitHub Actions integration as the sole `always` bypass actor (classic `BranchProtection` cannot bypass the strict up-to-date check); cross-repo dispatch GitHub App secrets wired onto backend/frontend `prod` environments; repo-level WIF variables for the workflow's crane auth; `prod-pin` environment with `pannpers` as required reviewer.
- **Docs**: runbook rewritten for the automated flow + one-time setup (GitHub App, ruleset, prod-pin env) + `git revert` rollback; both prod overlay comment blocks updated to "CI-written via dispatch".

## 🌍 Affected Stacks
- [x] Dev (no-op: all new resources are `env === 'prod'` gated)
- [x] Prod

## 🔮 Pulumi Preview
See CI. Expect on **prod**: replace `cloud-provisioning-protection` (BranchProtection) → `cloud-provisioning-main-ruleset` (RepositoryRuleset); new `ActionsVariable` (WIF provider + SA), `prod-pin` `RepositoryEnvironment`, and (once the App secret config is set in ESC) two `ActionsEnvironmentSecret` on backend/frontend prod.

## 📦 State Changes
Branch-protection mechanism swap (delete classic protection, create ruleset) — apply **attended** on prod and review the preview diff. No `state mv`/`import` needed.

## ✅ Checklist
- [x] `make lint-ts` (biome + tsc) passes locally; `kustomize build` of both prod overlays validates.
- [x] No unintended destructive changes (only the deliberate protection→ruleset swap).
- [x] Secrets managed via Pulumi Config / ESC (App credential optional until provisioned).

> ⚠️ **Merge sequencing**: before the next backend/frontend Release, create the dispatch GitHub App, set `pulumiConfig.github.prodPinDispatchAppId`/`…PrivateKey` in prod ESC, and run prod `pulumi up` (materializes the ruleset bypass + secrets + prod-pin env). Until then the release dispatch job has no token. See `docs/runbooks/prod-image-tag-pinning.md` "Automation setup".
