### PR TITLE
feat(zitadel): make wedge watchdog probe read-only via ListProjectRoles

### DIFF
--- a/docs/runbooks/zitadel-hang.md
+++ b/docs/runbooks/zitadel-hang.md
@@ -1,197 +1,196 @@
-# Runbook: Zitadel API hang on `GetAuthRequest`
+# Runbook: Zitadel projection-trigger wedge
 
-> **Source of truth:** this runbook is derived from
-> `specification/openspec/specs/zitadel-observability/spec.md` →
-> "Operator runbook for the Zitadel hang incident shape" requirement.
-> If the spec is updated, regenerate this file in the same PR.
+> **Source of truth:** this runbook covers the wedge shape documented in
+> `specification/openspec/specs/zitadel-self-hosted-deployment/spec.md`
+> → "Self-healing watchdog auto-restarts a wedged Zitadel API" requirement.
+> Update this file whenever the watchdog or detection signal changes.
+
+## TL;DR (self-healing first)
+
+**Since 2026-06-23** a watchdog CronJob runs every minute in prod:
+`k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
+
+If login is broken, **check the watchdog job history first** before
+taking manual action:
+
+```bash
+# Most-recent watchdog run
+kubectl get jobs -n zitadel -l component=self-healing \
+  --sort-by=.metadata.creationTimestamp | tail -3
+
+# Logs for the most-recent job pod
+kubectl logs -n zitadel \
+  -l app=zitadel,component=self-healing --tail=50
+```
+
+If you see `restarting deployment/zitadel-api ...` or
+`WATCHDOG_DRY_RUN=true — would run: kubectl rollout restart`, the
+watchdog detected the wedge. Wait 2–3 min for the restart to finish,
+then **verify recovery via an auth-flow probe** (see §Post-mitigation
+below) — NOT via `/debug/healthz` (it stays 200 during the wedge).
+
+If the watchdog is not firing or is stuck, continue to §Manual
+mitigation.
+
+---
 
 ## When this runbook applies
 
-You received the **Zitadel API latency p99** alert — `OIDCService/*`
-p99 above 10 seconds — and observe one or more of:
+The **wedge shape** (zitadel/zitadel#10103) exhibits:
 
-- `GetAuthRequest` (or another `OIDCService/*` call) is timing out
-  at 30+ seconds.
-- Zitadel API responses include `code: internal` with no useful
-  message body.
-- `https://auth.dev.liverty-music.app/.well-known/openid-configuration`
-  takes seconds-to-tens-of-seconds to return (or doesn't return).
-- Backend JWT validation is failing in a correlated burst (the
-  **backend JWT validation error rate** alert may also be firing).
-- The Zitadel API pod's age is ≥ ~3 days (the hang precondition
-  empirically requires accumulated in-memory state, not just any
-  short-uptime hiccup).
+- Login returns 504 at `auth.liverty-music.app`.
+- `ListProjectRoles` or `/oauth/v2/authorize` hangs past 10 s.
+- `/debug/healthz` **still returns 200** — the wedge is in-process only.
+- Cloud SQL `num_backends` is flat (no DB saturation).
+- No recent Zitadel upgrade; the same version has been running for ≥3 days.
 
-If only one of these symptoms is present without the others, it's
-probably **not** the §18.6 hang shape — investigate as a fresh
-incident before reaching for the mitigation below.
+The watchdog detects the wedge using a **read-only
+`ProjectService/ListProjectRoles` probe** (`POST
+auth.liverty-music.app/zitadel.project.v2.ProjectService/ListProjectRoles`
+with `Authorization: Bearer <watchdog-PAT>`). That method internally
+triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the same
+projection observed wedging on 2026-06-23. A hang = wedge signal; a fast
+200 = healthy.
 
-The §18.6 cutover-incident chain that this runbook captures was:
-~30 minutes of high-density state-changing API operations
-(multiple `_activate`, MachineKey replace, Action delete, email
-change) against a 3.5-day-old Zitadel API pod. Two hypotheses are
-documented for the root cause; both are resolved by a pod restart:
+**The probe is read-only** — it creates no OIDC auth requests in the
+eventstore (unlike the prior authorize-based probe). The ~1440/day
+auth-request accumulation is eliminated.
 
-1. **Hypothesis A:** in-memory projection updater stuck on a write
-   lock during the burst.
-2. **Hypothesis B:** Cloud SQL connection-pool exhaustion from
-   leaked connections in async notification-worker retries.
+If `ListProjectRoles` returns `401`/`403` the watchdog logs
+"watchdog credential invalid" and skips the restart — fail-safe, but
+detection is degraded. Check the watchdog PAT (see §Credential health).
 
-Capture forensic data **before** restarting — once the pod is
-recycled, all in-memory state is gone and we lose the only chance
-to disambiguate the two hypotheses.
+---
 
-## Forensic data capture (BEFORE mitigation)
+## Watchdog PAT credential health
 
-Save everything to `/tmp/zitadel-hang-$(date -u +%Y%m%dT%H%M%SZ)/` so
-the captured artifacts survive your terminal session ending. The
-directory should be uploaded to the §18.6 follow-up issue once the
-incident is resolved.
+The watchdog authenticates with a long-lived PAT for machine user
+`watchdog-probe` (least-privilege `PROJECT_OWNER_VIEWER` on the
+`liverty-music` product project, provisioned by Pulumi
+`WatchdogProbeComponent`). The PAT is synced from GSM
+`zitadel-watchdog-probe-pat` via ExternalSecret into K8s Secret
+`zitadel-watchdog-probe-pat` in the `zitadel` namespace.
+
+If the watchdog logs "watchdog credential invalid":
+
+```bash
+# Confirm the K8s Secret exists and is populated
+kubectl get secret zitadel-watchdog-probe-pat -n zitadel \
+  -o jsonpath='{.data.token}' | base64 -d | head -c 20
+# Should print the first 20 chars of the PAT
+
+# Confirm ESO synced successfully
+kubectl get externalsecret zitadel-watchdog-probe-pat -n zitadel
+# STATUS should be Ready / SecretSynced
+
+# Check PAT expiry in the Zitadel Admin Console:
+#   https://auth.liverty-music.app/ui/console
+#   → Organizations → admin → Users → watchdog-probe → Personal Access Tokens
+# Current expiry: 2099-01-01 (far-future)
+```
+
+If the PAT is expired or revoked, re-provision via `pulumi up` on the
+prod stack (Pulumi `WatchdogProbeComponent` in
+`src/zitadel/components/watchdog-probe.ts`). The ESO refresh interval
+is 1h; force an immediate sync if needed:
+
+```bash
+kubectl annotate externalsecret zitadel-watchdog-probe-pat \
+  -n zitadel force-sync=$(date +%s) --overwrite
+```
+
+---
+
+## Manual mitigation (if watchdog does not auto-recover)
+
+When the wedge is confirmed and the watchdog has not fired (or is in
+dry-run mode):
+
+```bash
+# Confirm you're targeting the right cluster
+kubectl config current-context
+# expected: gke_liverty-music-prod_asia-northeast2-a_...
+
+kubectl rollout restart deployment/zitadel-api -n zitadel
+kubectl rollout status deployment/zitadel-api -n zitadel --timeout=120s
+```
+
+With 2 prod replicas the rolling restart is non-disruptive.
+
+---
+
+## Post-mitigation verification
+
+**Do NOT use `/debug/healthz` to verify recovery** — it returns 200
+during the wedge and does not change on restart. Verify via an
+auth-flow probe instead:
+
+```bash
+# Verify the ListProjectRoles probe is fast (<2s) after restart
+PAT=$(kubectl get secret zitadel-watchdog-probe-pat -n zitadel \
+  -o jsonpath='{.data.token}' | base64 -d)
+time curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST https://auth.liverty-music.app/zitadel.project.v2.ProjectService/ListProjectRoles \
+  -H "Authorization: Bearer $PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"projectId":"373015520045170843"}'
+# Expected: 200, real time well under 2 s
+
+# Or verify via a real login attempt at https://liverty-music.app
+```
+
+---
+
+## Forensic data capture (for recurring wedges)
+
+If the wedge recurs within 24 hours of restart, capture before mitigating:
 
 ```bash
 INCIDENT_DIR="/tmp/zitadel-hang-$(date -u +%Y%m%dT%H%M%SZ)"
 mkdir -p "$INCIDENT_DIR"
-cd "$INCIDENT_DIR"
 
-# Cross-platform "1 hour ago" — GNU `date -d` on Linux, BSD `date -v`
-# on macOS. We try GNU first; if that errors (BSD does not understand
-# `-d`), the `||` falls through to the BSD form. Used by the gcloud
-# calls below.
+ZITADEL_POD=$(kubectl get pods -n zitadel -l component=api \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n zitadel "$ZITADEL_POD" -c zitadel --since=30m \
+  > "$INCIDENT_DIR/zitadel-logs.txt"
+kubectl describe pod -n zitadel "$ZITADEL_POD" \
+  > "$INCIDENT_DIR/pod-describe.txt"
+kubectl get events -n zitadel --sort-by=.lastTimestamp \
+  > "$INCIDENT_DIR/events.txt"
+
+# Cloud SQL connection count
 ONE_HOUR_AGO=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
   || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)
-
-# 1. Identify the affected pod.
-kubectl get pods -n zitadel -l component=api -o wide > pods.txt
-
-ZITADEL_POD=$(kubectl get pods -n zitadel -l component=api -o jsonpath='{.items[0].metadata.name}')
-echo "Affected pod: $ZITADEL_POD" | tee -a NOTES.md
-
-# 2. Pod state — uptime, restarts, recent events.
-kubectl describe pod -n zitadel "$ZITADEL_POD" > pod-describe.txt
-kubectl get events -n zitadel --sort-by=.lastTimestamp > events.txt
-
-# 3. Recent application logs (last 30 minutes).
-kubectl logs -n zitadel "$ZITADEL_POD" -c zitadel --since=30m > zitadel-logs.txt
-
-# 4. Cloud SQL Auth Proxy sidecar logs — if hypothesis B is right,
-#    the proxy will show connection saturation here.
-kubectl logs -n zitadel "$ZITADEL_POD" -c cloud-sql-proxy --since=30m > sql-proxy-logs.txt
-
-# 5. Cloud SQL connection-pool metric snapshot. The
-#    `zitadel-observability` dashboard panel shows the same data
-#    visually; this saves the underlying values for the issue tracker.
 gcloud monitoring time-series list \
-  --project=liverty-music-dev \
-  --filter='metric.type="cloudsql.googleapis.com/database/postgresql/num_backends" AND resource.label.database_id="liverty-music-dev:postgres-osaka"' \
+  --project=liverty-music-prod \
+  --filter='metric.type="cloudsql.googleapis.com/database/postgresql/num_backends"' \
   --interval-end-time=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
   --interval-start-time="$ONE_HOUR_AGO" \
-  --format=json > sql-num-backends.json
-
-# 6. Recent Zitadel API request rate by gRPC method, to identify
-#    whether a state-changing API burst preceded the hang.
-gcloud logging read \
-  'resource.type="k8s_container" AND resource.labels.namespace_name="zitadel" AND resource.labels.container_name="zitadel" AND timestamp>="'"$ONE_HOUR_AGO"'"' \
-  --project=liverty-music-dev \
-  --limit=10000 \
-  --format=json > zitadel-recent-api-calls.json
-
-# 7. Live API smoke test from inside the cluster, to confirm the
-#    hang is reproducible at the moment of mitigation.
-kubectl run -n zitadel zitadel-smoke-$$ \
-  --rm -i --restart=Never \
-  --image=curlimages/curl:8.10.1 \
-  --command -- curl -sS -m 35 -o /dev/null -w 'http_code=%{http_code} time=%{time_total}\n' \
-  http://zitadel.zitadel.svc.cluster.local:8080/.well-known/openid-configuration \
-  > smoke-test.txt 2>&1
+  --format=json > "$INCIDENT_DIR/sql-num-backends.json"
 
 ls -la "$INCIDENT_DIR"
 ```
 
-## Mitigation
+---
 
-After the forensic capture above completes, restart the Deployment.
+## Wedge signature summary
 
-```bash
-# Confirm you're targeting the right cluster!
-kubectl config current-context
-# expected: gke_liverty-music-dev_asia-northeast2-a_standard-cluster-osaka
+| Signal | During wedge | During other outages |
+|---|---|---|
+| `ListProjectRoles` (watchdog probe) | **hangs** (HTTP 000) | fast 401/503 |
+| `/debug/healthz` | **200** (misleading) | may be non-200 |
+| Cloud SQL `num_backends` | **flat** | may be elevated |
+| Pod age | ≥ 3 days (typically) | any age |
+| Restart fixes it | **yes** | depends |
 
-kubectl rollout restart deployment/zitadel -n zitadel
-kubectl rollout status deployment/zitadel -n zitadel --timeout=120s
-```
-
-The default RollingUpdate strategy (`maxUnavailable: 0`,
-`maxSurge: 1`) rolls in a fresh pod before terminating the old one,
-so external auth traffic continues uninterrupted regardless of
-replica count — the Service always has at least one Ready endpoint.
-**In dev**, replicas are scaled to 1, but the rollout is still
-zero-downtime for the same reason: the old pod is only terminated
-after the surge pod is Ready. The dev-specific risk is the inverse:
-if the spot pool has only one node and pod anti-affinity prevents
-co-location, the surge pod will be Pending and the rollout will
-stall while the old pod keeps serving (no 503s, but stuck
-Deployment). The `--timeout=120s` on `rollout status` above will
-catch this. If it expires, run `kubectl get events -n zitadel`
-and look for `FailedScheduling`.
-
-## Post-mitigation verification
-
-```bash
-# 1. The new pod is Ready.
-kubectl get pods -n zitadel -l component=api
-
-# 2. The healthz endpoint returns 200.
-curl -sS -m 5 -o /dev/null -w '%{http_code}\n' \
-  https://auth.dev.liverty-music.app/debug/healthz
-# expected: 200
-
-# 3. The OIDC discovery endpoint returns within steady-state latency
-#    (sub-second).
-time curl -sS -m 5 \
-  https://auth.dev.liverty-music.app/.well-known/openid-configuration \
-  > /dev/null
-# expected: real time well under 1 s
-
-# 4. The Cloud Monitoring p99 latency alert auto-closes within
-#    ~5 minutes of the new pod handling traffic at normal speed.
-gcloud alpha monitoring policies list \
-  --project=liverty-music-dev \
-  --filter='displayName="Zitadel OIDCService p99 latency"' \
-  --format='value(conditions[0].name,enabled)'
-# Visit Cloud Console → Monitoring → Alerting to confirm the
-# incident is resolved.
-```
-
-## Escalation
-
-Open an issue under `cloud-provisioning` (or comment on the existing
-`self-hosted-zitadel` §18.6 follow-up) with:
-
-1. Link to the alert in Cloud Monitoring.
-2. The `INCIDENT_DIR` artifacts (zip and attach, or upload to a GCS
-   bucket and link).
-3. The pod's prior uptime (from `pod-describe.txt`) and a one-line
-   summary of what state-changing API calls preceded the hang.
-
-Escalate to upstream Zitadel maintainers (`zitadel/zitadel` issue
-tracker) **only if**:
-
-- The same shape recurs within 24 hours of restart, **AND**
-- Forensic data captured does not match either §18.6 hypothesis A
-  or B (genuinely new failure mode).
-
-If the recurrence is consistent with hypothesis B and the
-connection-pool dashboard panel confirms saturation, file the issue
-with the connection-count time-series attached — that's the most
-upstream-actionable signal.
+---
 
 ## Related
 
-- `openspec/changes/archive/<date>-zitadel-observability/` — the
-  openspec change that introduced this runbook and the alerts that
-  surface the §18.6 shape.
-- `openspec/changes/self-hosted-zitadel/tasks.md` §18.6 — the
-  original incident write-up.
-- `k8s/namespaces/zitadel/overlays/dev/cronjob-restart-zitadel.yaml`
-  — the band-aid weekly restart CronJob (capped frequency to ≤ 7d).
-  Removing this band-aid is the goal of root-cause investigation.
+- `openspec/changes/archive/*-zitadel-watchdog-readonly-probe/` — the
+  OpenSpec change that introduced the read-only probe and this runbook.
+- `k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml`
+  — the watchdog CronJob manifest.
+- `src/zitadel/components/watchdog-probe.ts` — Pulumi provisioning of
+  the `watchdog-probe` machine user and PAT.
+- zitadel/zitadel#10103 — upstream tracking issue (unfixed as of v4.14.0).

--- a/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
@@ -8,28 +8,33 @@
 # manual `kubectl rollout restart`. On 2026-06-23 prod login was down ~13
 # min until a human restarted it.
 #
-# WHAT THIS DOES: every minute, probe a REAL auth-flow endpoint
-# (`/oauth/v2/authorize` with valid params → 302 healthy / hang wedged).
-# If it hangs N/N times WHILE `/debug/healthz` is still 200 (the precise
-# wedge signature), restart `zitadel-api`. With 2 prod replicas the
-# rolling restart is non-disruptive. Turns a multi-min manual outage into
-# ~2-min unattended recovery.
+# WHAT THIS DOES: every minute, probe `ProjectService/ListProjectRoles`
+# via Connect/gRPC HTTP+JSON POST against the static `liverty-music`
+# product project (id 373015520045170843 — always-present, Pulumi-managed).
+# That method internally calls `SearchProjectRoles(…, shouldTriggerBulk=true,
+# …)`, triggering `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the
+# exact projection that wedged on 2026-06-23 — as a pure read (no eventstore
+# write, no OIDC auth-request accumulation). Healthy → 200 fast; wedged →
+# hang (curl HTTP 000). If it hangs N/N times WHILE `/debug/healthz` is
+# still 200 (the precise wedge signature), restart `zitadel-api`. With 2
+# prod replicas the rolling restart is non-disruptive.
 #
-# WHY A CRONJOB, NOT A LIVENESS PROBE: an httpGet liveness on authorize
-# treats 400 as failure (an expired/misconfigured client id → restart
-# loop), can't distinguish a hang from a fast error, and writes a
-# side-effect every probe tick. `curl` in a CronJob matches the *hang*
-# specifically and probes only 1/min.
+# PROBE HOST: public `auth.liverty-music.app` (the Zitadel API domain),
+# consistent with the healthz precondition URL. This exercises the full
+# gateway path (Cloud LB → Envoy → Zitadel) for realistic hang detection.
+# The healthz precondition guards against gateway/DNS outages that would
+# also cause the probe to hang but are not the in-process wedge.
 #
-# SIDE EFFECT: each probe creates a short-lived throwaway auth request in
-# the eventstore (~1440/day). Accepted pre-launch; a read-only probe
-# target is a documented follow-up.
+# CREDENTIAL: a dedicated least-privilege machine-user PAT
+# (`watchdog-probe`, `PROJECT_OWNER_VIEWER` on the product project only).
+# Synced from GSM `zitadel-watchdog-probe-pat` via ExternalSecret into
+# K8s Secret `zitadel-watchdog-probe-pat` in this namespace. Fail-safe:
+# an invalid/expired PAT returns 401 fast, which the watchdog treats as
+# "healthy" (no restart), and logs "watchdog credential invalid" so the
+# loss of detection is discoverable.
 #
-# COUPLING: the probe hardcodes the prod consumer OIDC client id +
-# registered redirect uri. If the consumer app is reprovisioned and its
-# client id changes, update WATCHDOG_AUTHZ_URL below (the probe would
-# start returning 400 fast — visible as "healthy" — so it fails safe:
-# it stops detecting, it does not false-restart).
+# NOTE: unlike the prior authorize probe, this probe creates ZERO
+# OIDC auth requests. The ~1440/day eventstore accumulation is eliminated.
 #
 # Annotated `liverty-music.app/temporary` for cleanup once upstream
 # zitadel#10103 is fixed and pinned.
@@ -109,21 +114,27 @@ spec:
             # `alpine/k8s` bundles both; :1.32.x matches the cluster minor.
             image: alpine/k8s:1.32.3
             env:
-            # Active: on the wedge signature (N/N authorize hangs while
-            # healthz=200) the watchdog runs `rollout restart`. Verified in
-            # DRY-RUN first against live prod (healthy → no action). Set
-            # back to "true" to return to observe-only.
+            # DRY-RUN: first prod soak in observe-only mode. Set to "false"
+            # once healthy runs confirm the probe authenticates (200, not 401)
+            # and that zero auth-request writes accumulate.
             - name: WATCHDOG_DRY_RUN
-              value: "false"
+              value: "true"
             - name: HOME
               value: /tmp
             - name: WATCHDOG_HEALTHZ_URL
               value: "https://auth.liverty-music.app/debug/healthz"
-            # Valid prod consumer client id + registered redirect uri →
-            # 302 when healthy, hang when wedged. Invalid params would 400
-            # *before* the wedged code path, so valid params are required.
-            - name: WATCHDOG_AUTHZ_URL
-              value: "https://auth.liverty-music.app/oauth/v2/authorize?client_id=373015520582107291&response_type=code&scope=openid&redirect_uri=https://liverty-music.app/auth/callback&state=watchdog&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256"
+            # Connect/gRPC HTTP+JSON endpoint for the read-only probe.
+            # Served by Zitadel at the auth domain. See proposal.md D1.
+            - name: WATCHDOG_PROBE_URL
+              value: "https://auth.liverty-music.app/zitadel.project.v2.ProjectService/ListProjectRoles"
+            # Static ID of the `liverty-music` product project (Pulumi-managed,
+            # always-present). Pinned from `pulumi stack output` on the prod stack.
+            # Re-verify on Zitadel major upgrades or if the project is reprovisioned.
+            - name: WATCHDOG_PROJECT_ID
+              value: "373015520045170843"
+            # PAT file path — mounted from zitadel-watchdog-probe-pat Secret below.
+            - name: WATCHDOG_PAT_FILE
+              value: /var/run/watchdog/token
             command: ["/bin/sh", "-c"]
             args:
             - |
@@ -139,13 +150,33 @@ spec:
                 exit 0
               fi
 
-              # Probe the auth flow 3× ~5s apart. HTTP 000 = curl timeout
-              # = hang = wedge. 302 = healthy.
+              # Read PAT from mounted secret file.
+              if [ ! -f "$WATCHDOG_PAT_FILE" ]; then
+                echo "watchdog credential invalid: PAT file $WATCHDOG_PAT_FILE not found."
+                exit 0
+              fi
+              pat=$(cat "$WATCHDOG_PAT_FILE")
+
+              # Probe `ProjectService/ListProjectRoles` 3× ~5s apart.
+              # This method calls SearchProjectRoles(shouldTriggerBulk=true),
+              # triggering ProjectRoleProjection — the wedged projection.
+              # HTTP 000 = curl timeout = hang = wedge signal.
+              # 200 = healthy. 401/403 = credential invalid (fail-safe: no restart).
               hangs=0
               i=1
               while [ "$i" -le 3 ]; do
-                code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$WATCHDOG_AUTHZ_URL" 2>/dev/null || echo 000)
-                echo "probe $i/3: authorize http_code=$code"
+                code=$(curl -s -o /dev/null -w '%{http_code}' \
+                  --max-time 10 \
+                  -X POST "$WATCHDOG_PROBE_URL" \
+                  -H "Authorization: Bearer $pat" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"projectId\":\"$WATCHDOG_PROJECT_ID\"}" \
+                  2>/dev/null || echo 000)
+                echo "probe $i/3: ListProjectRoles http_code=$code"
+                if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+                  echo "watchdog credential invalid: probe returned $code — no action (detection degraded)."
+                  exit 0
+                fi
                 if [ "$code" = "000" ]; then
                   hangs=$((hangs + 1))
                 fi
@@ -160,7 +191,7 @@ spec:
                 exit 0
               fi
 
-              echo "WEDGE DETECTED: $hangs/3 authorize probes hung while healthz=200."
+              echo "WEDGE DETECTED: $hangs/3 ListProjectRoles probes hung while healthz=200."
               if [ "${WATCHDOG_DRY_RUN:-true}" = "true" ]; then
                 echo "WATCHDOG_DRY_RUN=true — would run: kubectl rollout restart deployment/zitadel-api (skipped)."
                 exit 0
@@ -184,8 +215,19 @@ spec:
             volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: watchdog-pat
+              mountPath: /var/run/watchdog
+              readOnly: true
           volumes:
           # Writable scratch for kubectl's discovery cache ($HOME=/tmp)
           # under readOnlyRootFilesystem.
           - name: tmp
             emptyDir: {}
+          # PAT for the watchdog probe bearer token.
+          # Synced from GSM `zitadel-watchdog-probe-pat` by ExternalSecret.
+          - name: watchdog-pat
+            secret:
+              secretName: zitadel-watchdog-probe-pat
+              items:
+              - key: token
+                path: token

--- a/k8s/namespaces/zitadel/overlays/prod/external-secret-watchdog-probe-pat.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/external-secret-watchdog-probe-pat.yaml
@@ -1,0 +1,33 @@
+# Syncs the watchdog-probe Personal Access Token from GSM
+# (`zitadel-watchdog-probe-pat`, provisioned by Pulumi WatchdogProbeComponent)
+# into a K8s Secret in the `zitadel` namespace. The self-healing watchdog
+# CronJob mounts this Secret to authenticate its read-only
+# `ProjectService/ListProjectRoles` probe as `Authorization: Bearer <token>`.
+#
+# ESO SecretStore: `google-secret-manager` (ClusterSecretStore, wired to the
+# ESO GCP SA via Workload Identity — same pattern as `zitadel-web-pat`).
+#
+# Naming convention: K8s ExternalSecret + target Secret share the name
+# `zitadel-watchdog-probe-pat`. The GSM source key is the same name
+# (Pulumi KubernetesComponent esoOnlySecrets uses the `name` field as the
+# GSM secretId). The in-Secret data key is `token` (matches `zitadel-web-pat`
+# convention for PAT secrets).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: zitadel-watchdog-probe-pat
+  annotations:
+    liverty-music.app/temporary: "until-upstream-zitadel-10103-fix"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: google-secret-manager
+    kind: ClusterSecretStore
+  target:
+    name: zitadel-watchdog-probe-pat
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+  - secretKey: token
+    remoteRef:
+      key: zitadel-watchdog-probe-pat

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -22,10 +22,14 @@ resources:
 # prod Cloud SQL `zitadel` DB.
 - job-grant-db.yaml
 # Self-healing watchdog (prod-only): detects the projection-trigger wedge
-# (zitadel#10103) via an auth-flow hang probe and auto-restarts
-# `zitadel-api` (active; flip WATCHDOG_DRY_RUN=true for observe-only).
-# See the manifest header for the full rationale.
+# (zitadel#10103) via a read-only ListProjectRoles hang probe and
+# auto-restarts `zitadel-api` (ships in dry-run; flip WATCHDOG_DRY_RUN=false
+# after confirming probe authenticates 200). See the manifest header.
 - cronjob-watchdog-zitadel.yaml
+# PAT for the watchdog probe — synced from GSM `zitadel-watchdog-probe-pat`
+# (provisioned by Pulumi WatchdogProbeComponent) into K8s Secret
+# `zitadel-watchdog-probe-pat`, mounted into the watchdog CronJob.
+- external-secret-watchdog-probe-pat.yaml
 # NOTE: PodMonitoring CRD (previously `podmonitoring.yaml`) was deleted as
 # part of the Helm chart migration. Zitadel v4 has no `/debug/metrics`
 # HTTP scrape endpoint — the path returns 404 on v4.14.0. Observability

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -55,6 +55,10 @@ export interface GcpArgs {
 	 *  Stored in Secret Manager and mounted into the zitadel-login pod via
 	 *  ExternalSecret as a file referenced by `ZITADEL_SERVICE_USER_TOKEN_FILE`. */
 	zitadelLoginPat?: pulumi.Output<string>
