### PR TITLE
refactor(ci): generalize dispatch App to shared liverty-music-ci-bot

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -140,29 +140,40 @@ prod `pulumi up`; the rest are documented here because they require an
 out-of-band credential or a setting GitHub does not expose to this provider
 version.
 
-### 1. Cross-repo dispatch credential (GitHub App) — backend + frontend
+### 1. Cross-repo dispatch credential (GitHub App `liverty-music-ci-bot`)
 
 The release workflows trigger `repository_dispatch` against `cloud-provisioning`
 with a **GitHub App installation token** (short-lived, auditable) rather than a
-long-lived PAT. The `POST /repos/{owner}/{repo}/dispatches` API requires
-`Contents: write` (no narrower scope exists), so the security boundary is NOT
-the token scope — it is branch protection (see §2): the token cannot push to
-`cloud-provisioning:main` because only `github-actions[bot]` bypasses, so its
-reach is limited to non-`main` refs ArgoCD does not track.
+long-lived PAT. The App is a shared org CI-automation bot (`liverty-music-ci-bot`)
+— intentionally named generically so it can be reused for future cross-repo CI
+automation at the same trust level, while keeping **least privilege**
+(`Contents: write` only, installed on `cloud-provisioning` only). The
+`POST /repos/{owner}/{repo}/dispatches` API requires `Contents: write` (no
+narrower scope exists), so the security boundary is NOT the token scope — it is
+branch protection (see §2): the token cannot push to `cloud-provisioning:main`
+because only `github-actions[bot]` bypasses, so its reach is limited to
+non-`main` refs ArgoCD does not track. Grow this App's permissions/installs only
+deliberately; if a future automation needs materially higher privilege or a
+different trust boundary, create a separate App instead.
 
 One-time setup:
-1. Create a GitHub App in the `liverty-music` org (Settings → Developer settings
-   → GitHub Apps → New). Permissions: **Repository → Contents: Read and write**
-   (the documented minimum for the dispatches API). No webhook needed.
-2. Install it on **`cloud-provisioning` only** (scope the installation).
-3. Generate a private key; note the App ID.
+1. Register a GitHub App in the `liverty-music` org: **Your organizations →
+   Settings → Developer settings → GitHub Apps → New GitHub App**. Name
+   `liverty-music-ci-bot`; uncheck **Webhook → Active**; under **Repository
+   permissions** set **Contents: Read and write** only; **Where can this app be
+   installed? → Only on this account**. Create.
+2. **Install App → Only select repositories → `cloud-provisioning` only.**
+3. On the App's **General** page, **Generate a private key** (downloads a `.pem`)
+   and note the **App ID**.
 4. Store the App ID and private key in Pulumi ESC so they are wired as the
-   backend + frontend `prod` environment secrets `PROD_PIN_DISPATCH_APP_ID` /
-   `PROD_PIN_DISPATCH_APP_PRIVATE_KEY` (consumed by the `dispatch-prod-pin` job
-   via `actions/create-github-app-token`):
+   backend + frontend `prod` environment secrets `CI_BOT_APP_ID` /
+   `CI_BOT_APP_PRIVATE_KEY` (consumed by the `dispatch-prod-pin` job via
+   `actions/create-github-app-token`). The secret stays on the consuming repos'
+   `prod` environments — NOT org-wide — so a compromised non-prod workflow cannot
+   mint the token:
    ```bash
-   esc env set liverty-music/prod pulumiConfig.github.prodPinDispatchAppId "<app-id>"
-   esc env set liverty-music/prod pulumiConfig.github.prodPinDispatchAppPrivateKey "$(cat app-private-key.pem)" --secret
+   esc env set liverty-music/prod pulumiConfig.github.ciBotAppId "<app-id>"
+   esc env set liverty-music/prod pulumiConfig.github.ciBotAppPrivateKey "$(cat liverty-music-ci-bot.*.private-key.pem)" --secret
    ```
    Then run a prod `pulumi up`; `GitHubRepositoryComponent` creates the two
    environment secrets on backend + frontend (no-op if the config is absent).

--- a/src/github/config.ts
+++ b/src/github/config.ts
@@ -5,15 +5,17 @@ export interface GitHubConfig {
 	geminiApiKey?: string
 	anthropicApiKey?: string
 	claudeCodeOauthToken?: string
-	// GitHub App credential used by the backend/frontend release workflows to
-	// trigger the cross-repo `bump-prod-pin` `repository_dispatch`. Wired as
-	// the `PROD_PIN_DISPATCH_APP_ID` / `PROD_PIN_DISPATCH_APP_PRIVATE_KEY`
-	// secrets on the backend + frontend `prod` environments. Optional: when
-	// unset (e.g. dev stack, or before the App is created) no secret is
-	// provisioned. See OpenSpec change `automate-prod-pin-bump` and
-	// docs/runbooks/prod-image-tag-pinning.md "Automation setup".
-	prodPinDispatchAppId?: string
-	prodPinDispatchAppPrivateKey?: string
+	// Shared org CI-automation GitHub App (`liverty-music-ci-bot`). Used by the
+	// backend/frontend release workflows to trigger the cross-repo
+	// `bump-prod-pin` `repository_dispatch`, and reusable for future cross-repo
+	// CI automation at the same trust level. Wired as the `CI_BOT_APP_ID` /
+	// `CI_BOT_APP_PRIVATE_KEY` secrets on the backend + frontend `prod`
+	// environments. Optional: when unset (e.g. dev stack, or before the App is
+	// created) no secret is provisioned. See OpenSpec change
+	// `automate-prod-pin-bump` and docs/runbooks/prod-image-tag-pinning.md
+	// "Automation setup".
+	ciBotAppId?: string
+	ciBotAppPrivateKey?: string
 }
 
 export interface BufConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,22 +210,20 @@ const sharedVariables = {
 	SERVICE_ACCOUNT: gcp.githubActionsSAEmail,
 }
 
