### PR TITLE
fix(zitadel): activate self-healing watchdog (dry-run -> active)

### DIFF
--- a/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
@@ -109,10 +109,12 @@ spec:
             # `alpine/k8s` bundles both; :1.32.x matches the cluster minor.
             image: alpine/k8s:1.32.3
             env:
-            # Flip to "false" to enable real restarts. Ships in DRY-RUN so
-            # one soak window can confirm zero false positives first.
+            # Active: on the wedge signature (N/N authorize hangs while
+            # healthz=200) the watchdog runs `rollout restart`. Verified in
+            # DRY-RUN first against live prod (healthy → no action). Set
+            # back to "true" to return to observe-only.
             - name: WATCHDOG_DRY_RUN
-              value: "true"
+              value: "false"
             - name: HOME
               value: /tmp
             - name: WATCHDOG_HEALTHZ_URL

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -23,8 +23,8 @@ resources:
 - job-grant-db.yaml
 # Self-healing watchdog (prod-only): detects the projection-trigger wedge
 # (zitadel#10103) via an auth-flow hang probe and auto-restarts
-# `zitadel-api`. Ships in dry-run mode (WATCHDOG_DRY_RUN=true). See the
-# manifest header for the full rationale.
+# `zitadel-api` (active; flip WATCHDOG_DRY_RUN=true for observe-only).
+# See the manifest header for the full rationale.
 - cronjob-watchdog-zitadel.yaml
 # NOTE: PodMonitoring CRD (previously `podmonitoring.yaml`) was deleted as
 # part of the Helm chart migration. Zitadel v4 has no `/debug/metrics`


### PR DESCRIPTION
Follow-up to #366. The watchdog shipped in **dry-run** and was verified against live prod — its first runs correctly classified a healthy system as no-action (3/3 authorize probes `302`, `/debug/healthz` `200`, "no action").

This flips `WATCHDOG_DRY_RUN` to `false` so it now actually runs `kubectl rollout restart deploy/zitadel-api` on the wedge signature (N/N authorize hangs while `/debug/healthz`==200), enabling **unattended recovery** from the zitadel/zitadel#10103 projection-trigger wedge.

Guards remain conservative: 3/3 in-run hangs + healthz=200 precondition + `concurrencyPolicy: Forbid`. With 2 replicas (#366) the rolling restart is non-disruptive.

`make lint-k8s` passes.

Closes #365