### PR TITLE
chore(prod): pin sales cronjobs to backend v1.17.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.17.0 # commit 4b12ac9b5a184be47ebf3ebd2cd47080820459ba
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.16.0 # commit 64e6762458f864ae8953e82e4a5cdaf3650b5061
+    newTag: v1.17.0 # commit 4b12ac9b5a184be47ebf3ebd2cd47080820459ba
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.16.0 # commit 64e6762458f864ae8953e82e4a5cdaf3650b5061
+    newTag: v1.17.0 # commit 4b12ac9b5a184be47ebf3ebd2cd47080820459ba


### PR DESCRIPTION
The automated `bump-prod-pin` workflow updated server/consumer and the concert/artist/merch cronjobs to v1.17.0 but omits `sales-phase-discovery` and `sales-reminders` (known gap). These CronJobs run `NotificationUseCase`, which now emits `notification.delivered` (backend v1.17.0, PR liverty-music/backend#358), so pin them to v1.17.0 as well — otherwise sales-phase-originated notifications would keep running old code and not report delivery to PostHog.

No schema change, so no crash risk on the old pin; this is coverage completeness.

Refs #675