-// Cross-repo dispatch credential (GitHub App) for the `automate-prod-pin-bump`
-// release path. Wired onto the backend + frontend `prod` environments so the
+// Shared org CI-automation GitHub App credential (`liverty-music-ci-bot`).
+// Wired onto the backend + frontend `prod` environments so the
 // `dispatch-prod-pin` job can mint an installation token (scoped to
 // cloud-provisioning) and POST the `bump-prod-pin` `repository_dispatch`.
 // Prod-only and optional: absent until the App is created and its credential
-// is set in ESC (`pulumiConfig.github.prodPinDispatchAppId` /
-// `...PrivateKey`). See docs/runbooks/prod-image-tag-pinning.md "Automation
-// setup" §1.
-const prodPinDispatchSecrets =
-	env === 'prod' &&
-	githubConfig.prodPinDispatchAppId &&
-	githubConfig.prodPinDispatchAppPrivateKey
+// is set in ESC (`pulumiConfig.github.ciBotAppId` / `...PrivateKey`). The
+// secret is intentionally kept on the consuming repos' `prod` environments
+// (not org-wide) so a compromised non-prod workflow cannot mint the token.
+// See docs/runbooks/prod-image-tag-pinning.md "Automation setup" §1.
+const ciBotSecrets =
+	env === 'prod' && githubConfig.ciBotAppId && githubConfig.ciBotAppPrivateKey
 		? {
-				PROD_PIN_DISPATCH_APP_ID: githubConfig.prodPinDispatchAppId,
-				PROD_PIN_DISPATCH_APP_PRIVATE_KEY:
-					githubConfig.prodPinDispatchAppPrivateKey,
+				CI_BOT_APP_ID: githubConfig.ciBotAppId,
+				CI_BOT_APP_PRIVATE_KEY: githubConfig.ciBotAppPrivateKey,
 			}
 		: undefined
 
@@ -236,7 +234,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.BACKEND,
 	environment: env,
 	variables: sharedVariables,
-	secrets: prodPinDispatchSecrets,
+	secrets: ciBotSecrets,
 	requiredStatusCheckContexts: ['CI Success'],
 })
 
@@ -247,7 +245,7 @@ new GitHubRepositoryComponent({
 	repositoryName: RepositoryName.FRONTEND,
 	environment: env,
 	variables: sharedVariables,
-	secrets: prodPinDispatchSecrets,
+	secrets: ciBotSecrets,
 	requiredStatusCheckContexts: ['CI Success'],
 })
 


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553 (kept open — operational verification still pending)

## 📝 Summary of Changes
Follow-up to #337. Generalizes the cross-repo dispatch GitHub App from the purpose-specific `prodPinDispatch*` naming to a shared org CI-automation bot (`liverty-music-ci-bot`), so the same App is reusable for future cross-repo CI automation at the same trust level instead of one App per task.

- `src/github/config.ts`: `prodPinDispatchAppId/PrivateKey` → `ciBotAppId/PrivateKey`.
- `src/index.ts`: secret object keys `PROD_PIN_DISPATCH_APP_*` → `CI_BOT_APP_*` (matched by the backend/frontend workflow refs in liverty-music/backend#322 and liverty-music/frontend#395); variable renamed to `ciBotSecrets`.
- Runbook "Automation setup" §1: current GitHub App registration steps, new ESC paths (`pulumiConfig.github.ciBotAppId/PrivateKey`), and the generalize-vs-split-App guidance.

**Least privilege is unchanged**: `Contents: write` only, installed on `cloud-provisioning` only, secret scoped to backend/frontend `prod` environments (not org-wide). The security boundary remains branch protection (the ruleset bot bypass), not the token scope.

## 🌍 Affected Stacks
- [x] Dev (no-op: secret wiring is `env === 'prod'` gated)
- [x] Prod (only renames config-key/secret-name; no new behavior)

## 🔮 Pulumi Preview
See CI. No infra diff until the `liverty-music-ci-bot` App credential is set in prod ESC under the new `ciBot*` keys; then a prod `pulumi up` creates the `CI_BOT_APP_*` secrets on backend/frontend prod.

## 📦 State Changes
None beyond the secret-name change (the secrets are not yet created — App credential not yet provisioned).

## ✅ Checklist
- [x] `make lint-ts` (biome + tsc) passes locally.
- [x] No stale `prodPinDispatch*` / `PROD_PIN_DISPATCH_*` references remain.
- [x] Secret names match the backend/frontend workflow refs.
