### PR TITLE
fix(ci): push prod pin-bump as ci-bot via a repo ruleset bypass

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -118,13 +118,30 @@ jobs:
             echo "bare=${BARE}"
           } >> "$GITHUB_OUTPUT"
 
+      # Mint a ci-bot installation token. The bump is pushed to `main` AS this
+      # org-owned App, which is the sole bypass actor on the `main` ruleset
+      # (the built-in github-actions[bot] cannot be a repo-ruleset bypass actor,
+      # and org rulesets need a Team plan — see bump-prod-pin design). Repo-level
+      # secrets (provisioned by Pulumi) so they resolve on the empty-environment
+      # repository_dispatch path.
+      - name: Mint ci-bot token
+        id: bot
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Full history + token retained so the fetch-rebase-retry push loop
-          # can rebase on a concurrent bump and push back to main.
+          # Full history so the fetch-rebase-retry push loop can rebase on a
+          # concurrent bump. Persist the ci-bot token (not the built-in
+          # GITHUB_TOKEN) as the origin credential so the loop's fetch + push
+          # authenticate AS ci-bot — the sole `main` ruleset bypass actor — and
+          # the push is accepted.
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.bot.outputs.token }}
 
       # ----------------------------------------------------------------------
       # 1.2a Provenance gate — fail-closed BEFORE any edit. The prod-AR image
@@ -241,8 +258,9 @@ jobs:
           echo "kustomize build of the ${COMPONENT} prod overlay succeeded."
 
       # ----------------------------------------------------------------------
-      # 1.6 + 1.7 Commit as github-actions[bot] and push to main with a
-      # fetch-rebase-retry loop (≤5 attempts). No PR.
+      # 1.6 + 1.7 Commit as the ci-bot App and push to main with a
+      # fetch-rebase-retry loop (≤5 attempts). No PR. The push authenticates as
+      # ci-bot (the persisted token), the sole `main` ruleset bypass actor.
       # ----------------------------------------------------------------------
       - name: Commit and push to main
         if: steps.idem.outputs.skip != 'true'
@@ -251,12 +269,15 @@ jobs:
           TAG: ${{ steps.payload.outputs.tag }}
           SHA: ${{ steps.payload.outputs.sha }}
           BARE: ${{ steps.payload.outputs.bare }}
