### PR TITLE
feat(zitadel): seed Japanese hosted-login translation override

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
         "useIgnoreFile": true
     },
     "files": {
-        "ignoreUnknown": false
+        "ignoreUnknown": false,
+        "includes": ["**", "!src/zitadel/translations/**"]
     },
     "formatter": {
         "enabled": true,

--- a/src/zitadel/dynamic/hosted-login-translation.ts
+++ b/src/zitadel/dynamic/hosted-login-translation.ts
@@ -1,0 +1,166 @@
+import * as pulumi from '@pulumi/pulumi'
+import { type JwtProfile, zitadelApiCall } from './api-client.js'
+
+export interface ZitadelHostedLoginTranslationArgs {
+	/** Zitadel domain, e.g. `auth.liverty-music.app`. */
+	domain: pulumi.Input<string>
+	/** Admin machine user JWT profile JSON (stringified) for Settings v2 auth. */
+	jwtProfileJson: pulumi.Input<string>
+	/**
+	 * Organization id to scope the override to (org-level translation). When
+	 * omitted, the override is applied at instance level. Scoping to the
+	 * product org keeps the admin/console org login unaffected.
+	 */
+	organizationId?: pulumi.Input<string>
+	/** BCP 47 locale, e.g. `ja`. */
+	locale: pulumi.Input<string>
+	/**
+	 * Full translation payload (Hosted Login translation schema, identical to
+	 * the upstream `apps/login/locales/<locale>.json`). MUST be the COMPLETE
+	 * key set: the Settings API English-fills any key omitted here, and the
+	 * login app merges the API result OVER its bundled locale file, so a
+	 * partial override leaves the un-supplied keys in English.
+	 */
+	translationsJson: pulumi.Input<string>
+}
+
+interface Inputs {
+	domain: string
+	jwtProfileJson: string
+	organizationId?: string
+	locale: string
+	translationsJson: string
+}
+
+interface Outputs extends Inputs {
+	/** sha256 of `translationsJson` so payload edits produce a clean diff. */
+	translationsHash: string
+	appliedAt: string
+}
+
+function sha256(s: string): string {
+	const crypto = require('node:crypto') as typeof import('node:crypto')
+	return crypto.createHash('sha256').update(s).digest('hex')
+}
+
+/** Build the SetHostedLoginTranslation request body (level oneof + payload). */
+function buildBody(inputs: Inputs): Record<string, unknown> {
+	const level = inputs.organizationId
+		? { organizationId: inputs.organizationId }
+		: { instance: true }
+	return {
+		...level,
+		locale: inputs.locale,
+		translations: JSON.parse(inputs.translationsJson) as unknown,
+	}
+}
+
+async function setTranslation(inputs: Inputs): Promise<void> {
+	const profile = JSON.parse(inputs.jwtProfileJson) as JwtProfile
+	const res = await zitadelApiCall({
+		domain: inputs.domain,
+		profile,
+		method: 'POST',
+		path: '/zitadel.settings.v2.SettingsService/SetHostedLoginTranslation',
+		body: buildBody(inputs),
+	})
+	if (res.statusCode < 200 || res.statusCode >= 300) {
+		throw new Error(
+			`Zitadel SetHostedLoginTranslation failed (${res.statusCode}): ${res.body}`,
+		)
+	}
+}
+
+/**
+ * Provider for `ZitadelHostedLoginTranslation`. `SetHostedLoginTranslation`
+ * is an idempotent upsert (it overwrites the stored translation for the given
+ * level + locale), so `create` and `update` both POST the full payload.
+ *
+ * - `create()` / `update()` POST the complete translation payload.
+ * - `delete()` is a no-op by design: removing the Pulumi record should not
+ *   wipe the live override (mirrors `ZitadelSmtpActivation`). Retiring the
+ *   override once upstream ships the language defaults (see OpenSpec change
+ *   `fix-zitadel-login-ja-i18n`, exit condition) is a deliberate manual step.
+ * - `read()` is a no-op returning current outputs; drift detection against the
+ *   live translation is not needed — the payload hash drives diffs.
+ */
+export const hostedLoginTranslationProvider: pulumi.dynamic.ResourceProvider = {
+	async create(
+		inputs: Inputs,
+	): Promise<pulumi.dynamic.CreateResult<Outputs>> {
+		await setTranslation(inputs)
+		const idScope = inputs.organizationId ?? 'instance'
+		return {
+			id: `hosted-login-translation:${idScope}:${inputs.locale}`,
+			outs: {
+				...inputs,
+				translationsHash: sha256(inputs.translationsJson),
+				appliedAt: new Date().toISOString(),
+			},
+		}
+	},
+
+	async update(
+		_id: string,
+		_olds: Outputs,
+		news: Inputs,
+	): Promise<pulumi.dynamic.UpdateResult<Outputs>> {
+		await setTranslation(news)
+		return {
+			outs: {
+				...news,
+				translationsHash: sha256(news.translationsJson),
+				appliedAt: new Date().toISOString(),
+			},
+		}
+	},
+
+	async delete(_id: string, _state: Outputs): Promise<void> {
+		// No-op by design — see class doc. Removing the resource record does
+		// not clear the upstream override.
+	},
+
+	async read(
+		id: string,
+		state: Outputs,
+	): Promise<pulumi.dynamic.ReadResult<Outputs>> {
+		return { id, props: state }
+	},
+}
+
+/**
+ * `ZitadelHostedLoginTranslation` provisions a Zitadel Hosted Login Translation
+ * override (Settings v2 `SetHostedLoginTranslation`) for a single locale.
+ *
+ * Why this exists: Zitadel's backend default hosted-login translations
+ * (`internal/query/v2-default.json`) omit Japanese (and several other
+ * languages present in the login app's `locales/`). For a missing language the
+ * Settings API returns the instance default language (English), and the Login
+ * UI v2 merges that API result OVER its own bundled `ja.json` — so the Japanese
+ * login renders English. Seeding the full Japanese payload here makes the API
+ * return Japanese, which the login app then renders. See OpenSpec change
+ * `fix-zitadel-login-ja-i18n`. The upstream permanent fix is to add the missing
+ * languages to `v2-default.json`; once a deployed Zitadel version ships that,
+ * this resource can be removed.
+ */
+export class ZitadelHostedLoginTranslation extends pulumi.dynamic.Resource {
+	public readonly translationsHash!: pulumi.Output<string>
+	public readonly appliedAt!: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: ZitadelHostedLoginTranslationArgs,
+		opts?: pulumi.CustomResourceOptions,
+	) {
+		super(
+			hostedLoginTranslationProvider,
+			name,
+			{
+				...args,
+				translationsHash: undefined,
+				appliedAt: undefined,
+			},
+			opts,
+		)
+	}
+}

