### PR TITLE
fix(prod): bump sales cronjob pins to v1.12.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.12.0 # commit dd888e8ff0acc379e30efb80fdf3b0fcb060e26d
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.10.0 # commit 13d130073173b12c63cba6a679f94bf1cfcdbe3f
+    newTag: v1.12.0 # commit dd888e8ff0acc379e30efb80fdf3b0fcb060e26d
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.10.0 # commit 13d130073173b12c63cba6a679f94bf1cfcdbe3f
+    newTag: v1.12.0 # commit dd888e8ff0acc379e30efb80fdf3b0fcb060e26d


### PR DESCRIPTION
## Why

The automated `bump-prod-pin` workflow (triggered by the backend v1.12.0 release) rewrote `server`, `consumer`, `concert-discovery`, `artist-image-sync`, and `merch-discovery` to `v1.12.0`, but left **`sales-phase-discovery` and `sales-reminders` on `v1.10.0`** — a recurring gap in the workflow's rewrite list.

This bumps both in lock-step so they run the same v1.12.0 build as the rest of the release and pick up the fail-fast `NATS_URL` guard (#341 in backend).

## Verification

- `grep -c "newTag: v1.12.0"` → 7 (all backend images aligned).
- `kubectl kustomize overlays/prod` renders both sales cronjobs at `:v1.12.0`.

Refs: #571