### PR TITLE
feat(backend): drop admin origin from consumer API CORS

### DIFF
--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -1,8 +1,8 @@
 # Environment
 ENVIRONMENT=development
-# CORS — consumer API. Keeps the admin origin until the frontend flips to
-# api.admin (removed in the cutover follow-up, task 5.4).
-CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app,https://admin.dev.liverty-music.app
+# CORS — consumer API. The admin console now calls api.admin (its own CORS),
+# so the admin origin is no longer needed here.
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://dev.liverty-music.app
 # CORS — admin API (admin origins only), governed independently of the consumer API.
 ADMIN_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:9000,https://admin.dev.liverty-music.app
 # GCP

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -1,8 +1,8 @@
 # Environment
 ENVIRONMENT=production
-# CORS — consumer API. Keeps the admin origin until the frontend flips to
-# api.admin (removed in the cutover follow-up, task 5.4).
-CORS_ALLOWED_ORIGINS=https://liverty-music.app,https://admin.liverty-music.app
+# CORS — consumer API. The admin console now calls api.admin (its own CORS),
+# so the admin origin is no longer needed here.
+CORS_ALLOWED_ORIGINS=https://liverty-music.app
 # CORS — admin API (admin origins only), governed independently of the consumer API.
 ADMIN_CORS_ALLOWED_ORIGINS=https://admin.liverty-music.app
 # GCP


### PR DESCRIPTION
## Why

Cutover follow-up for `split-admin-rpc-server` (**§5.4**). The admin origin was intentionally retained on the consumer API's `CORS_ALLOWED_ORIGINS` until the frontend flip shipped, so the admin console was never CORS-broken mid-cutover.

The frontend release **v1.14.0** is now live in prod (admin-app pod on v1.14.0, backend on v1.8.0, `api.admin` healthy) — the admin console calls `api.admin` with its own CORS allowlist and no longer hits the consumer API.

## What

Remove `https://admin.{env}.liverty-music.app` from the consumer `CORS_ALLOWED_ORIGINS` in the dev and prod overlays. The admin server's `ADMIN_CORS_ALLOWED_ORIGINS` is unchanged.

## Verification

`kubectl kustomize` dev/prod render: consumer CORS no longer contains the admin origin; `ADMIN_CORS_ALLOWED_ORIGINS` unchanged.

Refs: liverty-music/specification#615