+	/** Personal Access Token for the watchdog CronJob bearer token.
+	 *  Stored in Secret Manager and synced into the `zitadel` namespace via
+	 *  ExternalSecret (`zitadel-watchdog-probe-pat`), mounted into the CronJob. */
+	zitadelWatchdogProbePat?: pulumi.Output<string>
 	/** Gate for the workload tier (GKE / Cloud SQL / monitoring / GSM
 	 *  Zitadel bootstrap secrets). When false (dev shutdown mode), these
 	 *  resources are not provisioned. See
@@ -131,6 +135,7 @@ export class Gcp {
 			postmarkConfig,
 			zitadelMachineKey,
 			zitadelLoginPat,
+			zitadelWatchdogProbePat,
 			workloadEnabled,
 			postgresAvailabilityType,
 		} = args
@@ -443,6 +448,19 @@ export class Gcp {
 								{
 									name: 'zitadel-login-pat',
 									value: pulumi.secret(zitadelLoginPat),
+								},
+							]
+						: []),
+					// PAT for the self-healing watchdog CronJob. ESO syncs this into the
+					// `zitadel` namespace so the CronJob can mount it as a bearer token
+					// for the read-only `ProjectService/ListProjectRoles` probe.
+					...(zitadelWatchdogProbePat
+						? [
+								{
+									name: 'zitadel-watchdog-probe-pat',
+									value: pulumi.secret(
+										zitadelWatchdogProbePat,
+									),
 								},
 							]
 						: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ const zitadel = workloadEnabled
 	: undefined
 const zitadelMachineKey = zitadel?.machineKeyDetails
 const zitadelLoginPat = zitadel?.loginClientToken
+const zitadelWatchdogProbePat = zitadel?.watchdogProbeToken
 
 // 2. GCP Infrastructure (All Environments)
 const gcp = new Gcp({
@@ -180,6 +181,7 @@ const gcp = new Gcp({
 	postmarkConfig,
 	zitadelMachineKey,
 	zitadelLoginPat,
+	zitadelWatchdogProbePat,
 	workloadEnabled,
 	postgresAvailabilityType,
 })

--- a/src/zitadel/components/watchdog-probe.ts
+++ b/src/zitadel/components/watchdog-probe.ts
@@ -1,0 +1,114 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface WatchdogProbeComponentArgs {
+	/**
+	 * Product org ID. The machine user is placed here — co-located with the
+	 * project it probes — so the `ProjectMember` grant is a native same-org
+	 * membership (Zitadel `ProjectMember` requires the user and project to share
+	 * a resource-owner org; a cross-org grant would need a `ProjectGrant` first).
+	 */
+	productOrgId: pulumi.Input<string>
+	/** ID of the liverty-music product project to probe. */
+	productProjectId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * WatchdogProbeComponent provisions a dedicated least-privilege Zitadel Machine
+ * User and Personal Access Token for the self-healing watchdog CronJob.
+ *
+ * The machine user calls `ProjectService/ListProjectRoles` (Connect/gRPC, HTTP+JSON)
+ * on the prod `liverty-music` project. That method internally calls
+ * `SearchProjectRoles(…, shouldTriggerBulk=true, …)`, triggering
+ * `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the exact projection
+ * that wedged on 2026-06-23. A hang on this call (curl HTTP 000) is the wedge
+ * signal; a fast 200 means healthy. The probe is a pure read: no eventstore
+ * write, no OIDC auth-request accumulation.
+ *
+ * Minimum privilege: `PROJECT_OWNER_VIEWER` on the product project only.
+ * If `ListProjectRoles` returns `401`/`403`, the watchdog logs "watchdog
+ * credential invalid" and treats the run as healthy (fail-safe, no false restart).
+ *
+ * The PAT is long-lived (expires 2099) and delivered to the CronJob via GSM →
+ * ExternalSecret → K8s Secret mount.
+ */
+export class WatchdogProbeComponent extends pulumi.ComponentResource {
+	public readonly machineUser: zitadel.MachineUser
+
+	/** Minimum-privilege membership: PROJECT_OWNER_VIEWER on the product project. */
+	public readonly projectMember: zitadel.ProjectMember
+
+	/** Long-lived PAT for the watchdog CronJob bearer token. */
+	public readonly pat: zitadel.PersonalAccessToken
+
+	/** PAT value — callers MUST wrap in `pulumi.secret()` before storing. */
+	public readonly token: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: WatchdogProbeComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:WatchdogProbe', name, {}, opts)
+
+		const { productOrgId, productProjectId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		this.machineUser = new zitadel.MachineUser(
+			'watchdog-probe',
+			{
+				orgId: productOrgId,
+				userName: 'watchdog-probe',
+				name: 'Watchdog Probe',
+				description:
+					'Least-privilege probe identity for the self-healing watchdog CronJob. ' +
+					'Calls ProjectService/ListProjectRoles (read-only) to detect the ' +
+					'Zitadel projection-trigger wedge (zitadel#10103) without writing ' +
+					'to the eventstore. Stopgap until upstream fixes the wedge.',
+				accessTokenType: 'ACCESS_TOKEN_TYPE_BEARER',
+			},
+			resourceOptions,
+		)
+
+		// Minimal role: PROJECT_OWNER_VIEWER grants read-only access to the
+		// project and its role list. This is the minimum role that allows
+		// ListProjectRoles to return 200 rather than 403. Same-org membership
+		// (user + project both in the product org).
+		this.projectMember = new zitadel.ProjectMember(
+			'watchdog-probe-project-member',
+			{
+				orgId: productOrgId,
+				projectId: productProjectId,
+				userId: this.machineUser.id,
+				roles: ['PROJECT_OWNER_VIEWER'],
+			},
+			{ ...resourceOptions, dependsOn: [this.machineUser] },
+		)
+
+		// PAT with far-future expiry. Long-lived by design (same rationale as
+		// MachineUserComponent.machineKey) — there is no automated rotation path;
+		// expiry is tracked via the runbook. The fail-safe is preserved: an
+		// expired PAT produces a fast 401 which the watchdog reads as "healthy"
+		// (no false restart), so it degrades gracefully to "no detection" rather
+		// than "restart loop".
+		this.pat = new zitadel.PersonalAccessToken(
+			'watchdog-probe-pat',
+			{
+				orgId: productOrgId,
+				userId: this.machineUser.id,
+				expirationDate: '2099-01-01T00:00:00Z',
+			},
+			{ ...resourceOptions, dependsOn: [this.projectMember] },
+		)
+
+		this.token = this.pat.token
+
+		this.registerOutputs({
+			machineUser: this.machineUser,
+			projectMember: this.projectMember,
+			pat: this.pat,
+			token: this.token,
+		})
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -17,6 +17,7 @@ import { HumanAdminComponent } from './components/human-admin.js'
 import { LoginClientComponent } from './components/login-client.js'
 import { MachineUserComponent } from './components/machine-user.js'
 import { SmtpComponent } from './components/smtp.js'
+import { WatchdogProbeComponent } from './components/watchdog-probe.js'
 import {
 	adminOrgIdMap,
 	BACKEND_WEBHOOK_BASE_URL,
@@ -72,6 +73,7 @@ export * from './components/login-client.js'
 export * from './components/machine-user.js'
 export * from './components/secrets.js'
 export * from './components/smtp.js'
+export * from './components/watchdog-probe.js'
 export * from './constants.js'
 export * from './dynamic/index.js'
 
@@ -188,6 +190,9 @@ export class Zitadel {
 	/** E2E test user — dev-only. `undefined` in prod (and any future env). */
 	public readonly e2eTestUser: E2eTestUserComponent | undefined
 
+	/** Watchdog probe machine user + PAT for the self-healing CronJob. */
+	public readonly watchdogProbe: WatchdogProbeComponent
+
 	/** JWT profile JSON for the backend-app machine user. Store in Secret Manager. */
 	public readonly machineKeyDetails: pulumi.Output<string>
 
@@ -195,6 +200,10 @@ export class Zitadel {
 	 *  Store in Secret Manager and mount via ExternalSecret as a file
 	 *  (consumed by `ZITADEL_SERVICE_USER_TOKEN_FILE`). */
 	public readonly loginClientToken: pulumi.Output<string>
+
+	/** Personal Access Token for the watchdog CronJob bearer token.
+	 *  Store in Secret Manager and sync to the `zitadel` namespace via ExternalSecret. */
+	public readonly watchdogProbeToken: pulumi.Output<string>
 
 	constructor(name: string, args: ZitadelArgs) {
 		const {
@@ -404,6 +413,20 @@ export class Zitadel {
 		})
 
 		this.loginClientToken = this.loginClient.token
+
+		// Watchdog probe identity — least-privilege machine user in the product
+		// org (co-located with the project it probes), granted PROJECT_OWNER_VIEWER
+		// on the product project. The PAT is stored in GSM via
+		// `zitadelWatchdogProbePat` (threaded through GcpArgs → KubernetesComponent
+		// esoOnlySecrets) and synced to the `zitadel` namespace by an ExternalSecret.
+		// See OpenSpec change `zitadel-watchdog-readonly-probe`.
+		this.watchdogProbe = new WatchdogProbeComponent(name, {
+			productOrgId: this.productOrg.id,
+			productProjectId: this.project.id,
+			provider: this.provider,
+		})
+
+		this.watchdogProbeToken = this.watchdogProbe.token
 
 		// Instance-level Google IdP for human admin sign-in. The admin org's
 		// LoginPolicy below references this IdP id; the product org's policy


### PR DESCRIPTION
## Summary

Makes the self-healing Zitadel wedge watchdog **read-only**, eliminating its eventstore write side-effect and the hardcoded consumer-client coupling, while preserving (and slightly improving) wedge-detection fidelity.

The watchdog (shipped in `zitadel-wedge-self-healing`) detected the projection-trigger wedge (zitadel/zitadel#10103) by probing `/oauth/v2/authorize`. That probe is a **write**: each healthy tick mints a throwaway OIDC auth request, and Zitadel never auto-cleans them, so ~1440/day accumulated in the eventstore on the small prod `db-f1-micro` — unbounded growth plus steady load on the very projection path that wedges. It also hardcoded the prod consumer `client_id` + `redirect_uri`.

This change swaps the probe to the read-only Connect/gRPC `ProjectService/ListProjectRoles` call, which triggers `ProjectRoleProjection.Trigger(WithAwaitRunning())` — the exact projection observed wedging on 2026-06-23 — as a pure read (no eventstore write).

## Changes

**Pulumi (`src/zitadel/`)**
- New `WatchdogProbeComponent`: a dedicated least-privilege machine user `watchdog-probe` (in the product org, co-located with the project it probes) granted only `PROJECT_OWNER_VIEWER` on the `liverty-music` project, plus a long-lived (`2099`) `PersonalAccessToken`.
- The PAT is threaded through `GcpArgs` → `KubernetesComponent.esoOnlySecrets` into GSM secret `zitadel-watchdog-probe-pat`.

**Kubernetes (`k8s/namespaces/zitadel/overlays/prod/`)**
- New `ExternalSecret` `zitadel-watchdog-probe-pat` syncing the GSM PAT into the `zitadel` namespace.
- Rewrote the watchdog CronJob probe: `POST auth.liverty-music.app/zitadel.project.v2.ProjectService/ListProjectRoles` with `Authorization: Bearer <PAT>` and body `{"projectId":"373015520045170843"}`. HTTP 000 (hang) = wedge signal; `401`/`403` logs "watchdog credential invalid" and is treated as healthy (fail-safe). Dropped the old `WATCHDOG_AUTHZ_URL` + consumer client id / redirect uri.
- All conservative guards unchanged: 3/3 in-run hangs, `/debug/healthz`==200 precondition, `concurrencyPolicy: Forbid`, dedicated restart RBAC, `until-upstream-zitadel-10103-fix` annotation.
- **Ships in dry-run** (`WATCHDOG_DRY_RUN=true`) first.

**Docs**
- Refreshed `docs/runbooks/zitadel-hang.md`: self-healing-first flow, the read-only `ListProjectRoles` probe, "verify recovery via an auth-flow probe, NOT `/debug/healthz`", PAT credential-health steps, and the wedge signature table.

## Behavior

- **Zero** eventstore writes from probing (was ~1440/day).
- Detection now exercises `ProjectRoleProjection` (the observed wedge).
- No change to login behavior or the 2-replica posture.
- **New dependency**: a long-lived watchdog PAT (least-privilege, fail-safe — an expired PAT degrades to "no detection", never a false-restart loop). Expiry tracked via the runbook.

## Testing

- `make lint-ts` — biome + tsc clean
- `make lint-k8s` — kustomize render + kube-linter + spot-nodeSelector check clean

## Rollout

Ships in dry-run. After ArgoCD sync: confirm the probe authenticates (200, not 401) and that zero auth-requests accumulate, then flip `WATCHDOG_DRY_RUN=false`. `pulumi up` on the prod stack provisions the machine user + PAT (must run before/with the K8s sync so the GSM secret exists for ESO).

## OpenSpec

Implements `zitadel-watchdog-readonly-probe` (proposal/design/specs merged in liverty-music/specification#643). The change will be archived after prod verification.

close: #368
