### PR TITLE
fix(ci): use org ruleset for the bot main-push bypass

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -191,20 +191,25 @@ up to date" check.
 
 This is **IaC-managed** in `src/github/components/repository.ts`: for
 cloud-provisioning prod, the `main` protection is expressed as a
-`github.RepositoryRuleset` (not the classic `github.BranchProtection`) with the
-GitHub Actions integration (`slug: github-actions`, resolved via the
-`getGithubApp` data source) as an `always` **bypass actor**. Classic branch
-protection has no per-actor bypass for the strict (up-to-date) status check —
-only a ruleset `bypassActors` entry can grant it — which is why
-cloud-provisioning's protection uses a ruleset while the other repos stay on
-classic `BranchProtection`. The ruleset replicates the prior rules (PR required,
-0 approvals; strict `CI Success`; no force-push; no deletion) and applies to
-everyone except the single Actions-app bypass actor; **no human and no PAT** is
-added.
+`github.OrganizationRuleset` scoped to `cloud-provisioning`'s default branch
+(not the classic `github.BranchProtection`) with the GitHub Actions integration
+(`slug: github-actions`, resolved via the `getGithubApp` data source) as an
+`always` **bypass actor**. Two reasons it must be an *org* ruleset, not a repo
+one: (a) classic branch protection has no per-actor bypass for the strict
+(up-to-date) status check; (b) a *repository* ruleset rejects the GitHub Actions
+integration bypass with `422 — "Actor GitHub Actions integration must be part of
+the ruleset source or owner organization"` (the global `github-actions` app is
+GitHub-owned, not org-owned), whereas an *organization* ruleset accepts it. This
+keeps the built-in `GITHUB_TOKEN` as the pusher, so the cross-repo dispatch
+token is NOT a bypass actor and still cannot push to `main` (design D1 boundary
+preserved). The ruleset replicates the prior rules (PR required, 0 approvals;
+strict `CI Success`; no force-push; no deletion) and applies to everyone except
+the single Actions-integration bypass actor; **no human and no PAT** is added.
+Other repos keep classic `BranchProtection`.
 
 > **Migration note.** A prod `pulumi up` will **delete** the classic
 > `cloud-provisioning-protection` `BranchProtection` and **create** the
-> `cloud-provisioning-main-ruleset`. Review the `pulumi preview` diff before
+> `cloud-provisioning-main` org ruleset. Review the `pulumi preview` diff before
 > applying; the swap is a replace, so `main` is briefly governed by whichever
 > of the two exists during the apply — apply attended.
 

--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -35,14 +35,17 @@ export interface GitHubRepositoryComponentArgs {
 	pinBumpReviewerUsername?: string
 	/**
 	 * When true, the prod `main` protection is expressed as a
-	 * `github.RepositoryRuleset` (replacing the classic `BranchProtection`)
-	 * with the GitHub Actions integration as an `always` bypass actor. This is
-	 * the only mechanism that lets `github-actions[bot]` push the automated
-	 * pin-bump straight to `main` past BOTH the PR requirement AND the
-	 * strict "up-to-date" status check (classic protection cannot bypass the
-	 * strict check per-actor). See OpenSpec change `automate-prod-pin-bump`
-	 * D8 / spec "cloud-provisioning branch protection SHALL allow the bot to
-	 * bypass". The bypass is scoped to the Actions app only — no human/PAT.
+	 * `github.OrganizationRuleset` scoped to this repo's default branch
+	 * (replacing the classic `BranchProtection`) with the GitHub Actions
+	 * integration as an `always` bypass actor. This lets `github-actions[bot]`
+	 * push the automated pin-bump straight to `main` past BOTH the PR
+	 * requirement AND the strict "up-to-date" status check. An org ruleset is
+	 * required because a *repository* ruleset rejects the GitHub Actions
+	 * integration bypass (the global `github-actions` app is GitHub-owned, not
+	 * org-owned), while classic protection cannot bypass the strict check
+	 * per-actor. See OpenSpec change `automate-prod-pin-bump` D8 / spec
+	 * "branch protection SHALL allow the bot to bypass". Bypass is scoped to
+	 * the Actions integration only — no human/PAT.
 	 */
 	mainBranchBotBypass?: boolean
 }
