### PR TITLE
feat(backend): expose dedicated admin API host api.admin.{env}

### DIFF
--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -12,6 +12,9 @@ GCP_GEMINI_MODEL=gemini-3-flash-preview
 # Server
 SERVER_PORT=8080
 SERVER_HOST=0.0.0.0
+# Admin Connect server — second listener serving only admin-scoped RPCs.
+# ADMIN_CORS_ALLOWED_ORIGINS (admin origins only) is set per overlay.
+ADMIN_SERVER_PORT=8090
 # Default handler timeout for most RPCs.
 # ConcertService has its own timeout (SERVER_CONCERT_HANDLER_TIMEOUT) because
 # Gemini API + Google Search grounding takes 25-110s per call.

--- a/k8s/namespaces/backend/base/server/deployment.yaml
+++ b/k8s/namespaces/backend/base/server/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           name: http
         - containerPort: 9090
           name: webhook
+        # Admin Connect server — second in-process listener serving only
+        # admin-scoped RPCs, exposed via server-admin-svc / api.admin.{env}.
+        - containerPort: 8090
+          name: http-admin
         envFrom:
         - configMapRef:
             name: server-config

--- a/k8s/namespaces/backend/base/server/health-check-policy-admin.yaml
+++ b/k8s/namespaces/backend/base/server/health-check-policy-admin.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: server-admin-policy
+spec:
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        port: 8090
+  targetRef:
+    group: ""
+    kind: Service
+    name: server-admin-svc # Referenced via kustomizeconfig.yaml 'nameReference'

--- a/k8s/namespaces/backend/base/server/httproute-admin.yaml
+++ b/k8s/namespaces/backend/base/server/httproute-admin.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: server-admin-route
+spec:
+  # Shares the external gateway with the consumer API route; hostnames
+  # (api.admin.{env}) are patched per overlay. Consumer routing is untouched.
+  parentRefs:
+  - name: external-gateway
+    namespace: gateway
+  rules:
+  - backendRefs:
+    - name: server-admin-svc
+      port: 80

--- a/k8s/namespaces/backend/base/server/kustomization.yaml
+++ b/k8s/namespaces/backend/base/server/kustomization.yaml
@@ -5,9 +5,12 @@ resources:
 - deployment.yaml
 - service.yaml
 - service-webhook.yaml
+- service-admin.yaml
 - health-check-policy.yaml
+- health-check-policy-admin.yaml
 - backend-policy.yaml
 - httproute.yaml
+- httproute-admin.yaml
 - external-secret.yaml
 
 configurations:

--- a/k8s/namespaces/backend/base/server/service-admin.yaml
+++ b/k8s/namespaces/backend/base/server/service-admin.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-admin-svc
+spec:
+  type: ClusterIP
+  # Targets the same Pods as server-svc (commonLabels apply `app: server`),
+  # but routes to the admin Connect server's dedicated port.
+  ports:
+  - port: 80
+    targetPort: 8090
+    protocol: TCP
+    name: http-admin
+    appProtocol: kubernetes.io/h2c # HTTP/2 Cleartext

--- a/k8s/namespaces/backend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/dev/kustomization.yaml
@@ -66,6 +66,14 @@ patches:
       path: /spec/hostnames
       value: ["api.dev.liverty-music.app"]
 
+- target:
+    kind: HTTPRoute
+    name: server-admin-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["api.admin.dev.liverty-music.app"]
+
 # CronJob: run concert discovery only on Fridays in dev
 - path: cronjob/concert-discovery/schedule_patch.yaml
   target:

--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,7 +1,10 @@
 # Environment
 ENVIRONMENT=development
-# CORS
+# CORS — consumer API. Keeps the admin origin until the frontend flips to
+# api.admin (removed in the cutover follow-up, task 5.4).
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app,https://admin.dev.liverty-music.app
+# CORS — admin API (admin origins only), governed independently of the consumer API.
+ADMIN_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://admin.dev.liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-dev
 # GCP_VERTEX_AI_SEARCH_DATA_STORE=projects/liverty-music-dev/locations/global/collections/default_collection/dataStores/concert-search-engine

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -93,6 +93,14 @@ patches:
       - op: add
         path: /spec/hostnames
         value: ["api.liverty-music.app"]
