### PR TITLE
chore(prod): pin sales cronjobs to backend v1.15.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.15.0 # commit e2e46fe8757518e111a53e6026b819b7e87da164
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.14.0 # commit c5091c0ee2b9723fa125fb94dd624f55df61a4f1
+    newTag: v1.15.0 # commit e2e46fe8757518e111a53e6026b819b7e87da164
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.14.0 # commit c5091c0ee2b9723fa125fb94dd624f55df61a4f1
+    newTag: v1.15.0 # commit e2e46fe8757518e111a53e6026b819b7e87da164


### PR DESCRIPTION
## Summary

Pins the **sales-phase-discovery** and **sales-reminders** cronjobs to backend **v1.15.0** in the prod overlay.

The automated `bump-prod-pin` workflow (fired by the backend v1.15.0 release) updated server/consumer/concert-discovery/artist-image-sync/merch-discovery but — as it always does — omitted these two cronjobs, leaving them on v1.14.0.

Both cronjobs now dispatch through the notification service (`NotificationUseCase`) introduced in backend v1.15.0. Without this bump they would run the previous code against the new `notifications` schema and would not record sales-reminder / sales-phase-announcement notifications.

## Validation

- `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders cleanly; both cronjobs resolve to `…/sales-phase-discovery:v1.15.0` and `…/sales-reminders:v1.15.0`.
- The v1.15.0 images already exist in the prod AR (built + retagged by the backend release Deploy workflow).

Refs: liverty-music/specification#671
