### PR TITLE
Rebrand Zitadel hosted-login register copy to Liverty Music

### DIFF
--- a/src/zitadel/components/frontend.ts
+++ b/src/zitadel/components/frontend.ts
@@ -98,6 +98,17 @@ export class FrontendComponent extends pulumi.ComponentResource {
 				// See the design.md Risks table in the `playwright-password-test-user`
 				// OpenSpec change for the full mitigation record.
 				userLogin: true,
+				// `allowRegister` surfaces the Login UI v2 Register page. NOTE:
+				// the register form's First name / Last name / Email fields are
+				// HARDCODED and all `required` in the upstream login app
+				// (`apps/login/.../register-form.tsx` at the deployed `v4.14.0`),
+				// and the backend `AddHumanUser` requires `givenName`/`familyName`.
+				// There is no login-policy / branding / login-UI setting to hide
+				// or optional-ize First/Last name in v4.14.0, and we run the
+				// upstream `zitadel-login` image unmodified (no custom CSS/JS
+				// injection). Dropping those fields would require forking and
+				// rebuilding the login image — deferred. See zitadel/zitadel
+				// issue #4386 (remove required user fields).
 				allowRegister: true,
 				// Disable external IDPs (Google etc.) to enforce passkey-only authentication
 				allowExternalIdp: false,

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -37,6 +37,27 @@ const jaLoginTranslationJson = readFileSync(
 	'utf-8',
 )
 
+/**
+ * Complete English Hosted Login translation payload, pinned from upstream
+ * `zitadel/zitadel apps/login/locales/en.json` at the deployed login version
+ * (`v4.14.0`), with the product-org rebrand applied: `register.description`
+ * and `common.title` drop the literal "Zitadel" in favor of "Liverty Music".
+ *
+ * Unlike `ja`, English is NOT a missing-language case — the Settings API
+ * already returns English. We still seed the COMPLETE payload (rather than a
+ * partial 2-key override) because `SetHostedLoginTranslation` English-fills
+ * omitted keys from the backend `v2-default.json` and the Login UI v2 then
+ * shadows its bundled `en.json` with that API result. A partial override would
+ * therefore let backend-default English (which can lag the login app's bundled
+ * `en.json`) silently replace every un-supplied key. Pinning the login app's
+ * own `en.json` keeps all other strings byte-identical to what the image
+ * bundles, so only the two rebranded keys change. Re-sync on Zitadel upgrades.
+ */
+const enLoginTranslationJson = readFileSync(
+	fileURLToPath(new URL('./translations/en.json', import.meta.url)),
+	'utf-8',
+)
+
 export * from './components/actions-v2.js'
 export * from './components/admin-console.js'
 export * from './components/admin-org-config.js'
@@ -150,6 +171,9 @@ export class Zitadel {
 	public readonly adminConsole: AdminConsoleComponent
 	/** Japanese Hosted Login translation override for the product org. */
 	public readonly jaLoginTranslation: ZitadelHostedLoginTranslation
+	/** English Hosted Login translation override for the product org
+	 *  (carries the "Liverty Music" rebrand of the login/register copy). */
+	public readonly enLoginTranslation: ZitadelHostedLoginTranslation
 	public readonly smtp: SmtpComponent
 	public readonly actionsV2: ActionsV2Component
 	public readonly machineUser: MachineUserComponent
@@ -320,6 +344,25 @@ export class Zitadel {
 				organizationId: this.productOrg.id,
 				locale: 'ja',
 				translationsJson: jaLoginTranslationJson,
+			},
+		)
+
+		// English Hosted Login translation override, also scoped to the product
+		// org. English already resolves (it is the instance default language),
+		// so this override exists purely to rebrand the login/register copy:
+		// `register.description` and `common.title` drop the literal "Zitadel"
+		// for "Liverty Music". The payload is the complete pinned `en.json` (see
+		// `enLoginTranslationJson` doc) so only those two keys differ from the
+		// login image's bundled English. Org-scoped, so the admin/console org
+		// login keeps the upstream wording.
+		this.enLoginTranslation = new ZitadelHostedLoginTranslation(
+			`${name}-en-login-translation`,
+			{
+				domain,
+				jwtProfileJson,
+				organizationId: this.productOrg.id,
+				locale: 'en',
+				translationsJson: enLoginTranslationJson,
 			},
 		)
 

--- a/src/zitadel/translations/en.json
+++ b/src/zitadel/translations/en.json
@@ -1,0 +1,461 @@
+{
+  "common": {
+    "back": "Back",
+    "title": "Log in to Liverty Music"
+  },
+  "accounts": {
+    "title": "Accounts",
+    "description": "Select the account you want to use.",
+    "addAnother": "Add another account",
+    "noResults": "No accounts found",
+    "verified": "verified",
+    "expired": "expired"
+  },
+  "logout": {
+    "title": "Logout",
+    "description": "Click an account to end the session",
+    "noResults": "No accounts found",
+    "clear": "End Session",
+    "verifiedAt": "Last active: {time}",
+    "success": {
+      "title": "Logout successful",
+      "description": "You have successfully logged out."
+    }
+  },
+  "loginname": {
+    "title": "Welcome back!",
+    "description": "Enter your login details.",
+    "register": "Register new user",
+    "submit": "Continue",
+    "labels": {
+      "loginname": "Loginname",
+      "username": "Username",
+      "usernameOrPhoneNumber": "Username or phone number",
+      "usernameOrEmail": "Username or email"
+    },
+    "required": {
+      "loginName": "This field is required"
+    },
+    "errors": {
+      "internalError": "An internal error occurred",
+      "couldNotGetLoginSettings": "Could not get login settings",
+      "couldNotSearchUsers": "Could not search users",
+      "couldNotGetDomain": "Could not get domain",
+      "couldNotGetHost": "Could not get host",
+      "couldNotStartIDPFlow": "Could not start IDP flow",
+      "moreThanOneUserFound": "More than one user found. Provide a unique identifier.",
+      "userNotFound": "User not found in the system",
+      "couldNotCreateSession": "Could not create session for user",
+      "initialUserNotSupported": "Initial User not supported",
+      "localAuthenticationNotAllowed": "Local authentication is not allowed! Contact your administrator for more information.",
+      "passkeysNotAllowed": "Passkeys not allowed! Contact your administrator for more information.",
+      "couldNotFindIdentityProvider": "Could not find identity provider.",
+      "userNotActive": "User is not active. Contact your administrator for more information."
+    }
+  },
+  "zitadel": {
+    "errors": {
+      "errorOccured": "An error occurred",
+      "multipleUsersFound": "Multiple users found",
+      "userNotFound": "User not found in the system"
+    }
+  },
+  "password": {
+    "verify": {
+      "title": "Password",
+      "description": "Enter your password.",
+      "resetPassword": "Reset Password",
+      "submit": "Continue",
+      "labels": {
+        "password": "Password"
+      },
+      "required": {
+        "password": "This field is required"
+      },
+      "errors": {
+        "couldNotVerifyPassword": "Could not verify password",
+        "couldNotResetPassword": "Could not reset password"
+      },
+      "info": {
+        "passwordResetSent": "Password was reset. Please check your email"
+      }
+    },
+    "set": {
+      "title": "Set Password",
+      "description": "Set the password for your account",
+      "codeSent": "A new code has been sent to your email address.",
+      "noCodeReceived": "Didn't receive a code?",
+      "resend": "Resend code",
+      "submit": "Continue",
+      "labels": {
+        "code": "Code",
+        "newPassword": "New Password",
+        "confirmPassword": "Confirm Password"
+      },
+      "required": {
+        "code": "This field is required",
+        "newPassword": "You have to provide a password!",
+        "confirmPassword": "This field is required"
+      },
+      "errors": {
+        "couldNotSetPassword": "Could not set password",
+        "couldNotResetPassword": "Could not reset password",
+        "couldNotVerifyPassword": "Could not verify password"
+      }
+    },
+    "change": {
+      "title": "Change Password",
+      "description": "Set the password for your account",
+      "submit": "Continue",
+      "labels": {
+        "currentPassword": "Current Password",
+        "newPassword": "New Password",
+        "confirmPassword": "Confirm Password"
+      },
+      "required": {
+        "currentPassword": "You have to provide your current password!",
+        "newPassword": "You have to provide a new password!",
+        "confirmPassword": "This field is required"
+      },
+      "errors": {
+        "currentPasswordInvalid": "Current password is incorrect.",
+        "couldNotChangePassword": "Could not change password",
+        "couldNotVerifyPassword": "Could not verify password",
+        "unknownError": "Unknown error"
+      }
+    },
+    "complexity": {
+      "length": "Must be at least {minLength} characters long.",
+      "hasSymbol": "Must include a symbol.",
+      "hasNumber": "Must include a number.",
+      "hasUppercase": "Must include an uppercase letter.",
+      "hasLowercase": "Must include a lowercase letter.",
+      "equals": "Password confirmation matched.",
+      "matches": "Matches",
+      "doesNotMatch": "Doesn't match"
+    },
+    "errors": {
+      "noHostFound": "No host found",
+      "couldNotSendResetLink": "Could not send Password Reset Link",
+      "couldNotCreateSessionForUser": "Could not create session for user",
+      "couldNotVerifyPassword": "Could not verify password",
+      "failedToAuthenticate": "Failed to authenticate. You had {failedAttempts} of {maxPasswordAttempts} password attempts.{lockoutMessage}",
+      "failedToAuthenticateNoLimit": "Failed to authenticate.",
+      "accountLockedContactAdmin": " Contact your administrator to unlock your account",
+      "userNotFound": "User not found in the system",
+      "initialUserNotSupported": "Initial User not supported",
+      "userInitialStateNotSupported": "User Initial State is not supported",
+      "codeOrVerificationRequired": "You have to provide a code or have a valid User Verification Check",
+      "verificationRequired": "User Verification Check has to be done",
+      "couldNotLoadSession": "Could not load session",
+      "couldNotLoadAuthMethods": "Could not load auth methods",
+      "failedPrecondition": "Failed precondition",
+      "sessionNotValid": "Session is not valid",
+      "passwordVerificationMissing": "Password verification is missing.",
+      "passwordVerificationTooOld": "Password verification is too old. Please verify your password again."
+    }
+  },
+  "idp": {
+    "title": "Sign in with SSO",
+    "description": "Select one of the following providers to sign in",
+    "orSignInWith": "or sign in with",
+    "signInWithApple": "Sign in with Apple",
+    "signInWithGoogle": "Sign in with Google",
+    "signInWithAzureAD": "Sign in with AzureAD",
+    "signInWithGithub": "Sign in with GitHub",
+    "signInWithGitlab": "Sign in with GitLab",
+    "loginError": {
+      "title": "Login failed",
+      "description": "An error occurred while trying to login."
+    },
+    "linkingError": {
+      "title": "Account linking failed",
+      "description": "An error occurred while trying to link your account."
+    },
+    "completeRegister": {
+      "title": "Complete your data",
+      "description": "You need to complete your registration by providing your email address and name."
+    },
+    "accountNotFound": {
+      "title": "Account Not Found",
+      "description": "We couldn't find an account associated with your identity provider credentials.",
+      "info": "No existing account was found. Please sign in with an existing account or contact your administrator for assistance.",
+      "backToLogin": "Back to Login"
+    },
+    "registrationFailed": {
+      "title": "Registration Not Available",
+      "description": "We couldn't complete the registration process.",
+      "info": "Unable to determine the organization for registration. Please contact your administrator for assistance.",
+      "backToLogin": "Back to Login"
+    },
+    "processing": {
+      "message": "Processing authentication...",
+      "noRedirect": "No redirect or error returned from server",
+      "unexpectedError": "An unexpected error occurred"
+    },
+    "errors": {
+      "missingParameters": "Missing required parameters",
+      "missingIdpInfo": "IDP information missing",
+      "idpNotFound": "Identity provider not found",
+      "linkingNotAllowed": "Linking is not allowed for this identity provider",
+      "linkingFailed": "Failed to link identity provider to account",
+      "autoLinkingFailed": "Failed to automatically link account",
+      "userCreationFailed": "Failed to create user account",
+      "orgResolutionFailed": "Could not determine organization for registration",
+      "sessionCreationFailed": "Could not create session or determine redirect",
+      "unknownError": "An unknown error occurred"
+    }
+  },
+  "ldap": {
+    "title": "LDAP Login",
+    "description": "Enter your LDAP credentials.",
+    "submit": "Continue",
+    "labels": {
+      "username": "Username",
+      "password": "Password"
+    },
+    "required": {
+      "username": "This field is required",
+      "password": "This field is required"
+    }
+  },
+  "mfa": {
+    "verify": {
+      "title": "Verify your identity",
+      "description": "Choose one of the following factors.",
+      "noResults": "No second factors available to setup."
+    },
+    "set": {
+      "title": "Set up 2-Factor",
+      "description": "Choose one of the following second factors.",
+      "skip": "Skip"
+    }
+  },
+  "otp": {
+    "verify": {
+      "title": "Verify 2-Factor",
+      "totpDescription": "Enter the code from your authenticator app.",
+      "smsDescription": "Enter the code you received via SMS.",
+      "emailDescription": "Enter the code you received via email.",
+      "noCodeReceived": "Didn't receive a code?",
+      "resendCode": "Resend code",
+      "submit": "Continue",
+      "labels": {
+        "code": "Code"
+      },
+      "required": {
+        "code": "This field is required"
+      }
+    },
+    "set": {
+      "title": "Set up 2-Factor",
+      "totpDescription": "Scan the QR code with your authenticator app.",
+      "smsDescription": "Enter your phone number to receive a code via SMS.",
+      "emailDescription": "Enter your email address to receive a code via email.",
+      "totpRegisterDescription": "Scan the QR Code or navigate to the URL manually.",
+      "submit": "Continue",
+      "labels": {
+        "code": "Code"
+      },
+      "required": {
+        "code": "This field is required"
+      }
+    }
+  },
+  "passkey": {
+    "verify": {
+      "title": "Authenticate with a passkey",
+      "description": "Your device will ask for your fingerprint, face, or screen lock",
+      "usePassword": "Use password",
+      "submit": "Continue",
+      "errors": {
+        "couldNotRequestChallenge": "Could not request passkey challenge",
+        "couldNotVerifyPasskey": "Could not verify passkey",
+        "noResponseReceived": "Passkey verification failed - no response received",
+        "noRedirectProvided": "Passkey verification completed but no redirect was provided",
+        "couldNotRetrievePasskey": "An error occurred while retrieving passkey",
+        "verificationCancelled": "Passkey verification was cancelled",
+        "verificationFailed": "An error occurred during passkey verification",
+        "couldNotFindSession": "Could not find session",
+        "couldNotUpdateSession": "Could not update session",
+        "userNotFound": "User not found in the system",
+        "couldNotDetermineRedirect": "Could not determine redirect URL after passkey verification"
+      }
+    },
+    "set": {
+      "title": "Setup a passkey",
+      "description": "Your device will ask for your fingerprint, face, or screen lock",
+      "info": {
+        "description": "A passkey is an authentication method on a device like your fingerprint, Apple FaceID or similar. ",
+        "link": "Passkey Authentication"
+      },
+      "skip": "Skip",
+      "submit": "Continue"
+    }
+  },
+  "u2f": {
+    "verify": {
+      "title": "Verify 2-Factor",
+      "description": "Verify your account with your device."
+    },
+    "set": {
+      "title": "Set up 2-Factor",
+      "description": "Set up a device as a second factor.",
+      "submit": "Continue"
+    }
+  },
+  "register": {
+    "methods": {
+      "passkey": "Passkey",
+      "password": "Password"
+    },
+    "disabled": {
+      "title": "Registration disabled",
+      "description": "The registration is disabled. Please contact your administrator."
+    },
+    "missingdata": {
+      "title": "Missing data",
+      "description": "Provide email, first and last name to register."
+    },
+    "title": "Register",
+    "description": "Create your Liverty Music account.",
+    "noMethodAvailableWarning": "No authentication method available. Please contact your administrator.",
+    "selectMethod": "Select the method you would like to authenticate",
+    "agreeTo": "To register you must agree to the terms and conditions",
+    "termsOfService": "Terms of Service",
+    "privacyPolicy": "Privacy Policy",
+    "submit": "Continue",
+    "password": {
+      "title": "Set Password",
+      "description": "Set the password for your account",
+      "submit": "Continue",
+      "labels": {
+        "password": "Password",
+        "confirmPassword": "Confirm Password"
+      },
+      "required": {
+        "password": "You have to provide a password!",
+        "confirmPassword": "This field is required"
+      }
+    },
+    "labels": {
+      "firstname": "First name",
+      "lastname": "Last name",
+      "email": "E-mail"
+    },
+    "required": {
+      "firstname": "This field is required",
+      "lastname": "This field is required",
+      "email": "This field is required"
+    },
+    "errors": {
+      "couldNotCreateUser": "Could not create user",
+      "couldNotCreateSession": "Could not create session",
+      "userNotFound": "User not found in the system",
+      "couldNotLinkIDP": "Could not link IDP to user",
+      "couldNotRegisterUser": "Could not register user"
+    }
+  },
+  "invite": {
+    "title": "Invite User",
+    "description": "Provide the email address and the name of the user you want to invite.",
+    "info": "The user will receive an email with further instructions.",
+    "notAllowed": "Your settings do not allow you to invite users.",
+    "submit": "Continue",
+    "success": {
+      "title": "User invited",
+      "description": "The email has successfully been sent.",
+      "verified": "The user has been invited and has already verified his email.",
+      "notVerifiedYet": "The user has been invited. They will receive an email with further instructions.",
+      "submit": "Invite another user"
+    }
+  },
+  "signedin": {
+    "title": "Welcome {user}!",
+    "description": "You are signed in.",
+    "continue": "Continue",
+    "error": {
+      "title": "Error",
+      "description": "An error occurred while trying to sign in."
+    }
+  },
+  "verify": {
+    "userIdMissing": "No userId provided!",
+    "successTitle": "User verified",
+    "successDescription": "The user has been verified successfully.",
+    "successContinue": "Continue",
+    "setupAuthenticator": "Setup authenticator",
+    "verify": {
+      "title": "Verify user",
+      "description": "Enter the Code provided in the verification email.",
+      "noCodeReceived": "Didn't receive a code?",
+      "resendCode": "Resend code",
+      "codeSent": "A new code has just been sent to your email address.",
+      "submit": "Continue",
+      "labels": {
+        "code": "Code"
+      },
+      "required": {
+        "code": "This field is required"
+      }
+    },
+    "errors": {
+      "couldNotResendEmail": "Could not resend email",
+      "couldNotVerifyUser": "Could not verify user",
+      "couldNotVerifyInvite": "Could not verify invite",
+      "couldNotVerifyEmail": "Could not verify email",
+      "couldNotVerify": "Could not verify",
+      "couldNotLoadUser": "Could not load user",
+      "couldNotLoadAuthenticators": "Could not load possible authenticators",
+      "couldNotCreateSession": "Could not create session",
+      "noHostFound": "No host found",
+      "userAlreadyVerified": "User is already verified!",
+      "couldNotResendInvite": "Could not resend invite",
+      "inviteSendFailed": "Failed to send invitation email",
+      "emailSendFailed": "Failed to send verification email",
+      "contextMissing": "An error occurred. Please try again."
+    }
+  },
+  "authenticator": {
+    "title": "Choose authentication method",
+    "description": "Select the method you would like to authenticate",
+    "noMethodsAvailable": "No authentication methods available",
+    "allSetup": "You have already setup an authenticator!",
+    "linkWithIDP": "or link with an Identity Provider"
+  },
+  "device": {
+    "usercode": {
+      "title": "Device code",
+      "description": "Enter the code displayed on your app or device.",
+      "submit": "Continue",
+      "labels": {
+        "code": "Code"
+      },
+      "required": {
+        "code": "This field is required"
+      }
+    },
+    "request": {
+      "title": "{appName} would like to connect",
+      "description": "{appName} will have access to:",
+      "disclaimer": "By clicking Allow, you allow {appName} and Zitadel to use your information in accordance with their respective terms of service and privacy policies. You can revoke this access at any time.",
+      "submit": "Allow",
+      "deny": "Deny"
+    },
+    "scope": {
+      "openid": "Verify your identity.",
+      "email": "View your email address.",
+      "profile": "View your full profile information.",
+      "offline_access": "Allow offline access to your account."
+    }
+  },
+  "error": {
+    "noUserCode": "No user code provided!",
+    "noDeviceRequest": "No device request found.",
+    "unknownContext": "Could not get the context of the user. Make sure to enter the username first or provide a loginName as searchParam.",
+    "sessionExpired": "Your current session has expired. Please login again.",
+    "failedLoading": "Failed to load data. Please try again.",
+    "tryagain": "Try Again",
+    "couldNotContinueSession": "Could not continue with session - missing user information"
+  }
+}

--- a/src/zitadel/translations/ja.json
+++ b/src/zitadel/translations/ja.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "back": "戻る",
-    "title": "Zitadelでログイン"
+    "title": "Liverty Music にログイン"
   },
   "accounts": {
     "title": "アカウント",
@@ -311,7 +311,7 @@
       "description": "登録するにはメールアドレス、姓、名を入力してください。"
     },
     "title": "登録",
