### PR TITLE
feat(zitadel): activate wedge watchdog (flip dry-run off)

### DIFF
--- a/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/cronjob-watchdog-zitadel.yaml
@@ -114,11 +114,13 @@ spec:
             # `alpine/k8s` bundles both; :1.32.x matches the cluster minor.
             image: alpine/k8s:1.32.3
             env:
-            # DRY-RUN: first prod soak in observe-only mode. Set to "false"
-            # once healthy runs confirm the probe authenticates (200, not 401)
-            # and that zero auth-request writes accumulate.
+            # ACTIVE: on the wedge signature (N/N ListProjectRoles hangs while
+            # healthz=200) the watchdog runs `rollout restart`. Verified in
+            # DRY-RUN first against live prod: probe authenticates (200, not
+            # 401) and zero auth-request writes accumulate. Set back to "true"
+            # to return to observe-only.
             - name: WATCHDOG_DRY_RUN
-              value: "true"
+              value: "false"
             - name: HOME
               value: /tmp
             - name: WATCHDOG_HEALTHZ_URL

--- a/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/zitadel/overlays/prod/kustomization.yaml
@@ -23,8 +23,8 @@ resources:
 - job-grant-db.yaml
 # Self-healing watchdog (prod-only): detects the projection-trigger wedge
 # (zitadel#10103) via a read-only ListProjectRoles hang probe and
-# auto-restarts `zitadel-api` (ships in dry-run; flip WATCHDOG_DRY_RUN=false
-# after confirming probe authenticates 200). See the manifest header.
+# auto-restarts `zitadel-api` (active; flip WATCHDOG_DRY_RUN=true for
+# observe-only). See the manifest header.
 - cronjob-watchdog-zitadel.yaml
 # PAT for the watchdog probe — synced from GSM `zitadel-watchdog-probe-pat`
 # (provisioned by Pulumi WatchdogProbeComponent) into K8s Secret


### PR DESCRIPTION
## Summary

Activates the read-only Zitadel wedge watchdog by flipping `WATCHDOG_DRY_RUN` from `true` to `false`. The watchdog will now run `kubectl rollout restart deployment/zitadel-api` when it detects the projection-trigger wedge (zitadel/zitadel#10103).

Follow-up to #369, which shipped the read-only `ListProjectRoles` probe in dry-run.

## Dry-run soak results (prod-verified)

The probe soaked in dry-run on prod and verified clean before this activation:

- **Auth success**: 3/3 `ListProjectRoles` probes return `http_code=200` (not `401`) → the probe reaches the projection-trigger path.
- **Healthy → no action**: `healthy: 0/3 probes hung — no action.`
- **Zero write side-effect**: `auth_request` eventstore writes dropped from **3/min** (old authorize probe) to **0** after cutover — confirmed via a direct eventstore query (`eventstore.events2` per-minute breakdown showed the cutover).

## Changes

- `cronjob-watchdog-zitadel.yaml`: `WATCHDOG_DRY_RUN` `"true"` → `"false"`; comment updated to the active rationale.
- `kustomization.yaml`: comment updated from "ships in dry-run" to "active".

No Pulumi/infra change — pure K8s prod-overlay edit, applied by ArgoCD on merge.

## Behavior after merge

On the wedge signature (N/N `ListProjectRoles` hangs while `/debug/healthz` returns 200), the watchdog restarts `zitadel-api`. With 2 prod replicas the rolling restart is non-disruptive. Flip `WATCHDOG_DRY_RUN` back to `true` to return to observe-only.

## Testing

- `make lint-k8s` — kustomize render + kube-linter + spot-nodeSelector check clean

close: #368
