### PR TITLE
feat(backend): prod concert-discovery search cache TTL 72h

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
@@ -11,6 +11,12 @@ DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-os
 DATABASE_MAX_OPEN_CONNS=5
 DATABASE_MAX_IDLE_CONNS=1
 
+# Gemini concert search — longer freshness window in prod to cut API cost.
+# A completed search is reused for 72h (vs the 24h code default); the 14-day
+# post-discovery skip window stays at its default. See backend
+# GCP_GEMINI_SEARCH_CACHE_TTL / GCP_GEMINI_SEARCH_DISCOVERY_WINDOW.
+GCP_GEMINI_SEARCH_CACHE_TTL=72h
+
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry


### PR DESCRIPTION
Set `GCP_GEMINI_SEARCH_CACHE_TTL=72h` on the prod `concert-discovery` CronJob configmap to cut Gemini concert-search API cost (a completed search is reused for 72h vs the 24h code default). The 14-day post-discovery skip window keeps its default. Dev inherits the 24h default (unset).

Verified: `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders the value; kube-linter clean on the rendered backend overlay.

Depends on backend release exposing `GCP_GEMINI_SEARCH_CACHE_TTL` (liverty-music/backend#324). **Follow-up in this repo after the backend release:** bump the prod image pin (`images:` newTag) to the new `vX.Y.Z` so the new env is honored and the `last_found_at` migration ships.

Refs: liverty-music/backend#323