### PR TITLE
fix(iam): let cloud-provisioning impersonate the prod github-actions SA

### DIFF
--- a/src/gcp/components/workload-identity.ts
+++ b/src/gcp/components/workload-identity.ts
@@ -165,6 +165,20 @@ export class WorkloadIdentityComponent extends pulumi.ComponentResource {
 			this,
 		)
 
+		// Enable the cloud-provisioning `bump-prod-pin.yml` workflow to
+		// impersonate the GitHub Actions SA via WIF. It only reads prod AR
+		// (`crane manifest` provenance gate) before pushing the kustomize
+		// pin-bump; without this binding the auth step fails with
+		// `iam.serviceAccounts.getAccessToken denied`. See OpenSpec change
+		// `automate-prod-pin-bump`.
+		this.iamService.bindWifUser(
+			`${githubActionsSAName}-cloud-provisioning`,
+			`attribute.repository/liverty-music/cloud-provisioning`,
+			this.githubActionsSA,
+			this.pool,
+			this,
+		)
+
 		this.registerOutputs({
 			pool: this.pool,
 			provider: this.provider,


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
First real E2E (frontend **v1.5.0**) exercised the chain end-to-end and surfaced the last gap: the dispatch fired and the `bump-prod-pin.yml` run started, but its **provenance gate failed** with:
```
iam.serviceAccounts.getAccessToken denied ... crane manifest ...prod/frontend/web-app:v1.5.0
```
The prod `github-actions` SA's WIF impersonation (`bindWifUser`) was bound only to `attribute.repository/liverty-music/backend` and `.../frontend`. The bump workflow runs in **cloud-provisioning**, so its federated identity could not impersonate the SA to read prod AR.

Fix: add `bindWifUser` for `attribute.repository/liverty-music/cloud-provisioning`. The bump workflow only **reads** prod AR (the `crane manifest` provenance check); the `main` push is done separately as the ci-bot App.

## 🌍 Affected Stacks
- [x] Dev (no-op: this binds the **prod** SA; dev WIF is its own stack)
- [x] Prod

## 🔮 Pulumi Preview
Expect on prod: create one IAM member (WIF `workloadIdentityUser`/token-creator binding) granting the cloud-provisioning repo's federated principal impersonation of `github-actions@liverty-music-prod`. No other changes.

## ✅ Checklist
- [x] `make lint-ts` passes.
- [x] Scope: read-only AR usage; same shared CI SA pattern as backend/frontend.