+          BOT_SLUG: ${{ steps.bot.outputs.app-slug }}
         run: |
           set -euo pipefail
           file="k8s/namespaces/${COMPONENT}/overlays/prod/kustomization.yaml"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Commit as the ci-bot App identity (the push is authenticated as this
+          # App, the ruleset bypass actor).
+          git config user.name "${BOT_SLUG}[bot]"
+          git config user.email "${BOT_SLUG}[bot]@users.noreply.github.com"
 
           # Defensive: if no net diff (e.g. label/comment already matched),
           # skip the commit rather than create an empty one.

--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -165,55 +165,68 @@ One-time setup:
 2. **Install App → Only select repositories → `cloud-provisioning` only.**
 3. On the App's **General** page, **Generate a private key** (downloads a `.pem`)
    and note the **App ID**.
-4. Store the App ID and private key in Pulumi ESC so they are wired as the
-   backend + frontend `prod` environment secrets `CI_BOT_APP_ID` /
-   `CI_BOT_APP_PRIVATE_KEY` (consumed by the `dispatch-prod-pin` job via
-   `actions/create-github-app-token`). The secret stays on the consuming repos'
-   `prod` environments — NOT org-wide — so a compromised non-prod workflow cannot
-   mint the token:
+4. Store the App ID and private key in Pulumi ESC. They are wired as
+   `CI_BOT_APP_ID` / `CI_BOT_APP_PRIVATE_KEY` on (a) the backend + frontend
+   `prod` **environment** secrets — consumed by the `dispatch-prod-pin` job to
+   trigger the dispatch — and (b) the cloud-provisioning **repository** secrets
+   — consumed by `bump-prod-pin.yml` to mint the token it pushes the bump to
+   `main` with (the bump workflow's `repository_dispatch` path runs with an
+   empty `environment:`, so it needs a repo-level secret). All
+   via `actions/create-github-app-token`:
    ```bash
    esc env set liverty-music/prod pulumiConfig.github.ciBotAppId "<app-id>"
    esc env set liverty-music/prod pulumiConfig.github.ciBotAppPrivateKey "$(cat liverty-music-ci-bot.*.private-key.pem)" --secret
    ```
-   Then run a prod `pulumi up`; `GitHubRepositoryComponent` creates the two
-   environment secrets on backend + frontend (no-op if the config is absent).
-5. **Verify the reach is bounded**: confirm a token minted by this App CANNOT
-   push to `cloud-provisioning:main` (branch protection denies it) — only its
-   `repository_dispatch` trigger should succeed.
+   Then run a prod `pulumi up`; `GitHubRepositoryComponent` creates the secrets
+   (no-op if the config is absent).
+5. **Confirm the bypass scope**: after the ruleset applies (§2), the ci-bot App
+   is the sole `main` bypass actor. Note this means ci-bot CAN push to
+   `cloud-provisioning:main` (it is the bump pusher) — see the §2 security
+   trade-off; verify no human/PAT is on the bypass list.
 
-### 2. `cloud-provisioning:main` branch-protection bypass for the bot
+### 2. `cloud-provisioning:main` ruleset bypass (ci-bot App)
 
-`bump-prod-pin.yml` pushes the validated bump straight to `main` as
-`github-actions[bot]` using the built-in `GITHUB_TOKEN`. For that push to be
-accepted, `github-actions[bot]` MUST be a **bypass actor** on the `main`
-protection, covering BOTH the pull-request requirement AND the "require branches
-up to date" check.
+`bump-prod-pin.yml` pushes the validated bump straight to `main` **as the
+`liverty-music-ci-bot` App** (it mints a ci-bot installation token via
+`actions/create-github-app-token` and pushes with it). For that push to be
+accepted, the ci-bot App MUST be a **bypass actor** on the `main` protection,
+covering BOTH the pull-request requirement AND the "require branches up to date"
+check.
 
 This is **IaC-managed** in `src/github/components/repository.ts`: for
-cloud-provisioning prod, the `main` protection is expressed as a
-`github.OrganizationRuleset` scoped to `cloud-provisioning`'s default branch
-(not the classic `github.BranchProtection`) with the GitHub Actions integration
-(`slug: github-actions`, resolved via the `getGithubApp` data source) as an
-`always` **bypass actor**. Two reasons it must be an *org* ruleset, not a repo
-one: (a) classic branch protection has no per-actor bypass for the strict
-(up-to-date) status check; (b) a *repository* ruleset rejects the GitHub Actions
-integration bypass with `422 — "Actor GitHub Actions integration must be part of
-the ruleset source or owner organization"` (the global `github-actions` app is
-GitHub-owned, not org-owned), whereas an *organization* ruleset accepts it. This
-keeps the built-in `GITHUB_TOKEN` as the pusher, so the cross-repo dispatch
-token is NOT a bypass actor and still cannot push to `main` (design D1 boundary
-preserved). The ruleset replicates the prior rules (PR required, 0 approvals;
-strict `CI Success`; no force-push; no deletion) and applies to everyone except
-the single Actions-integration bypass actor; **no human and no PAT** is added.
-Other repos keep classic `BranchProtection`.
+cloud-provisioning prod, the `main` protection is a `github.RepositoryRuleset`
+(replacing the classic `github.BranchProtection`) whose sole `always` bypass
+actor is the ci-bot App (`actorType: Integration`, `actorId: ciBotAppId`). The
+ruleset replicates the prior rules (PR required, 0 approvals; strict
+`CI Success`; no force-push; no deletion) and applies to everyone except ci-bot;
+**no human and no PAT** is added. Other repos keep classic `BranchProtection`.
 
-> **Migration note.** A prod `pulumi up` will **delete** the classic
-> `cloud-provisioning-protection` `BranchProtection` and **create** the
-> `cloud-provisioning-main` org ruleset. Review the `pulumi preview` diff before
-> applying; the swap is a replace, so `main` is briefly governed by whichever
-> of the two exists during the apply — apply attended.
+**Why ci-bot and not `github-actions[bot]`** (the path we did NOT take): a repo
+ruleset rejects the global `github-actions` integration as a bypass actor —
+`422 "Actor GitHub Actions integration must be part of the ruleset source or
+owner organization"` (it is GitHub-owned, not org-owned). The fix that *would*
+keep the built-in `GITHUB_TOKEN` — an **organization** ruleset — requires a
+**GitHub Team plan** (`403 "Upgrade to GitHub Team to enable this feature"` on
+the Free plan). An org-owned App (ci-bot) passes the repo-ruleset validation, so
+the bump pushes as ci-bot instead.
 
-Verify after apply: a bot push from `bump-prod-pin.yml` lands on `main` without
+> **Security trade-off (relaxes design D1).** ci-bot is ALSO the cross-repo
+> dispatch credential stored on the backend/frontend `prod` environments, so a
+> compromised prod release workflow could mint a ci-bot token and push to
+> `cloud-provisioning:main` directly — i.e. the dispatch credential CAN now move
+> prod, which D1 originally forbade. Mitigations: the ci-bot secrets are scoped
+> to the `prod` environment (release events only), the provenance gate still
+> blocks bogus tags, and cutting the Release remains the human gate. Accepted
+> for a solo-dev org to avoid a second dedicated App. To restore the strict
+> boundary, introduce a dedicated push-only App (installed + keyed only on
+> cloud-provisioning) as the bypass actor instead of ci-bot.
+
+> **Migration note.** A prod `pulumi up` **deletes** the classic
+> `cloud-provisioning-protection` `BranchProtection` and **creates** the
+> `cloud-provisioning-main` `RepositoryRuleset`. Review the `pulumi preview`
+> diff; apply attended (the swap is a replace).
+
+Verify after apply: a bump push from `bump-prod-pin.yml` lands on `main` without
 a PR; a human direct push to `main` is still rejected (PR + up-to-date required).
 
 ### 3. `prod-pin` GitHub Environment (admin reviewer) — cloud-provisioning

--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -34,20 +34,32 @@ export interface GitHubRepositoryComponentArgs {
 	 */
 	pinBumpReviewerUsername?: string
 	/**
-	 * When true, the prod `main` protection is expressed as a
-	 * `github.OrganizationRuleset` scoped to this repo's default branch
-	 * (replacing the classic `BranchProtection`) with the GitHub Actions
-	 * integration as an `always` bypass actor. This lets `github-actions[bot]`
-	 * push the automated pin-bump straight to `main` past BOTH the PR
-	 * requirement AND the strict "up-to-date" status check. An org ruleset is
-	 * required because a *repository* ruleset rejects the GitHub Actions
-	 * integration bypass (the global `github-actions` app is GitHub-owned, not
-	 * org-owned), while classic protection cannot bypass the strict check
-	 * per-actor. See OpenSpec change `automate-prod-pin-bump` D8 / spec
-	 * "branch protection SHALL allow the bot to bypass". Bypass is scoped to
-	 * the Actions integration only — no human/PAT.
+	 * When true AND `botBypassAppId` is set, the prod `main` protection is
+	 * expressed as a `github.RepositoryRuleset` (replacing the classic
+	 * `BranchProtection`) with the org-owned bump App as an `always` bypass
+	 * actor, letting the automated pin-bump push straight to `main` past BOTH
+	 * the PR requirement AND the strict "up-to-date" status check. Classic
+	 * protection cannot bypass the strict check per-actor. If false / no app id,
+	 * classic `BranchProtection` is used instead. See OpenSpec change
+	 * `automate-prod-pin-bump`.
 	 */
 	mainBranchBotBypass?: boolean
+	/**
+	 * GitHub App ID used as the org-owned bypass actor on the `main` ruleset
+	 * (and the identity the bump workflow pushes as). MUST be an org-owned App:
+	 * the global `github-actions` integration is rejected by a repo ruleset
+	 * ("must be part of the ruleset source or owner organization"), and an org
+	 * ruleset (which would accept it) needs a GitHub Team plan. The
+	 * `liverty-music-ci-bot` App id (`ciBotAppId`) is passed here.
+	 */
+	botBypassAppId?: pulumi.Input<string>
+	/**
+	 * Repository-level Actions secrets (not environment-scoped). Used by
+	 * `bump-prod-pin.yml`'s `repository_dispatch` path (empty `environment:`,
+	 * so it cannot read environment secrets) to mint the ci-bot token it pushes
+	 * to `main` with.
+	 */
+	repositorySecrets?: Record<string, pulumi.Input<string>>
 }
 
 export class GitHubRepositoryComponent extends pulumi.ComponentResource {
@@ -78,6 +90,8 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 			repositoryVariables,
 			pinBumpReviewerUsername,
 			mainBranchBotBypass,
+			botBypassAppId,
+			repositorySecrets,
 		} = args
 
 		// Use a new provider instance to ensure we can use it in any stack
@@ -199,6 +213,24 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 			}
 		}
 
