### PR TITLE
feat(admin): Zitadel admin RBAC role + backend CORS for approval queue

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,7 +1,7 @@
 # Environment
 ENVIRONMENT=development
 # CORS
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app,https://admin.dev.liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
 # GCP_VERTEX_AI_SEARCH_DATA_STORE=projects/liverty-music-dev/locations/global/collections/default_collection/dataStores/concert-search-engine

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -1,7 +1,7 @@
 # Environment
 ENVIRONMENT=production
 # CORS
-CORS_ALLOWED_ORIGINS=https://liverty-music.app
+CORS_ALLOWED_ORIGINS=https://liverty-music.app,https://admin.liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-prod
 # Database

--- a/src/zitadel/components/admin-console.ts
+++ b/src/zitadel/components/admin-console.ts
@@ -80,11 +80,12 @@ export class AdminConsoleComponent extends pulumi.ComponentResource {
 		]
 
 		// Minimal project to host the admin console app inside the admin org.
-		// projectRoleAssertion is ON so the `admin` role (below) is asserted
-		// into the access/ID token under `urn:zitadel:iam:org:project:roles`,
-		// which the backend RBAC gate reads. projectRoleCheck stays OFF so
-		// sign-in itself is not blocked on a role grant — authorization is
-		// enforced at the backend, keeping the login flow resilient.
+		// projectRoleAssertion governs the userinfo/ID-token role paths; the
+		// access-token roles that the backend gate actually reads are turned on
+		// by `accessTokenRoleAssertion` on the app below. Both are enabled so the
+		// `admin` role surfaces wherever it is consumed. projectRoleCheck stays
+		// OFF so sign-in is not blocked on a grant — authorization is enforced at
+		// the backend, keeping the login flow resilient.
 		this.project = new zitadel.Project(
 			'admin-console',
 			{
@@ -118,8 +119,16 @@ export class AdminConsoleComponent extends pulumi.ComponentResource {
 					'OIDC_GRANT_TYPE_REFRESH_TOKEN',
 				],
 				responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
-				// Assert roles/userinfo in the ID token so a future admin role
-				// guard can read them client-side without an extra round-trip.
+				// Embed the project roles into the JWT *access* token. This is the
+				// flag the backend depends on: it validates the bearer access token
+				// and reads `urn:zitadel:iam:org:project:roles` via
+				// `auth.RequireRole(ctx, "admin")`. Project-level
+				// `projectRoleAssertion` only governs userinfo/ID-token paths, so
+				// without this the bearer token carries no roles and every
+				// ConcertModerationService RPC is denied for the granted admin.
+				accessTokenRoleAssertion: true,
+				// Assert roles/userinfo in the ID token too, so a client-side admin
+				// guard can read them without an extra round-trip.
 				idTokenRoleAssertion: true,
 				idTokenUserinfoAssertion: true,
 				clockSkew: '0s',

--- a/src/zitadel/components/admin-console.ts
+++ b/src/zitadel/components/admin-console.ts
@@ -3,6 +3,14 @@ import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../../config.js'
 import { baseDomainMap } from '../constants.js'
 
+/**
+ * Project role key for admin-console access. The backend's RBAC gate
+ * (`auth.RequireRole(ctx, "admin")`) checks for exactly this role name in the
+ * token's `urn:zitadel:iam:org:project:roles` claim, so the two MUST stay in
+ * sync — changing this value requires a matching backend change.
+ */
+export const ADMIN_CONSOLE_ROLE_ADMIN = 'admin'
+
 export interface AdminConsoleComponentArgs {
 	env: Environment
 	/** ID of the bootstrap-created `admin` role org. The admin console app
@@ -42,6 +50,7 @@ export interface AdminConsoleComponentArgs {
 export class AdminConsoleComponent extends pulumi.ComponentResource {
 	public readonly project: zitadel.Project
 	public readonly application: zitadel.ApplicationOidc
+	public readonly adminRole: zitadel.ProjectRole
 
 	constructor(
 		name: string,
@@ -71,13 +80,17 @@ export class AdminConsoleComponent extends pulumi.ComponentResource {
 		]
 
 		// Minimal project to host the admin console app inside the admin org.
-		// No role assertion/check — the foundation ships no admin roles.
+		// projectRoleAssertion is ON so the `admin` role (below) is asserted
+		// into the access/ID token under `urn:zitadel:iam:org:project:roles`,
+		// which the backend RBAC gate reads. projectRoleCheck stays OFF so
+		// sign-in itself is not blocked on a role grant — authorization is
+		// enforced at the backend, keeping the login flow resilient.
 		this.project = new zitadel.Project(
 			'admin-console',
 			{
 				name: 'admin-console',
 				orgId: adminOrgId,
-				projectRoleAssertion: false,
+				projectRoleAssertion: true,
 				projectRoleCheck: false,
 				hasProjectCheck: false,
 			},
@@ -118,9 +131,24 @@ export class AdminConsoleComponent extends pulumi.ComponentResource {
 			resourceOptions,
 		)
 
+		// The single `admin` role on the admin-console project. Granted to the
+		// human admin(s) via a UserGrant in the parent stack; the backend's
+		// ConcertModerationService requires this role on every RPC.
+		this.adminRole = new zitadel.ProjectRole(
+			'admin-console-admin',
+			{
+				orgId: adminOrgId,
+				projectId: this.project.id,
+				roleKey: ADMIN_CONSOLE_ROLE_ADMIN,
+				displayName: 'Admin',
+			},
+			resourceOptions,
+		)
+
 		this.registerOutputs({
 			project: this.project,
 			application: this.application,
+			adminRole: this.adminRole,
 		})
 	}
 }

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -5,7 +5,10 @@ import * as pulumi from '@pulumi/pulumi'
 import * as zitadel from '@pulumiverse/zitadel'
 import type { Environment } from '../config.js'
 import { ActionsV2Component } from './components/actions-v2.js'
-import { AdminConsoleComponent } from './components/admin-console.js'
+import {
+	ADMIN_CONSOLE_ROLE_ADMIN,
+	AdminConsoleComponent,
+} from './components/admin-console.js'
 import { AdminOrgConfigComponent } from './components/admin-org-config.js'
 import { E2eTestUserComponent } from './components/e2e-test-user.js'
 import { FrontendComponent } from './components/frontend.js'
@@ -181,6 +184,7 @@ export class Zitadel {
 	public readonly googleAdminIdp: GoogleAdminIdpComponent
 	public readonly adminOrgConfig: AdminOrgConfigComponent
 	public readonly humanAdmin: HumanAdminComponent
+	public readonly adminRoleGrant: zitadel.UserGrant
 	/** E2E test user — dev-only. `undefined` in prod (and any future env). */
 	public readonly e2eTestUser: E2eTestUserComponent | undefined
 
@@ -437,6 +441,22 @@ export class Zitadel {
 			jwtProfileJson,
 			provider: this.provider,
 		})
+
+		// Grant the admin-console `admin` role to the human admin so their
+		// access token carries the role claim the backend RBAC gate requires.
+		// Lives here (not inside AdminConsoleComponent) because it joins two
+		// siblings — the admin-console project and the human admin user — that
+		// are constructed separately in this stack.
+		this.adminRoleGrant = new zitadel.UserGrant(
+			'admin-console-admin-grant',
+			{
+				orgId: this.adminOrg.id,
+				projectId: this.adminConsole.project.id,
+				userId: this.humanAdmin.humanUser.id,
+				roleKeys: [ADMIN_CONSOLE_ROLE_ADMIN],
+			},
+			{ provider: this.provider },
+		)
 
 		// E2E test user — password-based HumanUser for Playwright headless
 		// capture. Lives in `productOrg` to ride on the same end-user


### PR DESCRIPTION
## Summary

Authorization + connectivity for the **concert approval queue**. The backend's `ConcertModerationService` gates every RPC on a Zitadel project role `admin`; this provisions that role and lets the admin SPA reach the backend.

## Changes

- **Zitadel RBAC** (`src/zitadel/`): add an `admin` `ProjectRole` on the admin-console project, turn on `projectRoleAssertion` so the role is asserted into the token under `urn:zitadel:iam:org:project:roles` (which the backend reads), and grant the role to the human admin via a `UserGrant`. `projectRoleCheck` stays off so sign-in isn't blocked on a grant — authorization is enforced at the backend. `ADMIN_CONSOLE_ROLE_ADMIN` is the single source of the role-key string (kept in sync with the backend `auth.RequireRole` check).
- **CORS** (`k8s/.../backend/overlays/{dev,prod}/server/configmap.env`): add the admin host (`admin.{dev.,}liverty-music.app`) to `CORS_ALLOWED_ORIGINS` so the browser-side admin SPA preflight succeeds.

## Testing
`make lint-ts` green (biome + tsc). `kubectl kustomize` renders both backend overlays with the admin origin present.

## Deploy note
Merging triggers ArgoCD sync of the Zitadel role/grant + the backend ConfigMap (Reloader restarts the backend). Prod-affecting — coordinate the merge with the backend + frontend PRs.

Refs: #611
