### PR TITLE
chore(prod): pin sales cronjobs to backend v1.16.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.16.0 # commit 64e6762458f864ae8953e82e4a5cdaf3650b5061
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.15.0 # commit e2e46fe8757518e111a53e6026b819b7e87da164
+    newTag: v1.16.0 # commit 64e6762458f864ae8953e82e4a5cdaf3650b5061
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.15.0 # commit e2e46fe8757518e111a53e6026b819b7e87da164
+    newTag: v1.16.0 # commit 64e6762458f864ae8953e82e4a5cdaf3650b5061


### PR DESCRIPTION
## Summary

Pins the **sales-phase-discovery** and **sales-reminders** cronjobs to backend **v1.16.0** in the prod overlay.

The automated `bump-prod-pin` workflow (fired by the backend v1.16.0 release) updated server/consumer but — as always — omitted these two cronjobs, leaving them on v1.15.0. Both dispatch through the notification service (`NotificationUseCase`), and v1.16.0 also carries the #356 JetStream-streams fix, so they should match the rest of the backend.

## Validation

- `kubectl kustomize k8s/namespaces/backend/overlays/prod` renders cleanly; both cronjobs resolve to `:v1.16.0`.
- v1.16.0 images exist in prod AR (built by the release Deploy workflow).

Refs: liverty-music/specification#671
