### PR TITLE
fix(zitadel): order admin-console UserGrant after its ProjectRole

### DIFF
--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -455,7 +455,14 @@ export class Zitadel {
 				userId: this.humanAdmin.humanUser.id,
 				roleKeys: [ADMIN_CONSOLE_ROLE_ADMIN],
 			},
-			{ provider: this.provider },
+			// `roleKeys` is a plain string constant, so Pulumi infers no
+			// dependency on the ProjectRole that defines it — the grant could be
+			// created before the role exists, which Zitadel rejects with
+			// `Errors.Project.Role.NotFound`. Order the grant after the role.
+			{
+				provider: this.provider,
+				dependsOn: [this.adminConsole.adminRole],
+			},
 		)
 
 		// E2E test user — password-based HumanUser for Playwright headless


### PR DESCRIPTION
## Summary

`pulumi up` (prod) failed creating the admin-console admin grant:

```
zitadel:index:UserGrant (admin-console-admin-grant):
  error: failed to create usergrant: rpc error: code = FailedPrecondition
         desc = Errors.Project.Role.NotFound (COMMAND-mm9F4)
```

## Root cause

The `admin-console-admin-grant` `UserGrant` sets `roleKeys: [ADMIN_CONSOLE_ROLE_ADMIN]` — a **plain string constant**, not a reference to the `ProjectRole` resource (`adminConsole.adminRole`) that defines it. Pulumi therefore inferred **no dependency** between the grant and the role: the grant's only data references are the org / project / user ids. On a fresh apply Pulumi can create the grant before (or concurrently with) the role, and Zitadel rejects it because the role does not exist yet.

## Fix

Add an explicit `dependsOn: [this.adminConsole.adminRole]` to the `UserGrant` so it is always ordered after its `ProjectRole`.

## Validation

- `tsc --noEmit` clean; biome formatted.
- Re-run `pulumi up`: the grant is now created after the role. (The role was already created in the failed run, so the re-apply also succeeds even before this lands; this fix makes a clean from-scratch apply correct.)

Refs: #571