--- a/src/zitadel/dynamic/hosted-login-translation.ts
+++ b/src/zitadel/dynamic/hosted-login-translation.ts
@@ -143,6 +143,28 @@ export const hostedLoginTranslationProvider: pulumi.dynamic.ResourceProvider = {
  * languages to `v2-default.json`; once a deployed Zitadel version ships that,
  * this resource can be removed.
  */
+/**
+ * Bake `jwtProfileJson` into `additionalSecretOutputs` so the admin machine-user
+ * RS256 private key cannot regress to plaintext in the Pulumi state checkpoint.
+ * `pulumi.secret(...)` on an INPUT does NOT auto-propagate secret status to an
+ * identically-named OUTPUT across the dynamic-resource RPC boundary, and the
+ * provider echoes `...inputs` into `outs` in `create()`/`update()`. Merge with
+ * caller-supplied additions rather than overwrite. Module-private (the
+ * barrel re-exports every module with `export *`, and `permanent-password.ts`
+ * already exports a `mergeSecretOutputs`); mirrors that helper's contract.
+ */
+function mergeSecretOutputs(
+	opts?: pulumi.CustomResourceOptions,
+): pulumi.CustomResourceOptions {
+	return {
+		...opts,
+		additionalSecretOutputs: [
+			'jwtProfileJson',
+			...(opts?.additionalSecretOutputs ?? []),
+		],
+	}
+}
+
 export class ZitadelHostedLoginTranslation extends pulumi.dynamic.Resource {
 	public readonly translationsHash!: pulumi.Output<string>
 	public readonly appliedAt!: pulumi.Output<string>
@@ -160,7 +182,7 @@ export class ZitadelHostedLoginTranslation extends pulumi.dynamic.Resource {
 				translationsHash: undefined,
 				appliedAt: undefined,
 			},
-			opts,
+			mergeSecretOutputs(opts),
 		)
 	}
 }

