### PR TITLE
fix(backend): repair sales-phase notification delivery (NATS_URL + consumer min=1)

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
@@ -31,3 +31,7 @@ DATABASE_SCHEMA=app
 
 # Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
 SHUTDOWN_TIMEOUT=90s
+# NATS — required so discovered phases publish SALES_PHASE.discovered to
+# JetStream for the consumer to deliver. Without it the job falls back to an
+# in-process channel and announcements never reach subscribers.
+NATS_URL=TO_REPLACE_BY_OVERLAY

--- a/k8s/namespaces/backend/base/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-reminders/configmap.env
@@ -19,6 +19,10 @@ DATABASE_SCHEMA=app
 
 # Shutdown timeout must fit within: terminationGracePeriodSeconds(120) - buffer(30) = 90s
 SHUTDOWN_TIMEOUT=90s
+# NATS — required so due reminders publish SALES_PHASE.reminder.due to JetStream
+# for the consumer to deliver. Without it the job falls back to an in-process
+# channel and reminders never reach subscribers.
+NATS_URL=TO_REPLACE_BY_OVERLAY
 
 # Push Notifications (VAPID) — Web Push delivery for sales-phase reminders.
 VAPID_PUBLIC_KEY=TO_REPLACE_BY_OVERLAY

--- a/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/sales-phase-discovery/configmap.env
@@ -10,5 +10,7 @@ DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osa
 # Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
 DATABASE_MAX_OPEN_CONNS=5
 DATABASE_MAX_IDLE_CONNS=1
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/dev/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/cronjob/sales-reminders/configmap.env
@@ -10,6 +10,8 @@ DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-dev:asia-northeast2:postgres-osa
 # Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
 DATABASE_MAX_OPEN_CONNS=5
 DATABASE_MAX_IDLE_CONNS=1
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
 

--- a/k8s/namespaces/backend/overlays/prod/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/sales-phase-discovery/configmap.env
@@ -10,5 +10,7 @@ DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-os
 # Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
 DATABASE_MAX_OPEN_CONNS=5
 DATABASE_MAX_IDLE_CONNS=1
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318

--- a/k8s/namespaces/backend/overlays/prod/cronjob/sales-reminders/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/sales-reminders/configmap.env
@@ -10,6 +10,8 @@ DATABASE_INSTANCE_CONNECTION_NAME=liverty-music-prod:asia-northeast2:postgres-os
 # Connection pool: db-f1-micro budget (25 total) → 5 per workload + headroom for Atlas/ops
 DATABASE_MAX_OPEN_CONNS=5
 DATABASE_MAX_IDLE_CONNS=1
+# NATS
+NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry
 TELEMETRY_OTLP_ENDPOINT=otel-collector.otel-collector.svc.cluster.local:4318
 

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -122,7 +122,18 @@ patches:
                 limits:
                   cpu: 200m
                   memory: 128Mi
-  # Consumer ScaledObject — start with maxReplicas: 1 (per design D8). KEDA can scale up via Pulumi tweak.
+  # Consumer ScaledObject — pin to exactly 1 replica (min=max=1).
+  #
+  # minReplicaCount MUST be 1 (not 0): the Watermill JetStream push
+  # consumers (durables) are deleted when the consumer Deployment scales to
+  # zero and no subscriber holds the queue-group interest. A deleted durable
+  # has no metric for KEDA's nats-jetstream scaler to read, so KEDA can never
+  # scale the consumer back up from 0 — events published while idle (e.g. the
+  # daily sales-phase discovery cron) pile up undelivered forever. Keeping one
+  # replica always running holds the durables open so every event is consumed.
+  # Long-lived streams created during earlier always-on periods (CONCERT,
+  # ARTIST, USER) survived by chance; SALES_PHASE, added later, exposed the
+  # deadlock. KEDA still scales up to maxReplicas under load.
   - target:
       kind: ScaledObject
       name: consumer-app
@@ -132,6 +143,7 @@ patches:
       metadata:
         name: consumer-app
       spec:
+        minReplicaCount: 1
         maxReplicaCount: 1
 configMapGenerator:
   - name: server-config


### PR DESCRIPTION
Repairs the two prod bugs that together prevented **any** sales-phase notification from ever being delivered since launch. Discovery itself works (Gemini URLContext grounding found real phases); the delivery path was broken end-to-end.

## Bug 1 — sales cronjobs missing `NATS_URL`
`sales-phase-discovery` and `sales-reminders` CronJob configmaps never defined `NATS_URL`. With an empty URL the jobs' DI falls back to an **in-process gochannel** publisher (and `EnsureStreams` no-ops), so `SALES_PHASE.discovered` / `SALES_PHASE.reminder.due` events went to a channel that goes nowhere. NATS `SALES_PHASE` stream `last_seq` stayed `0`.

**Fix:** add `NATS_URL` to both jobs (base `TO_REPLACE_BY_OVERLAY`; dev/prod overlays = in-cluster NATS), mirroring `concert-discovery`.

**Verified live:** after patching, a discovery run published to JetStream (`last_seq 0 → 3`) and KEDA auto-scaled the consumer `0 → 1` on pending.

## Bug 2 — consumer durable deleted on scale-to-zero
The Watermill JetStream push consumers (durables) are deleted when `consumer-app` scales to 0 and no subscriber holds the queue-group interest. A deleted durable has no metric for KEDA's nats-jetstream scaler, so KEDA can **never** scale the consumer back up from 0 → events published while idle pile up undelivered forever (the original deadlocked state). Confirmed reproducibly: `SALES_PHASE` shows `No Consumers defined` whenever `consumer-app=0`, while always-on-era streams (CONCERT/ARTIST/USER) persist.

**Fix:** pin `consumer-app` `minReplicaCount=1` so one replica always holds the durables open. KEDA still scales up to maxReplicas under load. Cost is negligible (10m CPU / 20Mi).

## Verified pipeline
With the consumer up, a message republished to `SALES_PHASE.discovered` reached the handler (`sales_phase_announcement` logged), exercising parse → retry → poison-queue correctly. publish → NATS → KEDA → consumer → handler is proven; only the marshaler-specific synthetic payload failed to parse (real publisher messages decode fine).

Refs: #571