### PR TITLE
feat(infra): bump prod frontend image v1.3.4 -> v1.4.0 (discovery reset + font)

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -26,7 +26,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
 - pairs:
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "1.4.0"
   includeSelectors: false
   includeTemplates: true
 
@@ -101,4 +101,4 @@ patches:
 images:
 - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
   newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-  newTag: v1.3.4  # commit 4f23d58c4d0ab392761388d2c4c6d3bf6a7fed6a
+  newTag: v1.4.0  # commit 8e12fd182357632b2a6a18a1d0b75dca38c96b90


### PR DESCRIPTION
## 🔗 Related Issue

Refs liverty-music/frontend#393 (frontend impl liverty-music/frontend#394, release v1.4.0).

## 📝 Summary of Changes

Bump the **prod** frontend image pin `v1.3.4 → v1.4.0` (discovery reset-to-Top-50 control + type-scale minimum-font raise). The frontend GH Release v1.4.0 retagged the byte-identical dev-AR digest into prod AR as `:v1.4.0`. This updates, in lock-step:
- `images[].newTag: v1.4.0` (+ `# commit 8e12fd18…` trailer)
- `app.kubernetes.io/version: "1.4.0"` label

Manual bump — the frontend release-side `repository_dispatch` (frontend#395) that would auto-write this pin is not merged yet.

ArgoCD auto-syncs prod to the new image on merge. K8s-manifest-only change; no Pulumi `src/**` impact.

## 🌍 Affected Stacks
- [ ] Dev
- [x] Prod

## 🔮 Pulumi Preview

No Pulumi `src/**` change (kustomize manifest only). `kubectl kustomize .../frontend/overlays/prod` renders the prod-AR image at `:v1.4.0` and the version label at `1.4.0`; no other resources change.

## 📦 State Changes

None.

## ✅ Checklist
- [x] Kustomize dry-run passes (prod overlay renders `:v1.4.0`).
- [x] No unintended destructive changes (single image-tag + label bump).
- [x] Secrets unaffected.