+		// Repository-level Actions secrets (not environment-scoped). The
+		// `bump-prod-pin.yml` `repository_dispatch` path runs with an empty
+		// `environment:`, so it reads the ci-bot App credential from here to mint
+		// the installation token it pushes the bump to `main` with.
+		if (repositorySecrets) {
+			for (const [key, value] of Object.entries(repositorySecrets)) {
+				new github.ActionsSecret(
+					`${repositoryName}-repo-secret-${key}`,
+					{
+						repository: repositoryName,
+						secretName: key,
+						plaintextValue: value,
+					},
+					{ provider, parent: this },
+				)
+			}
+		}
+
 		// `prod-pin` Environment with a required-reviewer (admin) rule. Gates
 		// the `bump-prod-pin.yml` manual `workflow_dispatch` recovery path; the
 		// automated `repository_dispatch` path resolves the environment to empty
@@ -233,37 +265,37 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 
 		// Apply main-branch protection (Prod Only to avoid stack conflicts).
 		if (environment === 'prod') {
-			if (mainBranchBotBypass) {
+			if (mainBranchBotBypass && botBypassAppId) {
 				// Ruleset form (automate-prod-pin-bump): `bump-prod-pin.yml` pushes
-				// the prod pin-bump straight to `cloud-provisioning:main` as
-				// `github-actions[bot]`, which needs a bypass for BOTH the PR
-				// requirement AND the strict "up-to-date" status check. Classic
-				// `BranchProtection` has no per-actor bypass for the strict check,
-				// and a *repository* ruleset rejects the GitHub Actions integration
-				// as a bypass actor ("Actor GitHub Actions integration must be part
-				// of the ruleset source or owner organization" — the global
-				// `github-actions` app is GitHub-owned, not org-owned). An
-				// *organization* ruleset DOES accept the GitHub Actions integration
-				// bypass, so we express the protection as an org ruleset scoped to
-				// this repo's default branch. It replaces the classic protection
-				// (the two stack, so leaving classic protection would still block
-				// the bot). Bypass is scoped to the GitHub Actions integration only
-				// — no human, no PAT (spec: "branch protection SHALL allow the bot
-				// to bypass"). This keeps the built-in GITHUB_TOKEN as the pusher,
-				// preserving the design D1 boundary (the cross-repo dispatch token
-				// is NOT a bypass actor and still cannot push to main).
+				// the prod pin-bump straight to `cloud-provisioning:main`, which
+				// needs a bypass for BOTH the PR requirement AND the strict
+				// "up-to-date" status check. Classic `BranchProtection` has no
+				// per-actor bypass for the strict check, so we use a
+				// `RepositoryRuleset` with a `bypassActors` entry.
 				//
-				// The Actions app id (slug `github-actions`) is resolved via the
-				// provider data source rather than hardcoded; `actorId` is a number,
-				// the data source returns the id as a string.
-				const actionsApp = github.getGithubAppOutput(
-					{ slug: 'github-actions' },
-					{ provider },
-				)
-				new github.OrganizationRuleset(
-					`${repositoryName}-main-org-ruleset`,
+				// The bypass actor is the org-owned `liverty-music-ci-bot` App
+				// (`botBypassAppId`), NOT the built-in `github-actions[bot]`: a repo
+				// ruleset rejects the global `github-actions` integration with
+				// "Actor GitHub Actions integration must be part of the ruleset
+				// source or owner organization" (it is GitHub-owned), and an *org*
+				// ruleset (which would accept it) requires a GitHub Team plan
+				// (403 on Free). An org-owned App passes the repo-ruleset
+				// validation. The bump workflow therefore pushes to main using a
+				// ci-bot installation token (see bump-prod-pin.yml), and ci-bot is
+				// the sole bypass actor — no human, no PAT.
+				//
+				// Trade-off (vs the original design D1): ci-bot is ALSO the
+				// cross-repo dispatch credential held on the backend/frontend prod
+				// environments, so a compromised prod release workflow could mint a
+				// ci-bot token and push to `cloud-provisioning:main`. This relaxes
+				// the D1 "dispatch token cannot move prod" boundary; it is mitigated
+				// by the prod-environment gating of those secrets, the provenance
+				// gate, and Release-as-the-human-gate. See the updated spec.
+				new github.RepositoryRuleset(
+					`${repositoryName}-main-ruleset`,
 					{
 						name: `${repositoryName}-main`,
+						repository: repositoryName,
 						target: 'branch',
 						enforcement: 'active',
 						conditions: {
@@ -271,16 +303,12 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 								includes: ['~DEFAULT_BRANCH'],
 								excludes: [],
 							},
-							repositoryName: {
-								includes: [repositoryName],
-								excludes: [],
-							},
 						},
 						bypassActors: [
 							{
-								actorId: actionsApp.id.apply((id) =>
-									Number(id),
-								),
+								actorId: pulumi
+									.output(botBypassAppId)
+									.apply((id) => Number(id)),
 								actorType: 'Integration',
 								// `always`: bypass on direct pushes too, not just PRs —
 								// the bot pushes the bump directly, no PR.

--- a/src/github/components/repository.ts
+++ b/src/github/components/repository.ts
@@ -202,7 +202,9 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 		if (repositoryVariables) {
 			for (const [key, value] of Object.entries(repositoryVariables)) {
 				new github.ActionsVariable(
-					`${repositoryName}-repo-var-${key}`,
+					// kebab-case the resource name per CLAUDE.md (the variable name
+					// `key` is UPPER_SNAKE, e.g. WORKLOAD_IDENTITY_PROVIDER).
+					`${repositoryName}-repo-var-${key.toLowerCase().replace(/_/g, '-')}`,
 					{
 						repository: repositoryName,
 						variableName: key,
@@ -220,7 +222,9 @@ export class GitHubRepositoryComponent extends pulumi.ComponentResource {
 		if (repositorySecrets) {
 			for (const [key, value] of Object.entries(repositorySecrets)) {
 				new github.ActionsSecret(
-					`${repositoryName}-repo-secret-${key}`,
+					// kebab-case the resource name per CLAUDE.md (the secret name
+					// `key` is UPPER_SNAKE, e.g. CI_BOT_APP_ID).
+					`${repositoryName}-repo-secret-${key.toLowerCase().replace(/_/g, '-')}`,
 					{
 						repository: repositoryName,
 						secretName: key,

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,10 +283,18 @@ new GitHubRepositoryComponent({
 			: undefined,
 	// Admin-reviewer gate for the `bump-prod-pin.yml` manual recovery path.
 	pinBumpReviewerUsername: env === 'prod' ? 'pannpers' : undefined,
-	// Express prod `main` protection as a ruleset so `github-actions[bot]` can
-	// bypass it to push the automated pin-bump (the only mechanism that bypasses
-	// the strict up-to-date check). Bypass scoped to the Actions app only.
+	// Express prod `main` protection as a RepositoryRuleset whose sole bypass
+	// actor is the org-owned ci-bot App, so the bump workflow (pushing as a
+	// ci-bot installation token) can land the pin-bump on main past the PR +
+	// strict up-to-date rules. The global `github-actions` integration can't be
+	// a repo-ruleset bypass actor, and org rulesets need a Team plan — hence the
+	// org-owned App. `botBypassAppId` resolves the bypass actor; only set in
+	// prod where `ciBotAppId` exists (else classic BranchProtection is used).
 	mainBranchBotBypass: true,
+	botBypassAppId: env === 'prod' ? githubConfig.ciBotAppId : undefined,
+	// ci-bot App credential as REPO-level secrets so the bump workflow's
+	// `repository_dispatch` path (empty environment) can mint the push token.
+	repositorySecrets: ciBotSecrets,
 })
 
 // Export common resources


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
Two prod `pulumi up` attempts failed on the `main` protection swap:
1. Repository ruleset with `github-actions` bypass → `422 "Actor GitHub Actions integration must be part of the ruleset source or owner organization"` (the global app is GitHub-owned).
2. Organization ruleset (which would accept github-actions) → `403 "Upgrade to GitHub Team to enable this feature"` (org rulesets need a Team plan; the org is Free).

This switches to a **repository ruleset whose sole bypass actor is the org-owned `liverty-music-ci-bot` App** (org-owned Apps pass repo-ruleset validation), and pushes the bump **as ci-bot**:
- `repository.ts`: `RepositoryRuleset` (not Org) with `bypassActors=[{Integration, actorId: ciBotAppId, always}]`; new `botBypassAppId` + `repositorySecrets` args. Falls back to classic `BranchProtection` if no app id.
- `index.ts`: passes `botBypassAppId = ciBotAppId` and the ci-bot credential as cloud-provisioning **repository** secrets (the bump workflow's `repository_dispatch` path has an empty `environment:`).
- `bump-prod-pin.yml`: mints a ci-bot token (`actions/create-github-app-token`), persists it as the git credential, commits/pushes as ci-bot.
- Runbook §1/§2 updated with the 422/403 rationale and the security trade-off.

**Security trade-off (relaxes design D1):** ci-bot is also the cross-repo dispatch credential on backend/frontend `prod` envs, so it can now push `cloud-provisioning:main`. Mitigated by prod-env secret scoping, the provenance gate, and Release-as-gate. The strict boundary can be restored later with a dedicated push-only App. (Spec/design update follows in specification#553.)

## 🌍 Affected Stacks
- [x] Dev (no-op: prod-gated)
- [x] Prod

## 🔮 Pulumi Preview
Expect: delete `cloud-provisioning-protection` (BranchProtection) → create `cloud-provisioning-main` **RepositoryRuleset**; create cloud-provisioning repo secrets `CI_BOT_APP_*` + repo vars `WORKLOAD_IDENTITY_PROVIDER`/`SERVICE_ACCOUNT`. (prod-pin env + backend/frontend prod secrets already exist from the prior partial apply.)

## ✅ Checklist
- [x] `make lint-ts` passes; workflow YAML validated.
- [x] Bypass scoped to the ci-bot App only; no human/PAT.