--- a/src/zitadel/dynamic/index.ts
+++ b/src/zitadel/dynamic/index.ts
@@ -1,4 +1,5 @@
 export * from './execution.js'
+export * from './hosted-login-translation.js'
 export * from './permanent-password.js'
 export * from './smtp-activation.js'
 export * from './target.js'

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import * as gcp from '@pulumi/gcp'
 import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
@@ -17,6 +19,22 @@ import {
 	PRE_ACCESS_TOKEN_PATH,
 	zitadelDomainMap,
 } from './constants.js'
+import { ZitadelHostedLoginTranslation } from './dynamic/index.js'
+
+/**
+ * Complete Japanese Hosted Login translation payload, pinned from upstream
+ * `zitadel/zitadel apps/login/locales/ja.json` at the deployed login version
+ * (`v4.14.0`). Seeded via `ZitadelHostedLoginTranslation` because Zitadel's
+ * backend defaults omit Japanese, so the Settings API otherwise returns English
+ * for `ja` and the Login UI v2 renders the Japanese login in English. MUST stay
+ * complete (the API English-fills omitted keys). Re-sync on Zitadel upgrades;
+ * remove once upstream `v2-default.json` ships Japanese. See OpenSpec change
+ * `fix-zitadel-login-ja-i18n`.
+ */
+const jaLoginTranslationJson = readFileSync(
+	fileURLToPath(new URL('./translations/ja.json', import.meta.url)),
+	'utf-8',
+)
 
 export * from './components/actions-v2.js'
 export * from './components/admin-org-config.js'
@@ -126,6 +144,8 @@ export class Zitadel {
 	public readonly productOrg: zitadel.Org
 	public readonly project: zitadel.Project
 	public readonly frontend: FrontendComponent
+	/** Japanese Hosted Login translation override for the product org. */
+	public readonly jaLoginTranslation: ZitadelHostedLoginTranslation
 	public readonly smtp: SmtpComponent
 	public readonly actionsV2: ActionsV2Component
 	public readonly machineUser: MachineUserComponent
@@ -269,6 +289,24 @@ export class Zitadel {
 			projectId: this.project.id,
 			provider: this.provider,
 		})
