### PR TITLE
feat(backend): schedule merch-discovery CronJob (daily prod, weekly dev)

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${COMPONENT}" = "backend" ]; then
-            images="server consumer concert-discovery artist-image-sync"
+            images="server consumer concert-discovery artist-image-sync merch-discovery"
           else
             images="web-app"
           fi

--- a/k8s/namespaces/backend/base/cronjob/merch-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/merch-discovery/configmap.env
@@ -1,0 +1,24 @@
+# Environment
+ENVIRONMENT=TO_REPLACE_BY_OVERLAY
+# Logging
+LOGGING_LEVEL=debug
+LOGGING_FORMAT=json
+# Telemetry
+TELEMETRY_SERVICE_NAME=liverty-music-merch-discovery
+# GCP (Defaults) — Gemini API key is supplied via backend-secrets
+# (GCP_GEMINI_SEARCH_API_KEY). The merch model (GCP_GEMINI_MERCH_MODEL) and
+# look-ahead window (GCP_MERCH_DISCOVERY_WINDOW) fall back to their code
+# defaults (Flash-Lite / 60 days) unless overridden per environment.
+GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
+GCP_LOCATION=global
+# Database (Defaults)
+DATABASE_NAME=liverty-music
+DATABASE_HOST=postgres.osaka.psc.internal
+DATABASE_PORT=5432
+DATABASE_USER=TO_REPLACE_BY_OVERLAY
+# Must be 'disable' because the Cloud SQL Connector handles internal encryption.
+DATABASE_SSL_MODE=disable
+DATABASE_SCHEMA=app
+
+# Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
+SHUTDOWN_TIMEOUT=90s

--- a/k8s/namespaces/backend/base/cronjob/merch-discovery/cronjob.yaml
+++ b/k8s/namespaces/backend/base/cronjob/merch-discovery/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: merch-discovery-app
+spec:
+  schedule: "0 11 * * *" # 20:00 JST daily (after concert-discovery 18:00 / artist-image-sync 19:00)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          terminationGracePeriodSeconds: 120
+          serviceAccountName: backend-app
+          restartPolicy: Never
+          containers:
+          - name: merch-discovery
+            image: merch-discovery
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: merch-discovery-job-config
+            - secretRef:
+                name: backend-secrets
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 250m
+                memory: 256Mi

--- a/k8s/namespaces/backend/base/cronjob/merch-discovery/kustomization.yaml
+++ b/k8s/namespaces/backend/base/cronjob/merch-discovery/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cronjob.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: merch-discovery
+
+images:
+- name: merch-discovery
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/merch-discovery
+  newTag: latest
+
+configMapGenerator:
+- name: merch-discovery-job-config
+  envs:
+  - configmap.env

--- a/k8s/namespaces/backend/base/kustomization.yaml
+++ b/k8s/namespaces/backend/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - server
 - cronjob/concert-discovery
 - cronjob/artist-image-sync
+- cronjob/merch-discovery
 - consumer
 
 namespace: backend

--- a/k8s/namespaces/backend/overlays/dev/cronjob/merch-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/merch-discovery/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=development
+# GCP
+GCP_PROJECT_ID=liverty-music-dev
+# Database
+DATABASE_USER=backend-app@liverty-music-dev.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/dev/cronjob/merch-discovery/schedule_patch.yaml
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/merch-discovery/schedule_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: merch-discovery-app
+spec:
+  schedule: "0 11 * * 5" # Fridays only at 20:00 JST (weekly in dev, mirroring concert-discovery)

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -72,6 +72,12 @@ patches:
     kind: CronJob
     name: concert-discovery-app
 
+# CronJob: run merch discovery only on Fridays in dev
+- path: cronjob/merch-discovery/schedule_patch.yaml
+  target:
+    kind: CronJob
+    name: merch-discovery-app
+
 # Right-size resources for consumer in dev
 - target:
     kind: Deployment
@@ -119,6 +125,10 @@ configMapGenerator:
   behavior: merge
   envs:
   - cronjob/artist-image-sync/configmap.env
+- name: merch-discovery-job-config
+  behavior: merge
+  envs:
+  - cronjob/merch-discovery/configmap.env
 - name: consumer-consumer-config
   behavior: merge
   envs:

--- a/k8s/namespaces/backend/overlays/prod/cronjob/merch-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/merch-discovery/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=production
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -138,6 +138,10 @@ configMapGenerator:
     behavior: merge
     envs:
       - cronjob/artist-image-sync/configmap.env
+  - name: merch-discovery-job-config
+    behavior: merge
+    envs:
+      - cronjob/merch-discovery/configmap.env
   - name: consumer-consumer-config
     behavior: merge
     envs:
@@ -188,4 +192,7 @@ images:
     newTag: v1.4.0 # commit 536230bff1f7973eafe4c672dfd0e7af38a69309
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/artist-image-sync
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/artist-image-sync
+    newTag: v1.4.0 # commit 536230bff1f7973eafe4c672dfd0e7af38a69309
+  - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/merch-discovery
+    newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/merch-discovery
     newTag: v1.4.0 # commit 536230bff1f7973eafe4c672dfd0e7af38a69309


### PR DESCRIPTION
## 🔗 Related Issue
Refs #569

<!-- Not "Closes": the issue spans specification + backend + frontend + cloud-provisioning; resolved only once the whole feature ships. -->

## 📝 Summary of Changes

Adds the Kubernetes scheduling for the new merch-url discovery job (`cmd/job/merch-discovery` in backend), which keeps `Series.merch_url` populated and healthy.

- **New `merch-discovery` CronJob** base manifest (daily, 20:00 JST — after concert-discovery/artist-image-sync), mirroring `artist-image-sync`: runs as `serviceAccountName: backend-app`, config from a `merch-discovery-job-config` ConfigMap + `backend-secrets`, spot-VM nodeSelector via the existing dev CronJob patch.
- **Dev overlay** patches the schedule to weekly (Fridays); **prod** keeps the base daily schedule and pins the prod-AR image by semver.
- Reuses the existing `backend-app` service account (already granted Vertex AI / Gemini + Cloud SQL) and the existing `backend` Artifact Registry repo — **no new IAM, K8s ServiceAccount, or AR repo**.
- Extends the `bump-prod-pin` provenance gate to verify the merch-discovery prod image exists before pinning it.

This is K8s-manifest only — **no `src/` (Pulumi) changes**.

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

N/A — no `src/**` changes, so no Pulumi diff. `kubectl kustomize` renders both `overlays/dev` and `overlays/prod` cleanly (merch-discovery CronJob: dev `0 11 * * 5` + dev AR `:latest`; prod `0 11 * * *` + prod AR `:vX.Y.Z`; `backend-app` SA; spot nodeSelector).

## 📦 State Changes
None. Manifest-only; no `pulumi state mv` / `import` / destructive changes.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI. <!-- N/A — no src/ changes; CI lint-k8s renders manifests -->
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config. <!-- Gemini API key comes from backend-secrets (existing); no new secrets -->
