### PR TITLE
Revert "feat(prod): pin frontend prod overlay to v1.5.0"

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -1,14 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 # Prod frontend overlay. Env-divergent fields per design D2 / spec Requirement 3:
 #   - HTTPRoute hostname: liverty-music.app (apex) vs dev's dev.liverty-music.app
 #   - Runtime config (web-app-runtime-config ConfigMap) — prod hostnames,
 #     prod OIDC client/org IDs, prod VAPID key, `info` log level.
 # Resource sizing matches dev exactly; spot label matches.
+
 resources:
-  - ../../base
-  - configmap.yaml
+- ../../base
+- configmap.yaml
+
 namespace: frontend
+
 # Apply the Kubernetes Recommended Label `app.kubernetes.io/version` to every
 # rendered resource. Value SHALL be the bare semver without the leading `v`
 # (per Kubernetes Recommended Labels convention: `1.0.0`, not `v1.0.0`). Bump
@@ -21,42 +25,46 @@ namespace: frontend
 # - `includeTemplates: true` propagates the label to `spec.template.metadata.labels`
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
-  - pairs:
-      app.kubernetes.io/version: "1.5.0"
-    includeSelectors: false
-    includeTemplates: true
+- pairs:
+    app.kubernetes.io/version: "1.4.0"
+  includeSelectors: false
+  includeTemplates: true
+
 patches:
-  - path: spot-vm_patch.yaml
-    target:
-      kind: Deployment
-  # Match dev's resource sizing exactly (design D2).
-  - target:
-      kind: Deployment
-    patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: web-app
-      spec:
-        template:
-          spec:
-            containers:
-            - name: caddy
-              resources:
-                requests:
-                  cpu: 10m
-                  memory: 52Mi
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-  # Prod HTTPRoute hostname (apex).
-  - target:
-      kind: HTTPRoute
-      name: web-route
-    patch: |-
-      - op: add
-        path: /spec/hostnames
-        value: ["liverty-music.app"]
+- path: spot-vm_patch.yaml
+  target:
+    kind: Deployment
+
+# Match dev's resource sizing exactly (design D2).
+- target:
+    kind: Deployment
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: web-app
+    spec:
+      template:
+        spec:
+          containers:
+          - name: caddy
+            resources:
+              requests:
+                cpu: 10m
+                memory: 52Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+
+# Prod HTTPRoute hostname (apex).
+- target:
+    kind: HTTPRoute
+    name: web-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["liverty-music.app"]
+
 # Pin the web-app image to prod Artifact Registry with an immutable
 # semantic-version tag. Per OpenSpec `enable-prod-ar-immutable-tags` +
 # the `prod-image-tag-immutability` spec, prod uses semver tags (e.g.,
@@ -91,6 +99,6 @@ patches:
 # to main. ArgoCD auto-syncs. No manual pin-bump PR. See
 # docs/runbooks/prod-image-tag-pinning.md (OpenSpec change automate-prod-pin-bump).
 images:
-  - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
-    newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-    newTag: v1.5.0 # commit 751dc51e7155acd431a23d14b55fe9b197d9ad74
+- name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
+  newTag: v1.4.0  # commit 8e12fd182357632b2a6a18a1d0b75dca38c96b90


### PR DESCRIPTION
## 🔗 Related Issue
Refs liverty-music/specification#553

## 📝 Summary of Changes
**Rollback verification (OpenSpec `automate-prod-pin-bump` task 6.4).** Reverts the automated bump commit `954c8e74`, rolling the frontend prod overlay pin back `v1.5.0 → v1.4.0` (and the `app.kubernetes.io/version` label). On merge, ArgoCD should re-sync prod frontend to `v1.4.0` (the prior immutable tag, still in prod AR).

This also demonstrates the "human pushes still obey the ruleset" property: a human cannot push the revert directly to `main` (only the ci-bot App bypasses), so the rollback lands via this PR.

**After verification, prod will be restored to `v1.5.0`** by re-running the bump workflow.

## 🌍 Affected Stacks
- [ ] Dev
- [x] Prod (manifest-only; ArgoCD rolls frontend back to v1.4.0)

## 📦 State Changes
None (kustomize `newTag` + label revert only). Rollback is a pure manifest change; the v1.4.0 image is already in prod AR.

## ✅ Checklist
- [x] Revert restores `newTag: v1.4.0` + label `1.4.0`.
- [x] Temporary — prod restored to v1.5.0 immediately after.
