### PR TITLE
fix(infra): reconcile KEDA consumer triggers with current subscriptions

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -61,3 +61,105 @@ spec:
       consumer: "SALES_PHASE_reminder_due"
       lagThreshold: "1"
       activationLagThreshold: "0"
+  # Analytics-forwarding consumers (analytics_consumer.go): each fans one
+  # domain event out to PostHog. Durable name = subject with dots replaced by
+  # underscores; stream = the subject's leading segment (see streams.go).
+  # USER.preferred_language_updated → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "USER"
+      consumer: "USER_preferred_language_updated"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # ARTIST.followed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ARTIST"
+      consumer: "ARTIST_followed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # ARTIST.unfollowed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ARTIST"
+      consumer: "ARTIST_unfollowed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # NOTIFICATION.subscribed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "NOTIFICATION"
+      consumer: "NOTIFICATION_subscribed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # NOTIFICATION.unsubscribed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "NOTIFICATION"
+      consumer: "NOTIFICATION_unsubscribed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # ENTRY.zk_proof_verified → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ENTRY"
+      consumer: "ENTRY_zk_proof_verified"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # ENTRY.zk_proof_rejected → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ENTRY"
+      consumer: "ENTRY_zk_proof_rejected"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # TICKET_JOURNEY.status_changed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "TICKET_JOURNEY"
+      consumer: "TICKET_JOURNEY_status_changed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # TICKET.mint_completed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "TICKET"
+      consumer: "TICKET_mint_completed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # TICKET_EMAIL.parsed → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "TICKET_EMAIL"
+      consumer: "TICKET_EMAIL_parsed"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
+  # SALES_REMINDER.delivered → forward to analytics.
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "SALES_REMINDER"
+      consumer: "SALES_REMINDER_delivered"
+      lagThreshold: "1"
+      activationLagThreshold: "0"


### PR DESCRIPTION
## Summary

`consumer-app` subscribes to **17 distinct NATS subjects** (one durable consumer per subject, via the subscriber's `DurableCalculator`), but the KEDA `ScaledObject` only watched **6**. The remaining **11** — the analytics-forwarding, notification, ticket, and sales-reminder-delivered subjects — had no trigger.

This reconciles the trigger list against the **current** `internal/di/consumer.go` subscription set. Supersedes the stale #336 (opened against a 4-trigger baseline that PR #176 has since superseded; #336 also predated the `TICKET_*` / `SALES_REMINDER` streams and mis-assumed obsolete names).

## Triggers added (11)

| Stream | Consumer (durable) | Producer |
| --- | --- | --- |
| `USER` | `USER_preferred_language_updated` | analytics forward |
| `ARTIST` | `ARTIST_followed` | analytics forward |
| `ARTIST` | `ARTIST_unfollowed` | analytics forward |
| `NOTIFICATION` | `NOTIFICATION_subscribed` | analytics forward |
| `NOTIFICATION` | `NOTIFICATION_unsubscribed` | analytics forward |
| `ENTRY` | `ENTRY_zk_proof_verified` | analytics forward |
| `ENTRY` | `ENTRY_zk_proof_rejected` | analytics forward |
| `TICKET_JOURNEY` | `TICKET_JOURNEY_status_changed` | analytics forward |
| `TICKET` | `TICKET_mint_completed` | analytics forward |
| `TICKET_EMAIL` | `TICKET_EMAIL_parsed` | analytics forward |
| `SALES_REMINDER` | `SALES_REMINDER_delivered` | analytics forward |

## How the names were derived (not guessed)

- **`consumer` (durable)** = the NATS subject with dots replaced by underscores — exactly what the subscriber's `DurableCalculator` (`internal/infrastructure/messaging/subscriber.go`) produces (`strings.ReplaceAll(topic, ".", "_")`, handler name ignored).
- **`stream`** = the subject's configured JetStream stream in `internal/infrastructure/messaging/streams.go`. Note `TICKET_JOURNEY.status_changed`, `TICKET_EMAIL.parsed`, and `SALES_REMINDER.delivered` live on their **own** streams (`TICKET_JOURNEY` / `TICKET_EMAIL` / `SALES_REMINDER`), not `TICKET` / `SALES_PHASE`.

Cross-checked every subject against the live `AddNoPublisherHandler` registrations in `internal/di/consumer.go`; `ENTRY.zk_proof_*` are still actively subscribed (the ZK *prover* removal was frontend-only), so those triggers are required.

## Impact / scope

- **Prod**: the prod overlay pins `minReplicaCount: maxReplicaCount: 1`, so a single replica always holds every durable open and consumes all subjects regardless of triggers — these triggers are effectively **inert in prod** (no behavior change, no risk).
- **dev/staging**: base defaults to `minReplicaCount: 0` / `maxReplicaCount: 3`; there the previously-untriggered subjects could pile up while the consumer idled at zero. This restores correct scale-from-zero / scale-up coverage.
- Keeps the manifest a faithful inventory of all subscribed subjects.

## Verification

`kubectl kustomize` dry-run renders cleanly for **both** overlays:
- dev → `minReplicaCount: 0`, 17 triggers
- prod → `minReplicaCount: maxReplicaCount: 1`, 17 triggers

## Related

- Closes the gap originally raised in #336 (now closed as stale/superseded)
- Refs: liverty-music/specification#532
