### PR TITLE
feat(prod): pin sales cronjobs to v1.14.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.14.0 # commit c5091c0ee2b9723fa125fb94dd624f55df61a4f1
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.12.0 # commit dd888e8ff0acc379e30efb80fdf3b0fcb060e26d
+    newTag: v1.14.0 # commit c5091c0ee2b9723fa125fb94dd624f55df61a4f1
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.12.0 # commit dd888e8ff0acc379e30efb80fdf3b0fcb060e26d
+    newTag: v1.14.0 # commit c5091c0ee2b9723fa125fb94dd624f55df61a4f1


### PR DESCRIPTION
## 📝 Summary of Changes

Brings the two cronjobs the automated `bump-prod-pin` workflow consistently skips — `sales-phase-discovery` and `sales-reminders` — onto the current backend release.

- They lagged at **v1.12.0** while the auto-bump moved `server`, `consumer`, `concert-discovery`, `artist-image-sync`, and `merch-discovery` to **v1.14.0** (and the `app.kubernetes.io/version` label is already `1.14.0`).
- Pin both to **v1.14.0** (commit `c5091c0`); v1.14.0 images for both were built by the backend release.
- Functionally unrelated to the analytics change in v1.14.0 — this is overlay hygiene so the whole backend prod overlay sits on one release and stops accumulating drift.

`kubectl kustomize k8s/namespaces/backend/overlays/prod` renders all backend prod images at v1.14.0.

Refs liverty-music/specification#532.
