### PR TITLE
feat(zitadel): brand the hosted Login UI v2 with product colors

### DIFF
--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -13,6 +13,7 @@ export interface FrontendComponentArgs {
 export class FrontendComponent extends pulumi.ComponentResource {
 	public readonly application: zitadel.ApplicationOidc
 	public readonly loginPolicy: zitadel.LoginPolicy
+	public readonly labelPolicy: zitadel.LabelPolicy
 
 	constructor(
 		name: string,
@@ -118,9 +119,48 @@ export class FrontendComponent extends pulumi.ComponentResource {
 			resourceOptions,
 		)
 
+		// 3. Define zitadel.LabelPolicy resource — product-org branding for the
+		// hosted Login UI v2 (`/ui/v2/login/*`). Login UI v2 automatically
+		// honors the org/instance label policy, so branding the product org +
+		// enforcing it per-app (see `Project.privateLabelingSetting` in
+		// ../index.ts) is all that is needed to on-brand the login screen.
+		//
+		// Colors are derived from the frontend brand tokens (oklch → hex):
+		//   primary  #fd00a6  --color-brand-primary (pink)
+		//   bg       #ffffff / #0d1023  white / --color-surface-base
+		//   font     #161929 / #fafafa  dark navy / --color-text-primary
+		//   warn     #f14d4c  --color-error
+		// `logoPath`/`iconPath` are intentionally left unset — no brand logo
+		// asset exists yet; the logo is a deferred fast-follow. `setActive`
+		// stages-then-activates the policy so the change is live.
+		this.labelPolicy = new zitadel.LabelPolicy(
+			'brand',
+			{
+				orgId: orgId,
+				primaryColor: '#fd00a6',
+				primaryColorDark: '#fd00a6',
+				backgroundColor: '#ffffff',
+				backgroundColorDark: '#0d1023',
+				fontColor: '#161929',
+				fontColorDark: '#fafafa',
+				warnColor: '#f14d4c',
+				warnColorDark: '#f14d4c',
+				// Follow the system theme; the v2 login exposes a toggle and both
+				// palettes are defined.
+				themeMode: 'THEME_MODE_AUTO',
+				// Suppress any future Zitadel watermark.
+				disableWatermark: true,
+				// Cleaner consumer login name (no org-domain suffix).
+				hideLoginNameSuffix: true,
+				setActive: true,
+			},
+			resourceOptions,
+		)
+
 		this.registerOutputs({
 			application: this.application,
 			loginPolicy: this.loginPolicy,
+			labelPolicy: this.labelPolicy,
 		})
 	}
 }

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -248,8 +248,17 @@ export class Zitadel {
 				projectRoleAssertion: false,
 				projectRoleCheck: false,
 				hasProjectCheck: false,
-				// Use default private labeling to avoid potential policy conflicts with instance SMTP
-				privateLabelingSetting: 'PRIVATE_LABELING_SETTING_UNSPECIFIED',
+				// Enforce the product org's own LabelPolicy (see
+				// `FrontendComponent.labelPolicy`) for this app's login flow,
+				// regardless of the logging-in user's resource-owner org. Zitadel
+				// has no application-level label policy; this project setting is
+				// the per-application control that selects which org's branding
+				// the hosted Login UI v2 renders. The admin/console org login is
+				// a separate org and stays unaffected. Supersedes the prior
+				// defensive `UNSPECIFIED` (its SMTP-conflict caution was unrelated
+				// to label policy). See OpenSpec change `brand-zitadel-login-ui`.
+				privateLabelingSetting:
+					'PRIVATE_LABELING_SETTING_ENFORCE_PROJECT_RESOURCE_OWNER_POLICY',
 			},
 			{ provider: this.provider, dependsOn: [this.productOrg] },
 		)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #346

## 📝 Summary of Changes
Brands the self-hosted Zitadel hosted Login UI v2 (`/ui/v2/login/*`) with Liverty Music colors. Previously the product login rendered with the default unbranded Zitadel appearance (neutral colors, watermark) because the product org had no label policy and the project's private-labeling setting was `UNSPECIFIED`.

- **`src/zitadel/components/frontend.ts`** — add a `zitadel.LabelPolicy` (`brand`) on the `liverty-music` product org:
  - Brand palette derived from the frontend brand tokens (oklch → hex): primary `#fd00a6`; background `#ffffff` (light) / `#0d1023` (dark); font `#161929` (light) / `#fafafa` (dark); warn `#f14d4c`.
  - `themeMode: THEME_MODE_AUTO`, `disableWatermark: true`, `hideLoginNameSuffix: true`, `setActive: true`.
  - Logo/icon intentionally left unset — no brand logo asset exists yet (deferred fast-follow).
- **`src/zitadel/index.ts`** — flip the product `Project.privateLabelingSetting` from `PRIVATE_LABELING_SETTING_UNSPECIFIED` to `PRIVATE_LABELING_SETTING_ENFORCE_PROJECT_RESOURCE_OWNER_POLICY` so the product app's login flow always renders this org's branding regardless of the logging-in user's resource-owner org.

Zitadel has no application-level label policy; org-level `LabelPolicy` + the project's `privateLabelingSetting` is the per-application enforcement mechanism. The admin/console org is a separate org and is unaffected.

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview
See the CI / Pulumi Cloud preview on this PR. Expected diff: one `zitadel:index/labelPolicy:LabelPolicy` **create** + one `zitadel:index/project:Project` **update** (`privateLabelingSetting`). No other resource churn expected.

## 📦 State Changes
None. No `pulumi state mv` / `import` / destructive changes. `LabelPolicy` is a net-new resource; the `Project` update is an in-place field change.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI. <!-- runs in Pulumi Cloud on this PR; local dev preview skipped (dev env intentionally stopped) -->
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config. <!-- N/A — colors only, no secrets -->