+  # Prod admin API HTTPRoute hostname.
+  - target:
+      kind: HTTPRoute
+      name: server-admin-route
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value: ["api.admin.liverty-music.app"]
   # Match dev's consumer resource sizing.
   - target:
       kind: Deployment

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -1,7 +1,10 @@
 # Environment
 ENVIRONMENT=production
-# CORS
+# CORS — consumer API. Keeps the admin origin until the frontend flips to
+# api.admin (removed in the cutover follow-up, task 5.4).
 CORS_ALLOWED_ORIGINS=https://liverty-music.app,https://admin.liverty-music.app
+# CORS — admin API (admin origins only), governed independently of the consumer API.
+ADMIN_CORS_ALLOWED_ORIGINS=https://admin.liverty-music.app
 # GCP
 GCP_PROJECT_ID=liverty-music-prod
 # Database

--- a/k8s/namespaces/frontend/overlays/prod/admin-configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/admin-configmap.yaml
@@ -16,10 +16,14 @@ data:
   #     satisfy the shared validator's non-empty requirement; the admin
   #     foundation registers no service worker and sends no push.
   #   - previewArtist*: empty — consumer-only discovery fields, unused by admin.
+  #   - adminApiBaseUrl: the dedicated admin API host the admin RPC clients
+  #     (e.g. ConcertModerationService) target; apiBaseUrl is retained only to
+  #     satisfy the shared validator's non-empty requirement.
   config.json: |
     {
       "environment": "prod",
       "apiBaseUrl": "https://api.liverty-music.app",
+      "adminApiBaseUrl": "https://api.admin.liverty-music.app",
       "zitadelIssuer": "https://auth.liverty-music.app",
       "zitadelClientId": "376175199994839311",
       "zitadelOrgId": "372892288692584603",

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -354,6 +354,12 @@ const SERVICES: ReadonlyArray<{
 	// dedicated HTTPRoute on this same shared gateway. See OpenSpec change
 	// `add-admin-console`.
 	{ name: 'admin-app', subdomain: 'admin' },
+	// Admin API — dev: api.admin.dev.liverty-music.app,
+	// prod: api.admin.liverty-music.app. The backend's dedicated admin Connect
+	// server (second listener in the same Pod) exposed via server-admin-svc and
+	// a dedicated HTTPRoute on this same shared gateway. See OpenSpec change
+	// `split-admin-rpc-server`.
+	{ name: 'admin-backend-server', subdomain: 'api.admin' },
 ]
 
 /**


### PR DESCRIPTION
## Why

The backend now runs a dedicated admin Connect server on its own port (8090). Expose it as a **separately governed** public surface so admin and consumer API traffic no longer share one host, CORS list, and route — enabling independent origins/limits and a future IAP/Cloud Armor layer.

## What

- **Deployment**: add the admin container port (`8090`, `http-admin`).
- **service-admin** (ClusterIP, `appProtocol: kubernetes.io/h2c`) + **httproute-admin** on the shared external gateway + gRPC **HealthCheckPolicy**, all targeting the admin port. Consumer routing untouched.
- Overlay hostname patches: `api.admin.dev.liverty-music.app` / `api.admin.liverty-music.app`.
- **network.ts**: add `admin-backend-server` so the managed cert + Cloud DNS for `api.admin.{env}` are provisioned via the shared certmap/static IP.
- Backend config: `ADMIN_SERVER_PORT` + `ADMIN_CORS_ALLOWED_ORIGINS` (admin origins only).
- The admin origin is **intentionally kept** in the consumer `CORS_ALLOWED_ORIGINS` until the frontend flips to `api.admin` (removed in a follow-up PR), so the admin console is never CORS-broken mid-cutover.
- Admin frontend prod config gains `adminApiBaseUrl`.

## Verification

`make lint-ts` (biome + tsc) green; `kubectl kustomize` renders dev + prod cleanly; `kube-linter` clean on the rendered backend overlay. `pulumi preview` runs on this PR.

## Cutover (see specification#615 §5)

**This is step 5.1** — stands up `api.admin` (route stays unhealthy until the backend serves the admin port; nothing uses it yet). Followed by backend release (5.2), frontend release (5.3), then a **follow-up PR** drops the admin origin from the consumer CORS (5.4).

Refs: liverty-music/specification#615