@@ -235,33 +238,41 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 				// the prod pin-bump straight to `cloud-provisioning:main` as
 				// `github-actions[bot]`, which needs a bypass for BOTH the PR
 				// requirement AND the strict "up-to-date" status check. Classic
-				// `BranchProtection` has no per-actor bypass for the strict check —
-				// only a `RepositoryRuleset` `bypassActors` entry can grant it. We
-				// therefore express the protection as a ruleset (it replaces the
-				// classic protection rather than stacking with it: the two are
-				// evaluated together, so leaving classic protection in place would
-				// still block the bot). The bypass is scoped to the GitHub Actions
-				// integration only — no human, no PAT (spec: "cloud-provisioning
-				// branch protection SHALL allow the bot to bypass").
+				// `BranchProtection` has no per-actor bypass for the strict check,
+				// and a *repository* ruleset rejects the GitHub Actions integration
+				// as a bypass actor ("Actor GitHub Actions integration must be part
+				// of the ruleset source or owner organization" — the global
+				// `github-actions` app is GitHub-owned, not org-owned). An
+				// *organization* ruleset DOES accept the GitHub Actions integration
+				// bypass, so we express the protection as an org ruleset scoped to
+				// this repo's default branch. It replaces the classic protection
+				// (the two stack, so leaving classic protection would still block
+				// the bot). Bypass is scoped to the GitHub Actions integration only
+				// — no human, no PAT (spec: "branch protection SHALL allow the bot
+				// to bypass"). This keeps the built-in GITHUB_TOKEN as the pusher,
+				// preserving the design D1 boundary (the cross-repo dispatch token
+				// is NOT a bypass actor and still cannot push to main).
 				//
 				// The Actions app id (slug `github-actions`) is resolved via the
-				// provider data source rather than hardcoded, so the bypass actor
-				// stays correct without a magic number. `actorId` is a number; the
-				// data source returns the id as a string.
+				// provider data source rather than hardcoded; `actorId` is a number,
+				// the data source returns the id as a string.
 				const actionsApp = github.getGithubAppOutput(
 					{ slug: 'github-actions' },
 					{ provider },
 				)
-				new github.RepositoryRuleset(
-					`${repositoryName}-main-ruleset`,
+				new github.OrganizationRuleset(
+					`${repositoryName}-main-org-ruleset`,
 					{
 						name: `${repositoryName}-main`,
-						repository: repositoryName,
 						target: 'branch',
 						enforcement: 'active',
 						conditions: {
 							refName: {
 								includes: ['~DEFAULT_BRANCH'],
+								excludes: [],
+							},
+							repositoryName: {
+								includes: [repositoryName],
 								excludes: [],
 							},
 						},


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
Fixes the prod `pulumi up` failure: the repository ruleset for cloud-provisioning `main` was rejected with `422 — "Actor GitHub Actions integration must be part of the ruleset source or owner organization"`. A **repository** ruleset only accepts an org-owned/repo-installed App as a bypass actor; the global `github-actions` app (id 15368) is GitHub-owned → rejected.

- Switches `src/github/components/repository.ts` (the `mainBranchBotBypass` path) from `github.RepositoryRuleset` → `github.OrganizationRuleset`, scoped via `conditions.repositoryName = [cloud-provisioning]` + `refName = ~DEFAULT_BRANCH`. Org rulesets accept the GitHub Actions integration bypass.
- Rules unchanged (PR required / 0 approvals; strict `CI Success`; no force-push; no deletion); bypass scoped to the Actions integration only (no human/PAT).
- Keeps the built-in `GITHUB_TOKEN` as the bump pusher → cross-repo dispatch token (ci-bot) is still NOT a bypass actor and cannot push `main` (design D1 boundary preserved).
- Runbook §2 updated with the 422 rationale.

## 🌍 Affected Stacks
- [x] Dev (no-op: prod-gated)
- [x] Prod

## 🔮 Pulumi Preview
Expect on prod: delete `cloud-provisioning-protection` (BranchProtection) → create `cloud-provisioning-main` **OrganizationRuleset**; plus the previously-planned prod-pin env, repo vars, and CI_BOT secrets (unchanged from #337/#339).

## 📦 State Changes
Branch-protection mechanism swap (classic → org ruleset). Apply attended; review preview.

## ✅ Checklist
- [x] `make lint-ts` passes.
- [x] Bypass scoped to Actions integration only; no human/PAT.