-    "description": "Zitadelアカウントを作成します。",
+    "description": "Liverty Music アカウントを作成します。",
     "noMethodAvailableWarning": "使用可能な認証方法がありません。管理者にお問い合わせください。",
     "selectMethod": "認証に使用する方法を選択してください",
     "agreeTo": "登録するには利用規約に同意する必要があります",


### PR DESCRIPTION
Replace the literal "Zitadel" in the hosted Login UI v2 register/login
copy for the product org:
- register.description "Create your Zitadel account." -> "Create your
  Liverty Music account."
- common.title "Login with Zitadel" -> "Log in to Liverty Music"

English needed its own Hosted Login Translation override (the existing
override only covered ja). Both overrides seed the COMPLETE pinned
v4.14.0 locale payload, since SetHostedLoginTranslation English-fills
omitted keys and the Login UI shadows its bundled locale file — a
partial override would regress un-supplied keys to backend-default
English. The new en.json is the upstream v4.14.0 en.json with only the
two rebranded keys changed.

Also document why the register form's First/Last name fields cannot be
removed at v4.14.0: they are hardcoded + required in the upstream login
app, the backend AddHumanUser requires givenName/familyName, and we run
the upstream zitadel-login image unmodified with no setting to hide
them. Removal is deferred (would require forking/rebuilding the image).