### PR TITLE
feat(admin-console): admin OIDC, networking, and k8s workload

### DIFF
--- a/docs/runbooks/prod-image-tag-pinning.md
+++ b/docs/runbooks/prod-image-tag-pinning.md
@@ -346,8 +346,62 @@ for this commit is still in-flight or failed — do NOT re-target an earlier com
 - If you genuinely need to roll back, update the kustomize prod overlay's `newTag:` to the older version's tag — the older immutable tag still resolves to its original digest.
 - For a true emergency tag re-point (compromised upstream dep), use the "Genuine emergency requiring tag re-point" escape hatch above. The retag flow's recovery is identical to the rebuild flow's recovery for this failure mode.
 
+## Admin console release path (independent of the consumer SPA)
+
+The admin console (`admin.liverty-music.app`, OpenSpec change `add-admin-console`)
+is a **second, independently-released artifact** built from the same `frontend`
+repo. It is NOT host-routed off the consumer pod — it has its own image, its own
+Kubernetes Deployment/Service/HTTPRoute (an `admin/` sibling to `web/` in the
+`frontend` namespace), and its own runtime `/config.json`. The two release on
+their own cadence: an admin copy change never re-releases the consumer SPA and
+vice versa.
+
+| | Consumer SPA | Admin console |
+|---|---|---|
+| Image | `frontend/web-app` | `frontend/admin-app` (same AR repo, different image) |
+| Build | `Dockerfile` (serves `index.html`, SW, manifest) | `Dockerfile.admin` (serves `admin.html` only; no SW/manifest) |
+| Frontend CI job | `build-and-push` | `build-and-push-admin` |
+| Hostname | `liverty-music.app` / `dev.liverty-music.app` | `admin.liverty-music.app` / `admin.dev.liverty-music.app` |
+| Runtime config | `web-app-runtime-config` ConfigMap | `admin-app-runtime-config` ConfigMap (admin org id + admin client id) |
+| Dispatch `component` | `frontend` | `frontend-admin` |
+
+**Dev** is fully wired: `build-and-push-admin` pushes `frontend/admin-app:main`
+to dev AR; the dev image-updater alias `admin-app`
+(`k8s/namespaces/argocd/overlays/dev/image-updater.yaml`) reconciles the dev
+overlay's admin Deployment by digest — exactly like `web-app`, independently.
+
+**Prod is intentionally NOT yet wired** (lands in `add-admin-console` §8, gated
+on dev verification first). Two pieces remain for the first prod admin release:
+
+1. **Prod overlay opt-in.** Add `../../base/admin` + an `admin-app-runtime-config`
+   ConfigMap to `k8s/namespaces/frontend/overlays/prod/kustomization.yaml`, and a
+   prod `images:` entry pinning `admin-app` to its own semver. Until then the prod
+   `frontend` ArgoCD Application renders the consumer workload only — adding the
+   admin workload before a prod `admin-app` image exists would `ImagePullBackOff`.
+2. **`bump-prod-pin.yml` per-component image selection + the admin dispatch.**
+   The frontend CI does NOT yet emit the `component: "frontend-admin"` dispatch
+   (it is held back precisely because the receiver can't honor it). Today
+   `bump-prod-pin.yml` (a) rejects any component other than `backend`/`frontend`
+   (it `::error::`s and exits non-zero — it does not silently ignore), and
+   (b) rewrites **every** `images[].newTag` in
+   `k8s/namespaces/${COMPONENT}/overlays/prod/kustomization.yaml` to the release
+   tag. To keep admin and consumer independent, the workflow must learn to map
+   `frontend-admin → frontend` overlay path but edit **only the `admin-app` image
+   entry** (and `frontend` must conversely edit only `web-app`), rather than all
+   entries. Once that lands, re-enable the `frontend-admin` dispatch step in the
+   frontend `push-image.yaml` (currently a documented no-op placeholder). Without
+   this, a consumer release would also bump the admin pin.
+
+Once both land, the admin prod release is structurally identical to the
+consumer's: GH Release → retag dev-AR digest to prod AR → `repository_dispatch`
+(`component: frontend-admin`) → `bump-prod-pin.yml` edits the admin pin → ArgoCD
+auto-syncs the admin Deployment. The consumer pod is never restarted.
+
 ## Related
 
+- Admin console: OpenSpec change `add-admin-console` (frontend `admin/` entry,
+  `Dockerfile.admin`, `build-and-push-admin` CI job; cloud-provisioning admin
+  Zitadel `ApplicationOidc`, `k8s/namespaces/frontend/base/admin/`).
 - Spec: `openspec/specs/prod-image-tag-immutability/spec.md` (post-archive) or the in-flight change at `openspec/changes/enable-prod-ar-immutable-tags/`.
 - Pulumi enforcement: `src/gcp/index.ts` (`gcp.artifactregistry.Repository` with `dockerConfig.immutableTags`).
 - Kustomize overlays: `k8s/namespaces/{backend,frontend}/overlays/prod/kustomization.yaml`.

--- a/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
+++ b/k8s/namespaces/argocd/overlays/dev/image-updater.yaml
@@ -33,3 +33,10 @@ spec:
       commonUpdateSettings:
         updateStrategy: digest
         pullSecret: ext:/scripts/auth.sh
+    # Admin console image — a second, independently-reconciled artifact in the
+    # same `frontend` ArgoCD Application. See OpenSpec change `add-admin-console`.
+    - alias: admin-app
+      imageName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/admin-app:main
+      commonUpdateSettings:
+        updateStrategy: digest
+        pullSecret: ext:/scripts/auth.sh

--- a/k8s/namespaces/frontend/base/admin/deployment.yaml
+++ b/k8s/namespaces/frontend/base/admin/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  annotations:
+    # Trigger a rolling restart when admin-app-runtime-config ConfigMap changes.
+    # The ConfigMap is mounted as a single-file subPath volume which kubelet
+    # does NOT live-update; explicit rollout via Reloader is the contract.
+    # Scoped to this Deployment only, so an admin config change never restarts
+    # the consumer web pod (and vice versa) — the ③b isolation guarantee.
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      # Labels handled by kustomize labels transformer
+    spec:
+      containers:
+      - name: caddy
+        image: admin-app
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        volumeMounts:
+        - name: runtime-config
+          mountPath: /srv/config.json
+          subPath: config.json
+          readOnly: true
+      volumes:
+      - name: runtime-config
+        configMap:
+          # ConfigMap with this name is provided by each environment overlay
+          # (overlays/<env>/admin-configmap.yaml). The mounted file shadows the
+          # admin image's bundled public/config.json fallback. Distinct from the
+          # consumer web-app-runtime-config so the admin pod gets the admin org
+          # id + admin client id without any host-conditional config rewrite.
+          name: admin-app-runtime-config

--- a/k8s/namespaces/frontend/base/admin/httproute.yaml
+++ b/k8s/namespaces/frontend/base/admin/httproute.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+spec:
+  parentRefs:
+  - name: external-gateway
+    namespace: gateway
+  rules:
+  - backendRefs:
+    - name: svc
+      port: 80
+  # hostname (admin.{base-domain}) is patched per overlay.

--- a/k8s/namespaces/frontend/base/admin/kustomization.yaml
+++ b/k8s/namespaces/frontend/base/admin/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Admin console workload — an `admin/` sibling to `web/` in the same
+# `frontend` namespace, served by the existing `frontend` ArgoCD Application.
+# Its own image (admin-app), Service, and HTTPRoute keep it bundle-, config-,
+# and release-isolated from the consumer web workload (design D4 / ③b). This
+# base is currently pulled in by the dev overlay only; the prod overlay opts in
+# during the prod-rollout step once the admin image has a prod release.
+# See OpenSpec change `add-admin-console`.
+
+resources:
+- deployment.yaml
+- service.yaml
+- httproute.yaml
+
+configurations:
+- kustomizeconfig.yaml
+
+namePrefix: admin-
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: admin
+
+images:
+- name: admin-app
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/admin-app
+  newTag: latest

--- a/k8s/namespaces/frontend/base/admin/kustomizeconfig.yaml
+++ b/k8s/namespaces/frontend/base/admin/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - path: spec/rules/backendRefs/name
+    kind: HTTPRoute

--- a/k8s/namespaces/frontend/base/admin/service.yaml
+++ b/k8s/namespaces/frontend/base/admin/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP

--- a/k8s/namespaces/frontend/overlays/dev/admin-configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/admin-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-app-runtime-config
+data:
+  # Admin console runtime config served at the admin pod's /config.json.
+  # Same `frontend-runtime-config` contract as the consumer (the admin entry
+  # reuses the shared loadAppConfig() + AppConfig validator), so all required
+  # fields are present even where the admin foundation does not use them:
+  #   - zitadelOrgId: the bootstrap-created `admin` role org (dev), so the SPA
+  #     passes `urn:zitadel:iam:org:id:<id>` and Zitadel applies the admin org's
+  #     Google-Workspace login policy (the access boundary).
+  #   - zitadelClientId: PENDING — created by `pulumi up` of the admin-console
+  #     ApplicationOidc. Fill from `pulumi stack output adminConsoleClientId`
+  #     after dev provisioning (dev is currently shut down: workloadEnabled=false,
+  #     so the admin app is not created until dev is brought back up).
+  #   - vapidPublicKey: reuses the dev consumer public VAPID key purely to
+  #     satisfy the shared validator's non-empty requirement; the admin
+  #     foundation registers no service worker and sends no push.
+  #   - previewArtist*: empty — consumer-only discovery fields, unused by admin.
+  config.json: |
+    {
+      "environment": "dev",
+      "apiBaseUrl": "https://api.dev.liverty-music.app",
+      "zitadelIssuer": "https://auth.dev.liverty-music.app",
+      "zitadelClientId": "PENDING_PULUMI_UP_adminConsoleClientId",
+      "zitadelOrgId": "371280364565496672",
+      "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
+      "circuitBaseUrl": "",
+      "previewArtistIds": [],
+      "previewArtistNames": [],
+      "logLevel": "debug"
+    }

--- a/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
@@ -3,7 +3,14 @@ kind: Kustomization
 
 resources:
 - ../../base
+# Admin console workload (dev only for now — prod opts in at the prod-rollout
+# step once the admin image has a prod release). The global Spot VM + dev
+# right-size patches below target `kind: Deployment`, so they apply to the
+# admin Deployment automatically (the patch-body name is ignored when a target
+# selector is set, as the spot-vm_patch already relies on).
+- ../../base/admin
 - configmap.yaml
+- admin-configmap.yaml
 
 namespace: frontend
 
@@ -42,3 +49,12 @@ patches:
     - op: add
       path: /spec/hostnames
       value: ["dev.liverty-music.app"]
+
+# Patch admin HTTPRoute hostname for dev environment
+- target:
+    kind: HTTPRoute
+    name: admin-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["admin.dev.liverty-music.app"]

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -349,6 +349,11 @@ const SERVICES: ReadonlyArray<{
 	{ name: 'backend-server', subdomain: 'api' },
 	{ name: 'web-app', subdomain: '' },
 	{ name: 'zitadel', subdomain: 'auth' },
+	// Internal admin console — dev: admin.dev.liverty-music.app,
+	// prod: admin.liverty-music.app. Served by its own k8s Deployment via a
+	// dedicated HTTPRoute on this same shared gateway. See OpenSpec change
+	// `add-admin-console`.
+	{ name: 'admin-app', subdomain: 'admin' },
 ]
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,3 +349,19 @@ export const webFrontendClientId: string | pulumi.Output<string> =
 	zitadel?.frontend.application.clientId ?? DEV_SHUTDOWN_SENTINEL
 export const productOrgId: string | pulumi.Output<string> =
 	zitadel?.productOrg.id ?? DEV_SHUTDOWN_SENTINEL
+
+// Admin console OIDC client_id + admin-org id — consumed by the admin
+// runtime ConfigMap (`admin-app-runtime-config`) that serves the admin
+// pod's `/config.json` (admin org id + admin client id). Operators
+// retrieve via `pulumi stack output adminConsoleClientId` / `pulumi stack
+// output adminOrgId` after `pulumi up`. Same `DEV_SHUTDOWN_SENTINEL`
+// fallback contract as the consumer exports above (the Zitadel
+// orchestrator is skipped while `workloadEnabled=false`). The admin org
+// id is the bootstrap-created `admin` role org (see `adminOrgIdMap` in
+// `zitadel/constants.ts`); exporting `adminConsole`'s resolved org id
+// keeps the ConfigMap value sourced from one canonical place.
+// See OpenSpec change `add-admin-console`.
+export const adminConsoleClientId: string | pulumi.Output<string> =
+	zitadel?.adminConsole.application.clientId ?? DEV_SHUTDOWN_SENTINEL
+export const adminOrgId: string | pulumi.Output<string> =
+	zitadel?.adminOrg.id ?? DEV_SHUTDOWN_SENTINEL

--- a/src/zitadel/components/admin-console.ts
+++ b/src/zitadel/components/admin-console.ts
@@ -1,0 +1,126 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+import type { Environment } from '../../config.js'
+import { baseDomainMap } from '../constants.js'
+
+export interface AdminConsoleComponentArgs {
+	env: Environment
+	/** ID of the bootstrap-created `admin` role org. The admin console app
+	 *  lives here so that the admin org's Google-Workspace LoginPolicy
+	 *  (provisioned by `AdminOrgConfigComponent`) is the access boundary. */
+	adminOrgId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * AdminConsoleComponent provisions the internal admin console's OIDC
+ * surface in the `admin` role org — a sibling of the consumer
+ * `FrontendComponent` (which lives in the product org), not a
+ * modification of it.
+ *
+ * ## Why the admin org (authN as the access boundary)
+ *
+ * The admin console authenticates against the **`admin` org**, reusing
+ * `oidc-client-ts` PKCE exactly like the consumer SPA, but the SPA passes
+ * the admin org id in the `urn:zitadel:iam:org:id:<id>` scope so Zitadel
+ * applies the admin org's Google-Workspace login policy
+ * (`AdminOrgConfigComponent.adminLoginPolicy`). Because only Google
+ * Workspace accounts can complete that flow, authentication itself is the
+ * access boundary — no separate authorization layer is needed for the
+ * foundation. This component therefore provisions ONLY the project + app;
+ * it must NOT declare a LoginPolicy/LabelPolicy (the admin org already
+ * owns those). See OpenSpec change `add-admin-console`, design D1.
+ *
+ * ## Project
+ *
+ * Zitadel apps belong to a project, and the admin org has no existing
+ * project (the consumer `liverty-music` Project lives in the product
+ * org). A minimal `admin-console` project is created here to host the
+ * app. Role assertion/checks are left off — the foundation has no admin
+ * roles yet (deferred to a follow-up change).
+ */
+export class AdminConsoleComponent extends pulumi.ComponentResource {
+	public readonly project: zitadel.Project
+	public readonly application: zitadel.ApplicationOidc
+
+	constructor(
+		name: string,
+		args: AdminConsoleComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:AdminConsole', name, {}, opts)
+
+		const { env, adminOrgId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		// The admin console is served at `admin.{base-domain}` per
+		// environment (dev: admin.dev.liverty-music.app, prod:
+		// admin.liverty-music.app).
+		const domain = `admin.${baseDomainMap[env]}`
+
+		// Ternary spread (per `refactor-unify-env-dispatch`): localhost URIs
+		// are only meaningful when env === 'dev'. Other envs receive the
+		// public admin host only. Mirrors `FrontendComponent`.
+		const redirectUris = [
+			`https://${domain}/auth/callback`,
+			...(env === 'dev' ? ['http://localhost:9000/auth/callback'] : []),
+		]
+		const postLogoutRedirectUris = [
+			`https://${domain}/`,
+			...(env === 'dev' ? ['http://localhost:9000/'] : []),
+		]
+
+		// Minimal project to host the admin console app inside the admin org.
+		// No role assertion/check — the foundation ships no admin roles.
+		this.project = new zitadel.Project(
+			'admin-console',
+			{
+				name: 'admin-console',
+				orgId: adminOrgId,
+				projectRoleAssertion: false,
+				projectRoleCheck: false,
+				hasProjectCheck: false,
+			},
+			resourceOptions,
+		)
+
+		// Admin console OIDC app — mirrors the consumer `web-frontend`
+		// ApplicationOidc settings (public SPA, PKCE, no secret), scoped to
+		// the admin org with admin-host redirect URIs.
+		this.application = new zitadel.ApplicationOidc(
+			'admin-console',
+			{
+				projectId: this.project.id,
+				name: 'admin-console',
+				orgId: adminOrgId,
+				// JWT access token to keep stateless validation parity with the
+				// consumer app if a future admin backend needs it.
+				accessTokenType: 'OIDC_TOKEN_TYPE_JWT',
+				// SPA running in the browser.
+				appType: 'OIDC_APP_TYPE_USER_AGENT',
+				// PKCE public client — no client secret.
+				authMethodType: 'OIDC_AUTH_METHOD_TYPE_NONE',
+				grantTypes: [
+					'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+					'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+				],
+				responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+				// Assert roles/userinfo in the ID token so a future admin role
+				// guard can read them client-side without an extra round-trip.
+				idTokenRoleAssertion: true,
+				idTokenUserinfoAssertion: true,
+				clockSkew: '0s',
+				redirectUris,
+				postLogoutRedirectUris,
+				// Allow http://localhost for development.
+				devMode: env === 'dev',
+			},
+			resourceOptions,
+		)
+
+		this.registerOutputs({
+			project: this.project,
+			application: this.application,
+		})
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -5,6 +5,7 @@ import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../config.js'
 import { ActionsV2Component } from './components/actions-v2.js'
+import { AdminConsoleComponent } from './components/admin-console.js'
 import { AdminOrgConfigComponent } from './components/admin-org-config.js'
 import { E2eTestUserComponent } from './components/e2e-test-user.js'
 import { FrontendComponent } from './components/frontend.js'
@@ -37,6 +38,7 @@ const jaLoginTranslationJson = readFileSync(
 )
 
 export * from './components/actions-v2.js'
+export * from './components/admin-console.js'
 export * from './components/admin-org-config.js'
 export * from './components/e2e-test-user.js'
 export * from './components/frontend.js'
@@ -144,6 +146,8 @@ export class Zitadel {
 	public readonly productOrg: zitadel.Org
 	public readonly project: zitadel.Project
 	public readonly frontend: FrontendComponent
+	/** Internal admin console OIDC surface in the admin role org. */
+	public readonly adminConsole: AdminConsoleComponent
 	/** Japanese Hosted Login translation override for the product org. */
 	public readonly jaLoginTranslation: ZitadelHostedLoginTranslation
 	public readonly smtp: SmtpComponent
@@ -287,6 +291,17 @@ export class Zitadel {
 			env,
 			orgId: this.productOrg.id,
 			projectId: this.project.id,
+			provider: this.provider,
+		})
+
+		// Internal admin console — its own project + ApplicationOidc in the
+		// admin role org (a sibling of `frontend`, not a modification of it).
+		// Authentication runs against the admin org's Google-Workspace
+		// LoginPolicy (provisioned by `AdminOrgConfigComponent` below), which
+		// is the access boundary. See OpenSpec change `add-admin-console`.
+		this.adminConsole = new AdminConsoleComponent(name, {
+			env,
+			adminOrgId: this.adminOrg.id,
 			provider: this.provider,
 		})
 


### PR DESCRIPTION
Adds the cloud side of the internal admin console (`admin.liverty-music.app`). Part of OpenSpec change **add-admin-console**.

## Pulumi
- **`AdminConsoleComponent`**: an admin-org `ApplicationOidc` (public SPA, PKCE, no secret) + its own project, with admin-host redirect/post-logout URIs (+localhost in dev). Sibling of the consumer `web-frontend` app; the admin org's existing Google-Workspace `LoginPolicy` is the access boundary, so **no LoginPolicy is declared here**. Exports `adminConsoleClientId` + `adminOrgId` (same `DEV_SHUTDOWN` sentinel contract as the consumer).
- Adds the `admin` hostname to the shared gateway **certmap + Cloud DNS** via the `network` SERVICES catalog (dev + prod).

## Kubernetes
- **`base/admin/`**: Deployment/Service/HTTPRoute sibling of `web/` in the `frontend` namespace — own `admin-app` image, Reloader-annotated, probes + explicit resources. Wired into the **dev overlay only** (`admin-app-runtime-config` ConfigMap + `admin.dev.liverty-music.app`); global spot + dev right-size patches apply automatically. Image-updater `admin-app` alias added.
- **Prod overlay opt-in is deferred** to the gated prod-rollout step (a prod admin image must exist first, and `bump-prod-pin.yml` must become per-component image-scoped). Documented in the prod-image-tag-pinning runbook.

> ⚠️ The dev `admin-app-runtime-config` ships `zitadelClientId: "PENDING_PULUMI_UP_..."` — fill from `pulumi stack output adminConsoleClientId` after dev provisioning (admin bootstrap fails fast on this sentinel). Dev is currently shut down (`workloadEnabled=false`).

## Verification
`tsc` + biome clean; **dev + prod `pulumi preview` additive-only** (8 creates on prod, no replacements); `kubectl kustomize` dev render + kube-linter + spot check green.

Companion PRs: frontend#433 (admin entry + image), specification#605.

Refs: #604