### PR TITLE
fix(keda): scale consumer-app on the SALES_PHASE stream

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -42,3 +42,22 @@ spec:
       consumer: "USER_created"
       lagThreshold: "1"
       activationLagThreshold: "0"
+  # SALES_PHASE.discovered → announcement consumer. Durable name is the subject
+  # with dots replaced by underscores (subscriber DurableCalculator).
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "SALES_PHASE"
+      consumer: "SALES_PHASE_discovered"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # SALES_PHASE.reminder.due → reminder delivery consumer.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "SALES_PHASE"
+      consumer: "SALES_PHASE_reminder_due"
+      lagThreshold: "1"
+      activationLagThreshold: "0"


### PR DESCRIPTION
## Why

The `consumer-app` KEDA `ScaledObject` only triggers on the **CONCERT, ARTIST, USER** streams. It has **no trigger for the `SALES_PHASE` stream**, so:

- `SALES_PHASE.discovered` (announcement) and
- `SALES_PHASE.reminder.due` (reminder delivery)

are published to NATS but **never scale `consumer-app` up from 0** → the registered handlers (`announce-sales-phase`, `send-sales-phase-reminder`) never run → sales-phase notifications are **never delivered in prod**.

This is a latent gap from the original sales-phase feature, masked until now because discovery found 0 phases (Gemini spend-cap / grounding) so the SALES_PHASE stream was never exercised.

## What

Add two `nats-jetstream` triggers for the `SALES_PHASE` stream. Durable consumer names follow the backend subscriber's `DurableCalculator` (subject with `.`→`_`):

- `SALES_PHASE_discovered`
- `SALES_PHASE_reminder_due`

`lagThreshold: "1"` wakes the consumer on any pending notification (matching the ARTIST/USER triggers). Base manifest, so it applies to dev and prod. Kustomize dry-run confirms both overlays render the two new triggers.

Refs: #571