### PR TITLE
fix(prod): pin sales-phase cronjobs to v1.10.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -214,7 +214,7 @@ images:
     newTag: v1.10.0 # commit 13d130073173b12c63cba6a679f94bf1cfcdbe3f
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.9.0 # commit 026eed95bc0481e8103d05b42a62a97478333af0
+    newTag: v1.10.0 # commit 13d130073173b12c63cba6a679f94bf1cfcdbe3f
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.9.0 # commit 026eed95bc0481e8103d05b42a62a97478333af0
+    newTag: v1.10.0 # commit 13d130073173b12c63cba6a679f94bf1cfcdbe3f


### PR DESCRIPTION
The auto pin-bump for backend v1.10.0 moved server/consumer (and other cronjobs) but **left `sales-phase-discovery` and `sales-reminders` at v1.9.0** (same gap as the v1.9.0 rollout, CP #360). `sales-phase-discovery` is where the v1.10.0 change lives (per-artist seed-URL searcher), so it must move to v1.10.0 or prod keeps running the old per-series searcher. Both v1.10.0 images exist in prod AR; kustomize render confirms both pins. Follow-up: add the two images to bump-prod-pin's rewrite list. Refs: #571