### PR TITLE
fix(prod): pin sales-phase cronjobs to v1.9.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -214,7 +214,7 @@ images:
     newTag: v1.9.0 # commit 026eed95bc0481e8103d05b42a62a97478333af0
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159
+    newTag: v1.9.0 # commit 026eed95bc0481e8103d05b42a62a97478333af0
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.6.1 # commit ae70efaad90473f2a3f94107a8dd4ffb5bea7159
+    newTag: v1.9.0 # commit 026eed95bc0481e8103d05b42a62a97478333af0


### PR DESCRIPTION
## Why

The automated `bump-prod-pin` workflow (triggered by backend Release `v1.9.0`) bumped `server`, `consumer`, and the `concert-discovery` / `artist-image-sync` / `merch-discovery` cronjobs to `v1.9.0`, but **left `sales-phase-discovery` and `sales-reminders` at `v1.6.1`**.

Those v1.6.1 binaries still read `sales_phases.anchor_event_id` and the `event_sales_phases` join table — both **dropped** by backend migration `20260617120000` (series-level SalesPhase, v1.9.0). Running them against the new schema fails:

- `sales-reminders` runs every 15 min → actively erroring now.
- `sales-phase-discovery` runs daily at 12:00 UTC → would fail to discover.

## What

Pin both cronjobs to `v1.9.0` (images already retagged into prod AR by the release). Kustomize dry-run confirms both render at `v1.9.0`.

## Follow-up

Add these two images to `bump-prod-pin`'s rewrite list so future releases bump them automatically (this gap caused the partial rollout).

Refs: #571