### PR TITLE
fix(zitadel): self-heal projection-trigger wedge + prod 2 replicas

### DIFF
--- a/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
@@ -1,0 +1,189 @@
+# Self-healing watchdog for the Zitadel projection-trigger wedge
+# (zitadel/zitadel#10103, unfixed in v4.14.0).
+#
+# THE PROBLEM IT SOLVES: when Zitadel hits the in-process wedge, every
+# auth-flow query that triggers-on-read a projection hangs (login 504),
+# yet `/debug/healthz` and `/debug/ready` keep returning 200 — so the
+# kubelet liveness/readiness probes never restart the pod. Recovery is a
+# manual `kubectl rollout restart`. On 2026-06-23 prod login was down ~13
+# min until a human restarted it.
+#
+# WHAT THIS DOES: every minute, probe a REAL auth-flow endpoint
+# (`/oauth/v2/authorize` with valid params → 302 healthy / hang wedged).
+# If it hangs N/N times WHILE `/debug/healthz` is still 200 (the precise
+# wedge signature), restart `zitadel-api`. With 2 prod replicas the
+# rolling restart is non-disruptive. Turns a multi-min manual outage into
+# ~2-min unattended recovery.
+#
+# WHY A CRONJOB, NOT A LIVENESS PROBE: an httpGet liveness on authorize
+# treats 400 as failure (an expired/misconfigured client id → restart
+# loop), can't distinguish a hang from a fast error, and writes a
+# side-effect every probe tick. `curl` in a CronJob matches the *hang*
+# specifically and probes only 1/min.
+#
+# SIDE EFFECT: each probe creates a short-lived throwaway auth request in
+# the eventstore (~1440/day). Accepted pre-launch; a read-only probe
+# target is a documented follow-up.
+#
+# COUPLING: the probe hardcodes the prod consumer OIDC client id +
+# registered redirect uri. If the consumer app is reprovisioned and its
+# client id changes, update WATCHDOG_AUTHZ_URL below (the probe would
+# start returning 400 fast — visible as "healthy" — so it fails safe:
+# it stops detecting, it does not false-restart).
+#
+# Annotated `liverty-music.app/temporary` for cleanup once upstream
+# zitadel#10103 is fixed and pinned.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zitadel-wedge-watchdog
+  annotations:
+    liverty-music.app/temporary: "until-upstream-zitadel-10103-fix"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: zitadel-wedge-watchdog
+  annotations:
+    liverty-music.app/temporary: "until-upstream-zitadel-10103-fix"
+# Minimum privilege: only get/patch the specific `zitadel-api` Deployment
+# (`patch` is what `kubectl rollout restart` issues). Nothing else.
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["zitadel-api"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zitadel-wedge-watchdog
+  annotations:
+    liverty-music.app/temporary: "until-upstream-zitadel-10103-fix"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: zitadel-wedge-watchdog
+subjects:
+- kind: ServiceAccount
+  name: zitadel-wedge-watchdog
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: zitadel-wedge-watchdog
+  annotations:
+    liverty-music.app/temporary: "until-upstream-zitadel-10103-fix"
+  labels:
+    app: zitadel
+    component: self-healing
+spec:
+  # Every minute.
+  schedule: "* * * * *"
+  timeZone: "Etc/UTC"
+  # A run takes up to ~45s worst case (healthz 5s + 3×10s probes + 2×5s
+  # sleeps); never overlap the next minute's fire.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  # Don't backfill missed fires if the cluster was briefly offline.
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 300
+      template:
+        metadata:
+          labels:
+            app: zitadel
+            component: self-healing
+        spec:
+          serviceAccountName: zitadel-wedge-watchdog
+          restartPolicy: Never
+          nodeSelector:
+            cloud.google.com/gke-spot: "true"
+          containers:
+          - name: watchdog
+            # Needs BOTH `curl` (probe) and `kubectl` (restart).
+            # `alpine/k8s` bundles both; :1.32.x matches the cluster minor.
+            image: alpine/k8s:1.32.3
+            env:
+            # Flip to "false" to enable real restarts. Ships in DRY-RUN so
+            # one soak window can confirm zero false positives first.
+            - name: WATCHDOG_DRY_RUN
+              value: "true"
+            - name: HOME
+              value: /tmp
+            - name: WATCHDOG_HEALTHZ_URL
+              value: "https://auth.liverty-music.app/debug/healthz"
+            # Valid prod consumer client id + registered redirect uri →
+            # 302 when healthy, hang when wedged. Invalid params would 400
+            # *before* the wedged code path, so valid params are required.
+            - name: WATCHDOG_AUTHZ_URL
+              value: "https://auth.liverty-music.app/oauth/v2/authorize?client_id=373015520582107291&response_type=code&scope=openid&redirect_uri=https://liverty-music.app/auth/callback&state=watchdog&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256"
+            command: ["/bin/sh", "-c"]
+            args:
+            - |
+              set -u
+
+              # Guard: only the wedge signature warrants a restart. The
+              # wedge keeps core health green while auth-flow hangs. If
+              # healthz is NOT 200, the fault is something else (gateway/
+              # DNS/pod-down) that a restart won't fix — bail out.
+              hz=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$WATCHDOG_HEALTHZ_URL" 2>/dev/null || echo 000)
+              if [ "$hz" != "200" ]; then
+                echo "healthz=$hz (not 200): not the wedge signature, skipping."
+                exit 0
+              fi
+
+              # Probe the auth flow 3× ~5s apart. HTTP 000 = curl timeout
+              # = hang = wedge. 302 = healthy.
+              hangs=0
+              i=1
+              while [ "$i" -le 3 ]; do
+                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$WATCHDOG_AUTHZ_URL" 2>/dev/null || echo 000)
+                echo "probe $i/3: authorize http_code=$code"
+                if [ "$code" = "000" ]; then
+                  hangs=$((hangs + 1))
+                fi
+                if [ "$i" -lt 3 ]; then
+                  sleep 5
+                fi
+                i=$((i + 1))
+              done
+
+              if [ "$hangs" -lt 3 ]; then
+                echo "healthy: $hangs/3 probes hung — no action."
+                exit 0
+              fi
+
+              echo "WEDGE DETECTED: $hangs/3 authorize probes hung while healthz=200."
+              if [ "${WATCHDOG_DRY_RUN:-true}" = "true" ]; then
+                echo "WATCHDOG_DRY_RUN=true — would run: kubectl rollout restart deployment/zitadel-api (skipped)."
+                exit 0
+              fi
+              echo "restarting deployment/zitadel-api ..."
+              kubectl rollout restart deployment/zitadel-api
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 65532
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          # Writable scratch for kubectl's discovery cache ($HOME=/tmp)
+          # under readOnlyRootFilesystem.
+          - name: tmp
+            emptyDir: {}

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -21,6 +21,11 @@ resources:
 # Prod DB grant Job — idempotent ALTER DATABASE OWNER + GRANT scoped to the
 # prod Cloud SQL `zitadel` DB.
 - job-grant-db.yaml
+# Self-healing watchdog (prod-only): detects the projection-trigger wedge
+# (zitadel#10103) via an auth-flow hang probe and auto-restarts
+# `zitadel-api`. Ships in dry-run mode (WATCHDOG_DRY_RUN=true). See the
+# manifest header for the full rationale.
+- cronjob-watchdog-zitadel.yaml
 # NOTE: PodMonitoring CRD (previously `podmonitoring.yaml`) was deleted as
 # part of the Helm chart migration. Zitadel v4 has no `/debug/metrics`
 # HTTP scrape endpoint — the path returns 404 on v4.14.0. Observability

--- a/k8s/namespaces/zitadel/overlays/prod/values.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/values.yaml
@@ -1,6 +1,17 @@
 # Prod-specific Helm values, layered on top of `../../base/values.yaml`.
 # See `../dev/values.yaml` for the full structural commentary.
 
+# Prod runs 2 `zitadel-api` replicas (base is single-replica for dev
+# cost-simplicity). A single wedged process (zitadel/zitadel#10103,
+# in-process projection-trigger deadlock) otherwise takes down ALL login
+# because readiness can't detect the wedge; a second replica keeps login
+# serving and makes the self-healing watchdog's rolling restart
+# (cronjob-watchdog-zitadel.yaml) non-disruptive. PDB `minAvailable: 1`
+# (overrides base's 0) keeps one replica up during voluntary disruptions.
+replicaCount: 2
+pdb:
+  minAvailable: 1
+
 zitadel:
   configmapConfig:
     ExternalDomain: auth.liverty-music.app


### PR DESCRIPTION
## Why

Prod hosted login was fully down **~13 min on 2026-06-23 (05:47–06:00 UTC)** when the self-hosted Zitadel API (`v4.14.0`) hit the in-process **projection-trigger wedge** (upstream zitadel/zitadel#10103, unfixed). Auth-flow queries (`/oauth/v2/authorize`, `searchProjectRoles`) hung past the gateway timeout (504), while `/debug/healthz`, `/debug/ready`, OIDC discovery and static assets all stayed 200/fast — so the kubelet liveness/readiness never restarted the wedged pod and recovery needed a **manual** `kubectl rollout restart`. DB was clean (zero slow-query/lock-wait logs, `num_backends` flat) → purely an in-process deadlock.

## What

- **Self-healing watchdog** (`overlays/prod/cronjob-watchdog-zitadel.yaml`): a small CronJob (`curl` + `kubectl`, the dev restart-cronjob pattern — no compiled app) that every minute confirms `/debug/healthz`==200, probes `/oauth/v2/authorize` with valid prod params 3×, and `rollout restart`s `zitadel-api` only if **all 3 hang** (the precise wedge signature). Dedicated min-privilege SA/Role/RoleBinding (`get`/`patch` on the `zitadel-api` Deployment only).
- **Ships in dry-run** (`WATCHDOG_DRY_RUN=true`) — logs the restart decision but skips the actual restart, for a soak window to confirm zero false positives. Flip to `false` to activate.
- **Prod `zitadel-api` → 2 replicas + PDB `minAvailable: 1`** (was 1) so a single wedged process degrades instead of fully outaging login, and the rolling restart is non-disruptive.

## Why a CronJob, not a liveness probe

An httpGet liveness on `/oauth/v2/authorize` treats `400` as failure (an expired/misconfigured client id → restart loop), can't distinguish a hang from a fast error, and writes a side-effect every probe tick. `curl` in a CronJob matches the *hang* specifically and probes only 1/min.

## Validation

- `kubectl kustomize --enable-helm` renders cleanly (replicas: 2, PDB minAvailable: 1, watchdog SA/Role/RoleBinding/CronJob).
- `make lint-k8s` → **No lint errors found!** + Spot nodeSelector check OK.

## Deploy note

⚠️ Merging syncs the prod overlay via ArgoCD. The watchdog is dry-run (no auto-restart yet); the **replica bump 1→2 takes effect on merge**.

## Follow-ups (tracked, not in this PR)

- Read-only probe target to eliminate the auth-request side-effect (~1440/day throwaway auth requests).
- Notification alert via a viable signal (watchdog-restart log-based metric or Gateway 504 rate) — the OIDCService latency metric is dropped at the OTLP collector.
- Flip watchdog to active after dry-run soak; refresh `docs/runbooks/zitadel-hang.md`.

OpenSpec change: `zitadel-wedge-self-healing` (liverty-music/specification#docs branch).

Closes #365