### PR TITLE
feat(cronjob): add sales-phase-discovery and sales-reminders CronJobs

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
@@ -9,6 +9,16 @@ TELEMETRY_SERVICE_NAME=liverty-music-sales-phase-discovery
 GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
 GCP_LOCATION=global
 GCP_GEMINI_MODEL=gemini-3-flash-preview
+# Sales-phase searcher models: pinned to flash-lite for BOTH steps (cost),
+# overriding the shared concert-search default (gemini-3.5-flash) for THIS job
+# only. thinking=high on the grounded extract recovers flash-lite's weaker
+# rule-following (covered-event accuracy, 全公演 marker, future-only filter):
+# live A/B showed lite+high -> 4/4 coverage, lite+medium -> 3/4. Parse is a plain
+# JSON coercion, so thinking=low suffices.
+GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.1-flash-lite
+GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite
+GCP_GEMINI_SEARCH_THINKING_EXTRACT=high
+GCP_GEMINI_SEARCH_THINKING_PARSE=low
 # Database (Defaults)
 DATABASE_NAME=liverty-music
 DATABASE_HOST=postgres.osaka.psc.internal

--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
@@ -1,0 +1,23 @@
+# Environment
+ENVIRONMENT=TO_REPLACE_BY_OVERLAY
+# Logging
+LOGGING_LEVEL=debug
+LOGGING_FORMAT=json
+# Telemetry
+TELEMETRY_SERVICE_NAME=liverty-music-sales-phase-discovery
+# GCP (Defaults)
+GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
+GCP_LOCATION=global
+GCP_GEMINI_MODEL=gemini-3-flash-preview
+# Database (Defaults)
+DATABASE_NAME=liverty-music
+DATABASE_HOST=postgres.osaka.psc.internal
+DATABASE_PORT=5432
+DATABASE_USER=TO_REPLACE_BY_OVERLAY
+# Must be 'disable' because the Cloud SQL Connector handles internal encryption.
+# Setting it to 'require' causes a double-encryption conflict/TLS refusal.
+DATABASE_SSL_MODE=disable
+DATABASE_SCHEMA=app
+
+# Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
+SHUTDOWN_TIMEOUT=90s

--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/cronjob.yaml
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sales-phase-discovery-app
+spec:
+  schedule: "0 12 * * *" # 21:00 JST daily (after merch-discovery 20:00)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          terminationGracePeriodSeconds: 120
+          serviceAccountName: backend-app
+          restartPolicy: Never
+          containers:
+          - name: sales-phase-discovery
+            image: sales-phase-discovery
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: sales-phase-discovery-job-config
+            - secretRef:
+                name: backend-secrets
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi

--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/kustomization.yaml
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cronjob.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: sales-phase-discovery
+
+images:
+- name: sales-phase-discovery
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
+  newTag: latest
+
+configMapGenerator:
+- name: sales-phase-discovery-job-config
+  envs:
+  - configmap.env

--- a/k8s/namespaces/backend/base/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-reminders/configmap.env
@@ -1,0 +1,25 @@
+# Environment
+ENVIRONMENT=TO_REPLACE_BY_OVERLAY
+# Logging
+LOGGING_LEVEL=debug
+LOGGING_FORMAT=json
+# Telemetry
+TELEMETRY_SERVICE_NAME=liverty-music-sales-reminders
+# GCP (Defaults)
+GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
+# Database (Defaults)
+DATABASE_NAME=liverty-music
+DATABASE_HOST=postgres.osaka.psc.internal
+DATABASE_PORT=5432
+DATABASE_USER=TO_REPLACE_BY_OVERLAY
+# Must be 'disable' because the Cloud SQL Connector handles internal encryption.
+# Setting it to 'require' causes a double-encryption conflict/TLS refusal.
+DATABASE_SSL_MODE=disable
+DATABASE_SCHEMA=app
+
+# Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
+SHUTDOWN_TIMEOUT=90s
+
+# Push Notifications (VAPID) — Web Push delivery for sales-phase reminders.
+VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY
+VAPID_CONTACT=mailto:pepperoni9@gmail.com

