### PR TITLE
revert(zitadel): remove CreateSession Actions v2 webhook (breaks prod sign-in)

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -42,16 +42,6 @@ spec:
       consumer: "USER_created"
       lagThreshold: "1"
       activationLagThreshold: "0"
-  # ACCOUNT.login → analytics consumer (account.login). Durable name is the
-  # subject with dots replaced by underscores (subscriber DurableCalculator).
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "ACCOUNT"
-      consumer: "ACCOUNT_login"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
   # SALES_PHASE.discovered → announcement consumer. Durable name is the subject
   # with dots replaced by underscores (subscriber DurableCalculator).
   - type: nats-jetstream

--- a/src/zitadel/components/actions-v2.ts
+++ b/src/zitadel/components/actions-v2.ts
@@ -1,10 +1,6 @@
 import * as pulumi from '@pulumi/pulumi'
 import type * as zitadel from '@pulumiverse/zitadel'
-import {
-	ZitadelExecutionFunction,
-	ZitadelExecutionResponse,
-	ZitadelTarget,
-} from '../dynamic/index.js'
+import { ZitadelExecutionFunction, ZitadelTarget } from '../dynamic/index.js'
 
 export interface ActionsV2ComponentArgs {
 	/** Zitadel domain hosting the Management API (e.g. `auth.dev.liverty-music.app`). */
@@ -13,9 +9,6 @@ export interface ActionsV2ComponentArgs {
 	jwtProfileJson: pulumi.Input<string>
 	/** In-cluster URL of the backend `/pre-access-token` webhook handler. */
 	preAccessTokenEndpoint: pulumi.Input<string>
-	/** In-cluster URL of the backend `/create-session` webhook handler (the
-	 *  account.login analytics source). */
-	createSessionEndpoint: pulumi.Input<string>
 	/** Pulumi Zitadel v1 provider — required as a `dependsOn` marker so executions
 	 *  are created after the Management API is reachable via the provider. */
 	provider: zitadel.Provider
@@ -71,8 +64,6 @@ export interface ActionsV2ComponentArgs {
 export class ActionsV2Component extends pulumi.ComponentResource {
 	public readonly preAccessTokenTarget: ZitadelTarget
 	public readonly preAccessTokenExecution: ZitadelExecutionFunction
-	public readonly createSessionTarget: ZitadelTarget
-	public readonly createSessionExecution: ZitadelExecutionResponse
 
 	constructor(
 		name: string,
@@ -81,13 +72,8 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:ActionsV2', name, {}, opts)
 
-		const {
-			domain,
-			jwtProfileJson,
-			preAccessTokenEndpoint,
-			createSessionEndpoint,
-			provider,
-		} = args
+		const { domain, jwtProfileJson, preAccessTokenEndpoint, provider } =
+			args
 
 		// Email-claim injection Target + ExecutionFunction.
 		// REST_CALL waits for the response so the token can be complemented
@@ -124,46 +110,8 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 			},
 		)
 
-		// account.login analytics Target + response Execution on CreateSession.
-		// A session is created once per user-initiated login and never by a
-		// silent refresh_token grant, so this hook is login-specific by
-		// construction. PAYLOAD_TYPE_JWT reuses the backend's JWKS validator.
-		// interruptOnError is FALSE: analytics must never block login — if the
-		// webhook fails, Zitadel proceeds with session creation regardless. The
-		// response side fires after CreateSession succeeds, so only successful
-		// logins are recorded.
-		this.createSessionTarget = new ZitadelTarget(
-			'create-session-webhook',
-			{
-				domain,
-				jwtProfileJson,
-				name: 'create-session-webhook',
-				endpoint: createSessionEndpoint,
-				targetType: 'REST_CALL',
-				timeout: '10s',
-				payloadType: 'PAYLOAD_TYPE_JWT',
-				interruptOnError: false,
-			},
-			{ parent: this, dependsOn: [provider] },
-		)
-
-		this.createSessionExecution = new ZitadelExecutionResponse(
-			'create-session-execution',
-			{
-				domain,
-				jwtProfileJson,
-				method: '/zitadel.session.v2.SessionService/CreateSession',
-				targetIds: [this.createSessionTarget.targetId],
-			},
-			{
-				parent: this,
-				dependsOn: [this.createSessionTarget],
-			},
-		)
-
 		this.registerOutputs({
 			preAccessTokenTargetId: this.preAccessTokenTarget.targetId,
-			createSessionTargetId: this.createSessionTarget.targetId,
 		})
 	}
 }

--- a/src/zitadel/constants.ts
+++ b/src/zitadel/constants.ts
@@ -47,7 +47,6 @@ export const zitadelDomainMap: Record<Environment, string> = {
 export const BACKEND_WEBHOOK_BASE_URL =
 	'http://server-webhook-svc.backend.svc.cluster.local:9090'
 export const PRE_ACCESS_TOKEN_PATH = '/pre-access-token'
-export const CREATE_SESSION_PATH = '/create-session'
 
 /**
  * Bootstrap-created `admin` Role Org IDs per environment.

--- a/src/zitadel/dynamic/__tests__/execution.test.ts
+++ b/src/zitadel/dynamic/__tests__/execution.test.ts
@@ -5,11 +5,9 @@ vi.mock('../api-client.js', () => ({
 }))
 
 const apiClient = await import('../api-client.js')
-const {
-	executionFunctionProvider,
-	executionRequestProvider,
-	executionResponseProvider,
-} = await import('../execution.js')
+const { executionFunctionProvider, executionRequestProvider } = await import(
+	'../execution.js'
+)
 
 const mockedCall = vi.mocked(apiClient.zitadelApiCall)
 
@@ -20,9 +18,6 @@ const fnProvider = executionFunctionProvider as Required<
 >
 const reqProvider = executionRequestProvider as Required<
 	typeof executionRequestProvider
->
-const resProvider = executionResponseProvider as Required<
-	typeof executionResponseProvider
 >
 
 const baseProfile = {
@@ -43,13 +38,6 @@ const baseRequestInputs = {
 	domain: 'auth.example.test',
 	jwtProfileJson: JSON.stringify(baseProfile),
 	method: '/zitadel.user.v2.UserService/AddHumanUser',
-	targetIds: ['tgt-1'],
-}
-
-const baseResponseInputs = {
-	domain: 'auth.example.test',
-	jwtProfileJson: JSON.stringify(baseProfile),
-	method: '/zitadel.session.v2.SessionService/CreateSession',
 	targetIds: ['tgt-1'],
 }
 
@@ -207,61 +195,6 @@ describe('executionRequestProvider.delete', () => {
 			condition: {
 				request: {
 					method: '/zitadel.user.v2.UserService/AddHumanUser',
-				},
-			},
-			targets: [],
-		})
-	})
-})
-
-describe('executionResponseProvider.create', () => {
-	beforeEach(() => {
-		mockedCall.mockReset()
-	})
-
-	it('PUTs /v2/actions/executions with `targets: string[]` and a `response.method` condition', async () => {
-		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
-
-		const result = await resProvider.create(baseResponseInputs)
-
-		const args = lastCallArgs()
-		expect(args.method).toBe('PUT')
-		expect(args.path).toBe('/v2/actions/executions')
-		expect(args.body).toEqual({
-			condition: {
-				response: {
-					method: '/zitadel.session.v2.SessionService/CreateSession',
-				},
-			},
-			targets: ['tgt-1'],
-		})
-		const body = args.body as { targets: unknown[] }
-		expect(typeof body.targets[0]).toBe('string')
-		expect(result.id).toBe(
-			'response:/zitadel.session.v2.SessionService/CreateSession',
-		)
-	})
-})
-
-describe('executionResponseProvider.delete', () => {
-	beforeEach(() => {
-		mockedCall.mockReset()
-	})
-
-	it('clears the binding by sending an empty targets array', async () => {
-		mockedCall.mockResolvedValueOnce({ statusCode: 200, body: '{}' })
-
-		await resProvider.delete(
-			'response:/zitadel.session.v2.SessionService/CreateSession',
-			baseResponseInputs,
-		)
-
-		const args = lastCallArgs()
-		expect(args.method).toBe('PUT')
-		expect(args.body).toEqual({
-			condition: {
-				response: {
-					method: '/zitadel.session.v2.SessionService/CreateSession',
 				},
 			},
 			targets: [],

--- a/src/zitadel/dynamic/execution.ts
+++ b/src/zitadel/dynamic/execution.ts
@@ -19,15 +19,6 @@ export interface ZitadelExecutionRequestArgs {
 	targetIds: pulumi.Input<pulumi.Input<string>[]>
 }
 
-export interface ZitadelExecutionResponseArgs {
-	domain: pulumi.Input<string>
-	jwtProfileJson: pulumi.Input<string>
-	/** gRPC method name, e.g. `/zitadel.session.v2.SessionService/CreateSession`. */
-	method: pulumi.Input<string>
-	/** Target IDs invoked in order when the response is produced. */
-	targetIds: pulumi.Input<pulumi.Input<string>[]>
-}
-
 interface FunctionInputs {
 	domain: string
 	jwtProfileJson: string
@@ -36,13 +27,6 @@ interface FunctionInputs {
 }
 
 interface RequestInputs {
-	domain: string
-	jwtProfileJson: string
-	method: string
-	targetIds: string[]
-}
-
-interface ResponseInputs {
 	domain: string
 	jwtProfileJson: string
 	method: string
@@ -147,43 +131,6 @@ export const executionRequestProvider: pulumi.dynamic.ResourceProvider = {
 	},
 }
 
-export const executionResponseProvider: pulumi.dynamic.ResourceProvider = {
-	async create(
-		inputs: ResponseInputs,
-	): Promise<pulumi.dynamic.CreateResult<ResponseInputs>> {
-		await setExecution({
-			inputs,
-			condition: { response: { method: inputs.method } },
-			targetIds: inputs.targetIds,
-		})
-		return {
-			id: `response:${inputs.method}`,
-			outs: inputs,
-		}
-	},
-
-	async update(
-		_id: string,
-		_olds: ResponseInputs,
-		news: ResponseInputs,
-	): Promise<pulumi.dynamic.UpdateResult<ResponseInputs>> {
-		await setExecution({
-			inputs: news,
-			condition: { response: { method: news.method } },
-			targetIds: news.targetIds,
-		})
-		return { outs: news }
-	},
-
-	async delete(_id: string, state: ResponseInputs): Promise<void> {
-		await setExecution({
-			inputs: state,
-			condition: { response: { method: state.method } },
-			targetIds: [],
-		})
-	},
-}
-
 /**
  * ZitadelExecutionFunction binds a Zitadel Actions v2 function (e.g.
  * `preaccesstoken`) to one or more Targets, via the Management REST API.
@@ -210,23 +157,5 @@ export class ZitadelExecutionRequest extends pulumi.dynamic.Resource {
 		opts?: pulumi.CustomResourceOptions,
 	) {
 		super(executionRequestProvider, name, args, opts)
-	}
-}
-
-/**
- * ZitadelExecutionResponse binds a Zitadel Actions v2 response hook (identified
- * by gRPC method, e.g. `/zitadel.session.v2.SessionService/CreateSession`) to
- * one or more Targets, via the Management REST API. The response condition
- * fires after Zitadel has successfully produced the method's response, so it is
- * the correct side for "this call succeeded" analytics (a failed call produces
- * no response and therefore no execution).
- */
-export class ZitadelExecutionResponse extends pulumi.dynamic.Resource {
-	constructor(
-		name: string,
-		args: ZitadelExecutionResponseArgs,
-		opts?: pulumi.CustomResourceOptions,
-	) {
-		super(executionResponseProvider, name, args, opts)
 	}
 }

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -21,7 +21,6 @@ import { WatchdogProbeComponent } from './components/watchdog-probe.js'
 import {
 	adminOrgIdMap,
 	BACKEND_WEBHOOK_BASE_URL,
-	CREATE_SESSION_PATH,
 	PRE_ACCESS_TOKEN_PATH,
 	zitadelDomainMap,
 } from './constants.js'
@@ -416,7 +415,6 @@ export class Zitadel {
 			domain,
 			jwtProfileJson,
 			preAccessTokenEndpoint: `${BACKEND_WEBHOOK_BASE_URL}${PRE_ACCESS_TOKEN_PATH}`,
-			createSessionEndpoint: `${BACKEND_WEBHOOK_BASE_URL}${CREATE_SESSION_PATH}`,
 			provider: this.provider,
 		})
 


### PR DESCRIPTION
## P0 — reverts the CreateSession Actions v2 Execution that broke prod sign-in

Reverts liverty-music/cloud-provisioning#377 (`97cc6bd`).

### Impact
New interactive sign-ins on prod were broken. Existing sessions (token refresh) unaffected.

### Root cause
The Actions v2 **response** execution on `/zitadel.session.v2.SessionService/CreateSession` **REPLACES the CreateSession response** with the webhook's return body (same replace-semantics documented for `request:*` executions in `actions-v2.ts`). Our handler returned `{}`, which stripped the `sessionId`. The Login UI v2 then called `GetSession("")` → `invalid GetSessionRequest.SessionId` → sign-in failed. (`interruptOnError:false` prevents *error*-based blocking, but a **successful** webhook response still replaces the payload.)

Separately, `request.checks.user.userId` is **absent** on CreateSession in the Login UI v2 flow (the user is attached via a later `SetSession`), so `account.login` never emitted anyway — confirmed by repeated `create-session: payload missing request.checks.user.userId` logs.

### This revert
Removes the CreateSession Target + response Execution (and the `ZitadelExecutionResponse` dynamic resource + KEDA `ACCOUNT` trigger added alongside). Back to the exact pre-feature state; `make check` green (biome + tsc + vitest 50 pass).

The backend `/create-session` handler + `ACCOUNT` stream (PR liverty-music/backend#359) stay deployed but are now **orphaned/harmless** (nothing invokes them).

### Follow-up
Re-approach `account.login` via a fire-and-forget Actions v2 **event** execution (cannot manipulate request/response, so it can't clobber login) with an event payload that carries the user id — tracked for a redesign.

Refs: liverty-music/specification#532