+
+		// Japanese Hosted Login translation override, scoped to the product
+		// org. Zitadel's backend default hosted-login translations omit `ja`,
+		// so the Settings API returns English for the `ja` locale and the
+		// Login UI v2 merges that over its bundled Japanese — rendering the
+		// Japanese login in English. Seeding the full Japanese payload here
+		// makes the API return Japanese. Org-scoped so the admin/console org
+		// login is unaffected. See OpenSpec change `fix-zitadel-login-ja-i18n`.
+		this.jaLoginTranslation = new ZitadelHostedLoginTranslation(
+			`${name}-ja-login-translation`,
+			{
+				domain,
+				jwtProfileJson,
+				organizationId: this.productOrg.id,
+				locale: 'ja',
+				translationsJson: jaLoginTranslationJson,
+			},
+		)
 
 		this.smtp = new SmtpComponent(name, {
 			env,

--- a/src/zitadel/translations/ja.json
+++ b/src/zitadel/translations/ja.json
@@ -1,0 +1,461 @@
+{
+  "common": {
+    "back": "戻る",
+    "title": "Zitadelでログイン"
+  },
+  "accounts": {
+    "title": "アカウント",
+    "description": "使用するアカウントを選択してください。",
+    "addAnother": "別のアカウントを追加",
+    "noResults": "アカウントが見つかりません",
+    "verified": "認証済み",
+    "expired": "期限切れ"
+  },
+  "logout": {
+    "title": "ログアウト",
+    "description": "セッションを終了するアカウントをクリックしてください",
+    "noResults": "アカウントが見つかりません",
+    "clear": "セッション終了",
+    "verifiedAt": "最後のアクティブ: {time}",
+    "success": {
+      "title": "ログアウト完了",
+      "description": "正常にログアウトしました。"
+    }
+  },
+  "loginname": {
+    "title": "お帰りなさい！",
+    "description": "ログイン情報を入力してください。",
+    "register": "新規ユーザー登録",
+    "submit": "続行",
+    "labels": {
+      "loginname": "ログイン名",
+      "username": "ユーザー名",
+      "usernameOrPhoneNumber": "ユーザー名または電話番号",
+      "usernameOrEmail": "ユーザー名またはメールアドレス"
+    },
+    "required": {
+      "loginName": "必須項目です"
+    },
+    "errors": {
+      "internalError": "内部エラーが発生しました",
+      "couldNotGetLoginSettings": "ログイン設定を取得できませんでした",
+      "couldNotSearchUsers": "ユーザーを検索できませんでした",
+      "couldNotGetDomain": "ドメインを取得できませんでした",
+      "couldNotGetHost": "ホストを取得できませんでした",
+      "couldNotStartIDPFlow": "IDPフローを開始できませんでした",
+      "moreThanOneUserFound": "複数のユーザーが見つかりました。一意の識別子を指定してください。",
+      "userNotFound": "ユーザーがシステムに見つかりません",
+      "couldNotCreateSession": "ユーザーのセッションを作成できませんでした",
+      "initialUserNotSupported": "初期ユーザーはサポートされていません",
+      "localAuthenticationNotAllowed": "ローカル認証は許可されていません！ 詳細については管理者に問い合わせてください。",
+      "passkeysNotAllowed": "パスキーは許可されていません！詳細については管理者にお問い合わせください。",
+      "couldNotFindIdentityProvider": "IDプロバイダーが見つかりませんでした。",
+      "userNotActive": "ユーザーはアクティブではありません。詳細については管理者にお問い合わせください。"
+    }
+  },
+  "password": {
+    "verify": {
+      "title": "パスワード",
+      "description": "パスワードを入力してください。",
+      "resetPassword": "パスワードをリセット",
+      "submit": "続行",
+      "labels": {
+        "password": "パスワード"
+      },
+      "required": {
+        "password": "必須項目です"
+      },
+      "errors": {
+        "couldNotVerifyPassword": "パスワードを確認できませんでした",
+        "couldNotResetPassword": "パスワードをリセットできませんでした"
+      },
+      "info": {
+        "passwordResetSent": "パスワードがリセットされました。メールを確認してください"
+      }
+    },
+    "set": {
+      "title": "パスワード設定",
+      "description": "アカウントのパスワードを設定してください",
+      "codeSent": "新しいコードがメールアドレスに送信されました。",
+      "noCodeReceived": "コードが届きませんか？",
+      "resend": "コードを再送信",
+      "submit": "続行",
+      "labels": {
+        "code": "コード",
+        "newPassword": "新しいパスワード",
+        "confirmPassword": "パスワード確認"
+      },
+      "required": {
+        "code": "必須項目です",
+        "newPassword": "パスワードを入力してください！",
+        "confirmPassword": "必須項目です"
+      },
+      "errors": {
+        "couldNotSetPassword": "パスワードを設定できませんでした",
+        "couldNotResetPassword": "パスワードをリセットできませんでした",
+        "couldNotVerifyPassword": "パスワードを確認できませんでした"
+      }
+    },
+    "change": {
+      "title": "パスワード変更",
+      "description": "アカウントのパスワードを設定してください",
+      "submit": "続行",
+      "labels": {
+        "currentPassword": "現在のパスワード",
+        "newPassword": "新しいパスワード",
+        "confirmPassword": "パスワード確認"
+      },
+      "required": {
+        "currentPassword": "現在のパスワードを入力してください！",
+        "newPassword": "新しいパスワードを入力してください！",
+        "confirmPassword": "必須項目です"
+      },
+      "errors": {
+        "currentPasswordInvalid": "現在のパスワードが正しくありません。",
+        "couldNotChangePassword": "パスワードを変更できませんでした",
+        "couldNotVerifyPassword": "パスワードを確認できませんでした",
+        "unknownError": "不明なエラー"
+      }
+    },
+    "errors": {
+      "passwordVerificationMissing": "パスワード確認がありません。",
+      "passwordVerificationTooOld": "パスワード確認が古すぎます。もう一度パスワードを確認してください。",
+      "noHostFound": "ホストが見つかりません",
+      "couldNotSendResetLink": "パスワードリセットリンクを送信できませんでした",
+      "couldNotCreateSessionForUser": "ユーザーのセッションを作成できませんでした",
+      "couldNotVerifyPassword": "パスワードを確認できませんでした",
+      "failedToAuthenticate": "認証に失敗しました。パスワード試行回数 {maxPasswordAttempts} 回中 {failedAttempts} 回失敗しました。{lockoutMessage}",
+      "failedToAuthenticateNoLimit": "認証に失敗しました。",
+      "accountLockedContactAdmin": " アカウントのロックを解除するには管理者に連絡してください",
+      "userNotFound": "ユーザーがシステムに見つかりません",
+      "initialUserNotSupported": "初期ユーザーはサポートされていません",
+      "userInitialStateNotSupported": "ユーザーの初期状態はサポートされていません",
+      "codeOrVerificationRequired": "コードを提供するか、有効なユーザー確認チェックを行う必要があります",
+      "verificationRequired": "ユーザー確認チェックを行う必要があります",
+      "couldNotLoadSession": "セッションを読み込めませんでした",
+      "couldNotLoadAuthMethods": "認証方法を読み込めませんでした",
+      "failedPrecondition": "前提条件に失敗しました",
+      "sessionNotValid": "セッションが無効です"
+    },
+    "complexity": {
+      "length": "{minLength} 文字以上である必要があります。",
+      "hasSymbol": "記号を含める必要があります。",
+      "hasNumber": "数字を含める必要があります。",
+      "hasUppercase": "大文字を含める必要があります。",
+      "hasLowercase": "小文字を含める必要があります。",
+      "equals": "パスワード確認が一致しました。",
+      "matches": "一致します",
+      "doesNotMatch": "一致しません"
+    }
+  },
+  "idp": {
+    "title": "SSOでサインイン",
+    "description": "以下のプロバイダーを選択してサインインしてください",
+    "orSignInWith": "または次でサインイン",
+    "signInWithApple": "Appleでサインイン",
+    "signInWithGoogle": "Googleでサインイン",
+    "signInWithAzureAD": "AzureADでサインイン",
+    "signInWithGithub": "GitHubでサインイン",
+    "signInWithGitlab": "GitLabでサインイン",
+    "loginError": {
+      "title": "ログイン失敗",
+      "description": "ログインの際にエラーが発生しました。"
+    },
+    "linkingError": {
+      "title": "アカウント連携失敗",
+      "description": "アカウント連携の際にエラーが発生しました。"
+    },
+    "completeRegister": {
+      "title": "データを完成させる",
+      "description": "メールアドレスと名前を入力して登録を完了してください。"
+    },
+    "accountNotFound": {
+      "title": "アカウントが見つかりません",
+      "description": "アイデンティティプロバイダの認証情報に関連付けられたアカウントが見つかりませんでした。",
+      "info": "既存のアカウントが見つかりませんでした。既存のアカウントでサインインするか、管理者にお問い合わせください。",
+      "backToLogin": "ログインに戻る"
+    },
+    "registrationFailed": {
+      "title": "登録が利用できません",
+      "description": "登録プロセスを完了できませんでした。",
+      "info": "登録する組織を特定できませんでした。管理者にお問い合わせください。",
+      "backToLogin": "ログインに戻る"
+    },
+    "processing": {
+      "message": "認証を処理しています...",
+      "noRedirect": "サーバーからリダイレクトまたはエラーが返されませんでした",
+      "unexpectedError": "予期しないエラーが発生しました"
+    },
+    "errors": {
+      "missingParameters": "必要なパラメータが不足しています",
+      "missingIdpInfo": "IDP情報が不足しています",
+      "idpNotFound": "アイデンティティプロバイダが見つかりません",
+      "linkingNotAllowed": "このアイデンティティプロバイダとの連携は許可されていません",
+      "linkingFailed": "アイデンティティプロバイダのアカウントへの連携に失敗しました",
+      "autoLinkingFailed": "アカウントの自動連携に失敗しました",
+      "userCreationFailed": "ユーザーアカウントの作成に失敗しました",
+      "orgResolutionFailed": "登録する組織を特定できませんでした",
+      "sessionCreationFailed": "セッションの作成またはリダイレクトの決定に失敗しました",
+      "unknownError": "不明なエラーが発生しました"
+    }
+  },
+  "ldap": {
+    "title": "LDAPログイン",
+    "description": "LDAP認証情報を入力してください。",
+    "submit": "続行",
+    "labels": {
+      "username": "ユーザー名",
+      "password": "パスワード"
+    },
+    "required": {
+      "username": "必須項目です",
+      "password": "必須項目です"
+    }
+  },
+  "mfa": {
+    "verify": {
+      "title": "本人確認",
+      "description": "以下の要素の中から一つを選択してください。",
+      "noResults": "設定可能な二要素認証がありません。"
+    },
+    "set": {
+      "title": "二要素認証の設定",
+      "description": "以下の二要素認証の中から一つを選択してください。",
+      "skip": "スキップ"
+    }
+  },
+  "otp": {
+    "verify": {
+      "title": "二要素認証",
+      "totpDescription": "認証アプリからコードを入力してください。",
+      "smsDescription": "SMSで受信したコードを入力してください。",
+      "emailDescription": "メールで受信したコードを入力してください。",
+      "noCodeReceived": "コードが届きませんか？",
+      "resendCode": "コードを再送信",
+      "submit": "続行",
+      "labels": {
+        "code": "コード"
+      },
+      "required": {
+        "code": "必須項目です"
+      }
+    },
+    "set": {
+      "title": "二要素認証の設定",
+      "totpDescription": "認証アプリでQRコードをスキャンしてください。",
+      "smsDescription": "SMSでコードを受信する電話番号を入力してください。",
+      "emailDescription": "メールでコードを受信するメールアドレスを入力してください。",
+      "totpRegisterDescription": "QRコードをスキャンするか、URLに手動でアクセスしてください。",
+      "submit": "続行",
+      "labels": {
+        "code": "コード"
+      },
+      "required": {
+        "code": "必須項目です"
+      }
+    }
+  },
+  "passkey": {
+    "verify": {
+      "title": "パスキーで認証",
+      "description": "デバイスが指紋、顔、または画面ロックの入力を求めます",
+      "usePassword": "パスワードを使用",
+      "submit": "続行",
+      "errors": {
+        "couldNotRequestChallenge": "パスキーチャレンジを要求できませんでした",
+        "couldNotVerifyPasskey": "パスキーを確認できませんでした",
+        "noResponseReceived": "パスキー確認に失敗しました - 応答がありません",
+        "noRedirectProvided": "パスキー確認は完了しましたが、リダイレクトが提供されませんでした",
+        "couldNotRetrievePasskey": "パスキーの取得中にエラーが発生しました",
+        "verificationCancelled": "パスキー確認がキャンセルされました",
+        "verificationFailed": "パスキー確認中にエラーが発生しました",
+        "couldNotFindSession": "セッションが見つかりませんでした",
+        "couldNotUpdateSession": "セッションを更新できませんでした",
+        "userNotFound": "ユーザーがシステムに見つかりません",
+        "couldNotDetermineRedirect": "パスキー確認後のリダイレクトURLを決定できませんでした"
+      }
+    },
+    "set": {
+      "title": "パスキーの設定",
+      "description": "デバイスが指紋、顔、または画面ロックの入力を求めます",
+      "info": {
+        "description": "パスキーは、指紋やApple FaceIDなどのデバイス上の認証方法です。",
+        "link": "パスキー認証"
+      },
+      "skip": "スキップ",
+      "submit": "続行"
+    }
+  },
+  "u2f": {
+    "verify": {
+      "title": "二要素認証",
+      "description": "デバイスでアカウントを確認してください。"
+    },
+    "set": {
+      "title": "二要素認証の設定",
+      "description": "デバイスを二要素認証として設定します。",
+      "submit": "続行"
+    }
+  },
+  "register": {
+    "methods": {
+      "passkey": "パスキー",
+      "password": "パスワード"
+    },
+    "disabled": {
+      "title": "登録が無効",
+      "description": "登録が無効になっています。管理者にお問い合わせください。"
+    },
+    "missingdata": {
+      "title": "データが不足",
+      "description": "登録するにはメールアドレス、姓、名を入力してください。"
+    },
+    "title": "登録",
+    "description": "Zitadelアカウントを作成します。",
+    "noMethodAvailableWarning": "使用可能な認証方法がありません。管理者にお問い合わせください。",
+    "selectMethod": "認証に使用する方法を選択してください",
+    "agreeTo": "登録するには利用規約に同意する必要があります",
+    "termsOfService": "利用規約",
+    "privacyPolicy": "プライバシーポリシー",
+    "submit": "続行",
+    "password": {
+      "title": "パスワード設定",
+      "description": "アカウントのパスワードを設定してください",
+      "submit": "続行",
+      "labels": {
+        "password": "パスワード",
+        "confirmPassword": "パスワード確認"
+      },
+      "required": {
+        "password": "パスワードを入力してください！",
+        "confirmPassword": "必須項目です"
+      }
+    },
+    "labels": {
+      "firstname": "名",
+      "lastname": "姓",
+      "email": "メールアドレス"
+    },
+    "required": {
+      "firstname": "必須項目です",
+      "lastname": "必須項目です",
+      "email": "必須項目です"
+    },
+    "errors": {
+      "couldNotCreateUser": "ユーザーを作成できませんでした",
+      "couldNotCreateSession": "セッションを作成できませんでした",
+      "userNotFound": "ユーザーがシステムに見つかりません",
+      "couldNotLinkIDP": "IDPをユーザーにリンクできませんでした",
+      "couldNotRegisterUser": "ユーザーを登録できませんでした"
+    }
+  },
+  "invite": {
+    "title": "ユーザー招待",
+    "description": "招待するユーザーのメールアドレスと名前を入力してください。",
+    "info": "ユーザーには詳細な手順が記載されたメールが送信されます。",
+    "notAllowed": "設定によりユーザーを招待できません。",
+    "submit": "続行",
+    "success": {
+      "title": "ユーザーを招待しました",
+      "description": "メールが正常に送信されました。",
+      "verified": "ユーザーが招待され、既にメールアドレスが確認済みです。",
+      "notVerifiedYet": "ユーザーが招待されました。詳細な手順が記載されたメールを受信します。",
+      "submit": "別のユーザーを招待"
+    }
+  },
+  "signedin": {
+    "title": "ようこそ {user}さん！",
+    "description": "サインインしました。",
+    "continue": "続行",
+    "error": {
+      "title": "エラー",
+      "description": "サインインの際にエラーが発生しました。"
+    }
+  },
+  "verify": {
+    "userIdMissing": "ユーザーIDが指定されていません！",
+    "successTitle": "ユーザー確認完了",
+    "successDescription": "ユーザーの確認が正常に完了しました。",
+    "successContinue": "続行",
+    "setupAuthenticator": "認証の設定",
+    "verify": {
+      "title": "ユーザー確認",
+      "description": "確認メールに記載されたコードを入力してください。",
+      "noCodeReceived": "コードが届きませんか？",
+      "resendCode": "コードを再送信",
+      "codeSent": "確認コードをメールアドレスに送信しました。",
+      "submit": "続行",
+      "labels": {
+        "code": "コード"
+      },
+      "required": {
+        "code": "必須項目です"
+      }
+    },
+    "errors": {
+      "couldNotResendEmail": "メールを再送信できませんでした",
+      "couldNotVerifyUser": "ユーザーを確認できませんでした",
+      "couldNotVerifyInvite": "招待を確認できませんでした",
+      "couldNotVerifyEmail": "メールアドレスを確認できませんでした",
+      "couldNotVerify": "確認できませんでした",
+      "couldNotLoadUser": "ユーザーを読み込めませんでした",
+      "couldNotLoadAuthenticators": "認証方法を読み込めませんでした",
+      "couldNotCreateSession": "セッションを作成できませんでした",
+      "noHostFound": "ホストが見つかりません",
+      "userAlreadyVerified": "ユーザーは既に確認済みです！",
+      "couldNotResendInvite": "招待を再送信できませんでした",
+      "inviteSendFailed": "招待メールの送信に失敗しました",
+      "emailSendFailed": "確認メールの送信に失敗しました",
+      "contextMissing": "エラーが発生しました。もう一度お試しください。"
+    }
+  },
+  "authenticator": {
+    "title": "認証方法を選択",
+    "description": "認証に使用する方法を選択してください",
+    "noMethodsAvailable": "使用可能な認証方法がありません",
+    "allSetup": "認証の設定は既に完了しています！",
+    "linkWithIDP": "またはIDプロバイダーと連携"
+  },
+  "device": {
+    "usercode": {
+      "title": "デバイスコード",
+      "description": "アプリまたはデバイスに表示されるコードを入力してください。",
+      "submit": "続行",
+      "labels": {
+        "code": "コード"
+      },
+      "required": {
+        "code": "必須項目です"
+      }
+    },
+    "request": {
+      "title": "{appName}が接続を要求しています",
+      "description": "{appName}は以下にアクセスします：",
+      "disclaimer": "「許可」をクリックすることで、{appName}とZitadelがそれぞれの利用規約およびプライバシーポリシーに従ってあなたの情報を使用することを許可します。このアクセスはいつでも取り消すことができます。",
+      "submit": "許可",
+      "deny": "拒否"
+    },
+    "scope": {
+      "openid": "本人確認を行います。",
+      "email": "メールアドレスを表示します。",
+      "profile": "すべてのプロフィール情報を表示します。",
+      "offline_access": "アカウントへのオフラインアクセスを許可します。"
+    }
+  },
+  "error": {
+    "noUserCode": "ユーザーコードが指定されていません！",
+    "noDeviceRequest": "デバイスリクエストが見つかりません。",
+    "unknownContext": "ユーザーのコンテキストを取得できませんでした。最初にユーザー名を入力するか、検索パラメータとしてloginNameを指定してください。",
+    "sessionExpired": "現在のセッションが期限切れです。再度ログインしてください。",
+    "failedLoading": "データの読み込みに失敗しました。再試行してください。",
+    "tryagain": "再試行",
+    "couldNotContinueSession": "セッションを継続できませんでした - ユーザー情報が不足しています"
+  },
+  "zitadel": {
+    "errors": {
+      "errorOccured": "エラーが発生しました",
+      "multipleUsersFound": "複数のユーザーが見つかりました",
+      "userNotFound": "ユーザーがシステムに見つかりません"
+    }
+  }
+}


### PR DESCRIPTION
## 🔗 Related Issue
Closes #349

## 📝 Summary of Changes
Fixes the self-hosted Zitadel hosted Login UI v2 rendering the **Japanese** login screen in **English**.

**Root cause (confirmed):** Login v2 renders `deepmerge([en.json, <locale>.json, GetHostedLoginTranslation(locale)])` — the API translation wins. Zitadel's backend default `internal/query/v2-default.json` ships only 8 languages (`de,en,es,it,nl,pl,ru,zh`) — **no `ja`** — so `GetHostedLoginTranslation(ja)` returns the English fallback and overrides the login app's complete bundled `ja.json`. Our instance config is correct (`ja` allowed, default `en`); latest Zitadel `main` still omits `ja`, so a version bump does not fix it.

**Fix:** provision a **product-org-scoped Hosted Login Translation override for `ja`** via Settings v2 `SetHostedLoginTranslation`.

- `src/zitadel/translations/ja.json` — complete Japanese payload pinned from upstream `apps/login/locales/ja.json` @ `v4.14.0`. The full key set is required (the API English-fills omitted keys). Excluded from Biome (`biome.json`) to stay byte-identical to upstream for easy re-sync.
- `src/zitadel/dynamic/hosted-login-translation.ts` — `ZitadelHostedLoginTranslation` dynamic resource: create/update POST the full payload to `SetHostedLoginTranslation` (idempotent upsert) using the `pulumi-admin` JWT; `sha256` of the payload drives clean diffs; `delete` is a no-op (mirrors `ZitadelSmtpActivation`).
- `src/zitadel/index.ts` — wired into the `Zitadel` orchestrator (`jaLoginTranslation`), org-scoped to `productOrg` so the admin/console org login is unaffected. Payload loaded via `readFileSync` + `import.meta.url`.

Permanent fix is upstream (add the missing languages to `v2-default.json`); this override can be retired once a deployed Zitadel version ships Japanese defaults.

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview
See the CI / Pulumi Cloud preview on this PR. Expected diff: one `pulumi-nodejs:dynamic:Resource` **create** (`...-ja-login-translation`). No other resource churn expected.

## 📦 State Changes
None. No `pulumi state mv` / `import` / destructive changes. Net-new dynamic resource; `SetHostedLoginTranslation` is an idempotent upsert. May require a `kubectl rollout restart deploy/zitadel-api-login -n zitadel` after apply to clear the Login UI v2 translation cache.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI. <!-- runs in Pulumi Cloud on this PR; local dev preview skipped (dev Zitadel stopped) -->
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config. <!-- N/A — translation payload only; auth via existing pulumi-admin JWT from GSM -->