--- a/k8s/namespaces/backend/base/cronjob/sales-reminders/cronjob.yaml
+++ b/k8s/namespaces/backend/base/cronjob/sales-reminders/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sales-reminders-app
+spec:
+  schedule: "*/15 * * * *" # Every 15 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          terminationGracePeriodSeconds: 120
+          serviceAccountName: backend-app
+          restartPolicy: Never
+          containers:
+          - name: sales-reminders
+            image: sales-reminders
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: sales-reminders-job-config
+            - secretRef:
+                name: backend-secrets
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 250m
+                memory: 256Mi

--- a/k8s/namespaces/backend/base/cronjob/sales-reminders/kustomization.yaml
+++ b/k8s/namespaces/backend/base/cronjob/sales-reminders/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cronjob.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: sales-reminders
+
+images:
+- name: sales-reminders
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
+  newTag: latest
+
+configMapGenerator:
+- name: sales-reminders-job-config
+  envs:
+  - configmap.env

--- a/k8s/namespaces/backend/base/kustomization.yaml
+++ b/k8s/namespaces/backend/base/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 - cronjob/concert-discovery
 - cronjob/artist-image-sync
 - cronjob/merch-discovery
+- cronjob/sales-phase-discovery
+- cronjob/sales-reminders
 - consumer
 
 namespace: backend

--- a/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=development
+# GCP
+GCP_PROJECT_ID=liverty-music-dev
+# Database
+DATABASE_USER=backend-app@liverty-music-dev.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/schedule_patch.yaml
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/schedule_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sales-phase-discovery-app
+spec:
+  schedule: "0 12 * * 5" # Fridays only at 21:00 JST (weekly in dev, mirroring concert/merch discovery)

--- a/k8s/namespaces/backend/overlays/dev/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/sales-reminders/configmap.env
@@ -1,0 +1,17 @@
+# Environment
+ENVIRONMENT=development
+# GCP
+GCP_PROJECT_ID=liverty-music-dev
+# Database
+DATABASE_USER=backend-app@liverty-music-dev.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=6ea7e9f2efe1.3saucev2x125n.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
+
+# Push Notifications (VAPID)
+VAPID_PUBLIC_KEY=BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -78,6 +78,12 @@ patches:
     kind: CronJob
     name: merch-discovery-app
 
+# CronJob: run sales-phase discovery only on Fridays in dev
+- path: cronjob/sales-phase-discovery/schedule_patch.yaml
+  target:
+    kind: CronJob
+    name: sales-phase-discovery-app
+
 # Right-size resources for consumer in dev
 - target:
     kind: Deployment
@@ -129,6 +135,14 @@ configMapGenerator:
   behavior: merge
   envs:
   - cronjob/merch-discovery/configmap.env
+- name: sales-phase-discovery-job-config
+  behavior: merge
+  envs:
+  - cronjob/sales-phase-discovery/configmap.env
+- name: sales-reminders-job-config
+  behavior: merge
+  envs:
+  - cronjob/sales-reminders/configmap.env
 - name: consumer-consumer-config
   behavior: merge
   envs:

--- a/k8s/namespaces/backend/overlays/prod/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/sales-phase-discovery/configmap.env
@@ -1,0 +1,14 @@
+# Environment
+ENVIRONMENT=production
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/prod/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/sales-reminders/configmap.env
@@ -1,0 +1,19 @@
+# Environment
+ENVIRONMENT=production
+# GCP
+GCP_PROJECT_ID=liverty-music-prod
+# Database
+DATABASE_USER=backend-app@liverty-music-prod.iam
+# Official hashed .sql.goog domain is required for Go SDK/Cloud SQL Connector TLS verification.
+DATABASE_HOST=298474959c18.25pf3r4b6sfkn.asia-northeast2.sql.goog
+DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-osaka
+# Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
+DATABASE_MAX_OPEN_CONNS=5
+DATABASE_MAX_IDLE_CONNS=1
+# Telemetry
+TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
+
+# Push Notifications (VAPID) — see server/configmap.env for the full
+# derivation note. Public half of the prod keypair whose private half
+# lives in GSM `vapid-private-key`.
+VAPID_PUBLIC_KEY=BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -142,11 +142,19 @@ configMapGenerator:
     behavior: merge
     envs:
       - cronjob/merch-discovery/configmap.env
