### PR TITLE
fix(ci): store bump workflow WIF/SA as repo secrets, not variables

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -153,11 +153,15 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          # Repository-level vars (not environment-scoped) so they resolve on
-          # the empty-environment `repository_dispatch` path. Provisioned by
+          # Repository-level SECRETS (not environment-scoped) so they resolve on
+          # the empty-environment `repository_dispatch` path. Stored as secrets
+          # rather than variables because the Pulumi GitHub token has
+          # Secrets:write but not Variables:write on the repo (the repo-variables
+          # API returns 403). The values (WIF provider, SA email) are not
+          # sensitive — masking in logs is a harmless side effect. Provisioned by
           # Pulumi on the prod stack — see cloud-provisioning/src/github/.
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,19 +268,6 @@ new GitHubRepositoryComponent({
 	variables: sharedVariables,
 	requiredStatusCheckContexts: ['CI Success'],
 	requireUpToDateBranch: true,
-	// Prod-only (repo-level vars are repo-global, so only one stack may own
-	// them): the `bump-prod-pin.yml` `repository_dispatch` path runs with an
-	// empty `environment:` and reads the prod WIF provider + SA from these
-	// repository-level variables to authenticate `crane` for the provenance
-	// gate against prod AR.
-	repositoryVariables:
-		env === 'prod'
-			? {
-					WORKLOAD_IDENTITY_PROVIDER:
-						gcp.githubWorkloadIdentityProvider,
-					SERVICE_ACCOUNT: gcp.githubActionsSAEmail,
-				}
-			: undefined,
 	// Admin-reviewer gate for the `bump-prod-pin.yml` manual recovery path.
 	pinBumpReviewerUsername: env === 'prod' ? 'pannpers' : undefined,
 	// Express prod `main` protection as a RepositoryRuleset whose sole bypass
@@ -292,9 +279,22 @@ new GitHubRepositoryComponent({
 	// prod where `ciBotAppId` exists (else classic BranchProtection is used).
 	mainBranchBotBypass: true,
 	botBypassAppId: env === 'prod' ? githubConfig.ciBotAppId : undefined,
-	// ci-bot App credential as REPO-level secrets so the bump workflow's
-	// `repository_dispatch` path (empty environment) can mint the push token.
-	repositorySecrets: ciBotSecrets,
+	// REPO-level secrets the `bump-prod-pin.yml` `repository_dispatch` path
+	// (empty environment) needs: the ci-bot App credential (to mint the push
+	// token) AND the prod WIF provider + SA (to authenticate `crane` for the
+	// provenance gate). Stored as SECRETS, not variables: the Pulumi GitHub
+	// token has Secrets:write but not Variables:write on the repo (the
+	// repo-variables API returns 403). The WIF provider + SA are not sensitive;
+	// masking in logs is a harmless side effect.
+	repositorySecrets:
+		env === 'prod' && ciBotSecrets
+			? {
+					...ciBotSecrets,
+					WORKLOAD_IDENTITY_PROVIDER:
+						gcp.githubWorkloadIdentityProvider,
+					SERVICE_ACCOUNT: gcp.githubActionsSAEmail,
+				}
+			: undefined,
 })
 
 // Export common resources

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,9 +287,13 @@ new GitHubRepositoryComponent({
 	// repo-variables API returns 403). The WIF provider + SA are not sensitive;
 	// masking in logs is a harmless side effect.
 	repositorySecrets:
-		env === 'prod' && ciBotSecrets
+		env === 'prod'
 			? {
-					...ciBotSecrets,
+					// Spread the ci-bot credential only when present (optional —
+					// absent before the App is provisioned); the WIF provider + SA
+					// are always written for prod so the crane provenance auth works
+					// regardless.
+					...(ciBotSecrets ?? {}),
 					WORKLOAD_IDENTITY_PROVIDER:
 						gcp.githubWorkloadIdentityProvider,
 					SERVICE_ACCOUNT: gcp.githubActionsSAEmail,


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
The prod `pulumi up` (after #341) failed on the last step:
```
POST /repos/liverty-music/cloud-provisioning/actions/variables: 403 Resource not accessible by personal access token
```
The Pulumi GitHub token has **Secrets:write but not Variables:write** on the repo (repo secrets created fine; repo variables 403). 

Fix: the bump workflow's `WORKLOAD_IDENTITY_PROVIDER` / `SERVICE_ACCOUNT` (needed on the empty-environment `repository_dispatch` path) move from repo **variables** to repo **secrets** — which the token can create. The values aren't sensitive; log masking is a harmless side effect.

- `index.ts`: drop `repositoryVariables`; fold `WORKLOAD_IDENTITY_PROVIDER` + `SERVICE_ACCOUNT` into the cloud-provisioning `repositorySecrets` (alongside the ci-bot credential).
- `bump-prod-pin.yml`: read `secrets.WORKLOAD_IDENTITY_PROVIDER` / `secrets.SERVICE_ACCOUNT` (was `vars.*`).

## 🌍 Affected Stacks
- [x] Dev (no-op: prod-gated)
- [x] Prod

## 🔮 Pulumi Preview
After #341's partial apply, the ruleset + ci-bot repo secrets + backend/frontend prod secrets + prod-pin env already exist. This run should: create 2 repo secrets (`workload-identity-provider`, `service-account`), delete classic `cloud-provisioning-protection`. (The previously-failing `ActionsVariable` resources are removed from the program.)

## ✅ Checklist
- [x] `make lint-ts` passes; workflow YAML validated.