+  - name: sales-phase-discovery-job-config
+    behavior: merge
+    envs:
+      - cronjob/sales-phase-discovery/configmap.env
+  - name: sales-reminders-job-config
+    behavior: merge
+    envs:
+      - cronjob/sales-reminders/configmap.env
   - name: consumer-consumer-config
     behavior: merge
     envs:
       - consumer/configmap.env
-# Pin all four backend images to the prod Artifact Registry with an
+# Pin all backend images to the prod Artifact Registry with an
 # immutable semantic-version tag. Per OpenSpec `enable-prod-ar-immutable-tags`
 # + the `prod-image-tag-immutability` spec, prod uses semver tags (e.g.,
 # v1.0.0) backed by AR's `dockerConfig.immutableTags: true` policy, which
@@ -175,7 +183,7 @@ configMapGenerator:
 # Bumping on release: this block is now CI-written, not hand-edited.
 # Cutting a GH Release (e.g., v1.0.1) on backend retags the dev-AR digest
 # into prod AR, then emits a `repository_dispatch` to this repo's
-# `.github/workflows/bump-prod-pin.yml`, which rewrites all four `newTag:`
+# `.github/workflows/bump-prod-pin.yml`, which rewrites every `newTag:`
 # + their inline `# commit <sha>` trailers AND the `app.kubernetes.io/version`
 # label above (in lock-step) and pushes straight to main. ArgoCD auto-syncs.
 # No manual pin-bump PR. See docs/runbooks/prod-image-tag-pinning.md
@@ -195,4 +203,10 @@ images:
     newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/merch-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/merch-discovery
+    newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159
+  - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
+    newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
+    newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159
+  - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
+    newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
     newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159


### PR DESCRIPTION
## What

Two backend CronJobs for the SalesPhase timeline feature (#571):

- **sales-phase-discovery** (daily) — Gemini-grounded discovery that upserts SalesPhase rows for followed artists' upcoming series and announces newly discovered phases. Needs Vertex AI + DB.
- **sales-reminders** (`*/15 * * * *`) — multi-stage reminder scan (application open / 24h- / 1h-before-close / result-day). Needs DB + Web Push (no Vertex AI).

Modeled on the merch-discovery / concert-discovery manifests: per-job base (`cronjob.yaml` + `kustomization.yaml` + `configmap.env`) with dev/prod overlays, spot-VM nodeSelector, and per-env ConfigMaps.

## IAM

No new IAM required — both jobs run as the existing `backend-app` KSA whose GSA already holds `roles/aiplatform.user` (Vertex) and `roles/cloudsql.instanceUser` (DB).

## ⚠️ Prod deployment sequencing

The prod `images:` block pins `sales-phase-discovery` / `sales-reminders` at the placeholder **v1.5.1** (matching the current backend pin), but **no prod release has built these images yet** — they require a backend prod Release whose image contains the new Dockerfile stages (added in liverty-music/backend#329). The CI `bump-prod-pin.yml` workflow rewrites these tags on the next backend Release.

**Do not sync the prod overlay until that backend Release exists**, or the prod CronJobs will ImagePullBackOff. The dev overlay (`:latest`, auto-built on backend `main` merge) is unaffected. Runtime per-leg coverage also depends on `auto-discovery-series-grouping`.

## Verification

`make check` green (biome + tsc + 50 vitest). `kustomize build` renders dev + prod overlays cleanly; kube-linter + spot-nodeSelector pass (scoped).

Refs: #571