### PR TITLE
feat(zitadel): add login-event Actions v2 event execution for account.login

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -91,6 +91,16 @@ spec:
       consumer: "ARTIST_unfollowed"
       lagThreshold: "1"
       activationLagThreshold: "0"
+  # ACCOUNT.login → forward to analytics (account.login, sourced from the
+  # Zitadel session.user.checked event execution).
+  - type: nats-jetstream
+    metadata:
+      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
+      account: "$G"
+      stream: "ACCOUNT"
+      consumer: "ACCOUNT_login"
+      lagThreshold: "1"
+      activationLagThreshold: "0"
   # NOTIFICATION.subscribed → forward to analytics.
   - type: nats-jetstream
     metadata:

--- a/src/zitadel/components/actions-v2.ts
+++ b/src/zitadel/components/actions-v2.ts
@@ -1,6 +1,10 @@
 import * as pulumi from '@pulumi/pulumi'
 import type * as zitadel from '@pulumiverse/zitadel'
-import { ZitadelExecutionFunction, ZitadelTarget } from '../dynamic/index.js'
+import {
+	ZitadelExecutionEvent,
+	ZitadelExecutionFunction,
+	ZitadelTarget,
+} from '../dynamic/index.js'
 
 export interface ActionsV2ComponentArgs {
 	/** Zitadel domain hosting the Management API (e.g. `auth.dev.liverty-music.app`). */
@@ -9,6 +13,9 @@ export interface ActionsV2ComponentArgs {
 	jwtProfileJson: pulumi.Input<string>
 	/** In-cluster URL of the backend `/pre-access-token` webhook handler. */
 	preAccessTokenEndpoint: pulumi.Input<string>
+	/** In-cluster URL of the backend `/account-login-event` webhook handler —
+	 *  the account.login source, bound to the session.user.checked event. */
+	loginEventEndpoint: pulumi.Input<string>
 	/** Pulumi Zitadel v1 provider — required as a `dependsOn` marker so executions
 	 *  are created after the Management API is reachable via the provider. */
 	provider: zitadel.Provider
@@ -64,6 +71,8 @@ export interface ActionsV2ComponentArgs {
 export class ActionsV2Component extends pulumi.ComponentResource {
 	public readonly preAccessTokenTarget: ZitadelTarget
 	public readonly preAccessTokenExecution: ZitadelExecutionFunction
+	public readonly loginEventTarget: ZitadelTarget
+	public readonly loginEventExecution: ZitadelExecutionEvent
 
 	constructor(
 		name: string,
@@ -72,8 +81,13 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 	) {
 		super('zitadel:liverty-music:ActionsV2', name, {}, opts)
 
-		const { domain, jwtProfileJson, preAccessTokenEndpoint, provider } =
-			args
+		const {
+			domain,
+			jwtProfileJson,
+			preAccessTokenEndpoint,
+			loginEventEndpoint,
+			provider,
+		} = args
 
 		// Email-claim injection Target + ExecutionFunction.
 		// REST_CALL waits for the response so the token can be complemented
@@ -110,8 +124,49 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 			},
 		)
 
+		// Login-event Target + ExecutionEvent — the account.login source.
+		// REST_CALL with PAYLOAD_TYPE_JWT so the backend verifies the body with
+		// its existing Zitadel JWKS validator (no HMAC secret). `interruptOnError`
+		// is FALSE: analytics must never block login. Unlike the reverted
+		// `response`-on-CreateSession approach, an EVENT execution is
+		// fire-and-forget — Zitadel ignores the webhook response — so it cannot
+		// strip the session response or otherwise break sign-in.
+		this.loginEventTarget = new ZitadelTarget(
+			'login-event-webhook',
+			{
+				domain,
+				jwtProfileJson,
+				name: 'login-event-webhook',
+				endpoint: loginEventEndpoint,
+				targetType: 'REST_CALL',
+				timeout: '10s',
+				payloadType: 'PAYLOAD_TYPE_JWT',
+				interruptOnError: false,
+			},
+			{ parent: this, dependsOn: [provider] },
+		)
+
+		// Bound to `session.user.checked`: stored once per interactive login via
+		// the hosted Login UI, never on a refresh_token grant (which touches only
+		// the oidc_session aggregate) and never on a machine jwt_profile grant.
+		// Event type determined empirically via the Zitadel Events API.
+		this.loginEventExecution = new ZitadelExecutionEvent(
+			'login-event-execution',
+			{
+				domain,
+				jwtProfileJson,
+				eventType: 'session.user.checked',
+				targetIds: [this.loginEventTarget.targetId],
+			},
+			{
+				parent: this,
+				dependsOn: [this.loginEventTarget],
+			},
+		)
+
 		this.registerOutputs({
 			preAccessTokenTargetId: this.preAccessTokenTarget.targetId,
+			loginEventTargetId: this.loginEventTarget.targetId,
 		})
 	}
 }

--- a/src/zitadel/constants.ts
+++ b/src/zitadel/constants.ts
@@ -47,6 +47,9 @@ export const zitadelDomainMap: Record<Environment, string> = {
 export const BACKEND_WEBHOOK_BASE_URL =
 	'http://server-webhook-svc.backend.svc.cluster.local:9090'
 export const PRE_ACCESS_TOKEN_PATH = '/pre-access-token'
+/** Backend login-event webhook path — the account.login source, bound to the
+ *  Zitadel Actions v2 event execution on `session.user.checked`. */
+export const LOGIN_EVENT_PATH = '/account-login-event'
 
 /**
  * Bootstrap-created `admin` Role Org IDs per environment.

--- a/src/zitadel/dynamic/execution.ts
+++ b/src/zitadel/dynamic/execution.ts
@@ -19,6 +19,17 @@ export interface ZitadelExecutionRequestArgs {
 	targetIds: pulumi.Input<pulumi.Input<string>[]>
 }
 
+export interface ZitadelExecutionEventArgs {
+	domain: pulumi.Input<string>
+	jwtProfileJson: pulumi.Input<string>
+	/** Event type, e.g. `session.user.checked`. Fires after the event is
+	 *  persisted; the execution is fire-and-forget and cannot alter any API
+	 *  request/response. */
+	eventType: pulumi.Input<string>
+	/** Target IDs invoked in order when the event is stored. */
+	targetIds: pulumi.Input<pulumi.Input<string>[]>
+}
+
 interface FunctionInputs {
 	domain: string
 	jwtProfileJson: string
@@ -30,6 +41,13 @@ interface RequestInputs {
 	domain: string
 	jwtProfileJson: string
 	method: string
+	targetIds: string[]
+}
+
+interface EventInputs {
+	domain: string
+	jwtProfileJson: string
+	eventType: string
 	targetIds: string[]
 }
 
@@ -131,6 +149,43 @@ export const executionRequestProvider: pulumi.dynamic.ResourceProvider = {
 	},
 }
 
+export const executionEventProvider: pulumi.dynamic.ResourceProvider = {
+	async create(
+		inputs: EventInputs,
+	): Promise<pulumi.dynamic.CreateResult<EventInputs>> {
+		await setExecution({
+			inputs,
+			condition: { event: { event: inputs.eventType } },
+			targetIds: inputs.targetIds,
+		})
+		return {
+			id: `event:${inputs.eventType}`,
+			outs: inputs,
+		}
+	},
+
+	async update(
+		_id: string,
+		_olds: EventInputs,
+		news: EventInputs,
+	): Promise<pulumi.dynamic.UpdateResult<EventInputs>> {
+		await setExecution({
+			inputs: news,
+			condition: { event: { event: news.eventType } },
+			targetIds: news.targetIds,
+		})
+		return { outs: news }
+	},
+
+	async delete(_id: string, state: EventInputs): Promise<void> {
+		await setExecution({
+			inputs: state,
+			condition: { event: { event: state.eventType } },
+			targetIds: [],
+		})
+	},
+}
+
 /**
  * ZitadelExecutionFunction binds a Zitadel Actions v2 function (e.g.
  * `preaccesstoken`) to one or more Targets, via the Management REST API.
@@ -157,5 +212,22 @@ export class ZitadelExecutionRequest extends pulumi.dynamic.Resource {
 		opts?: pulumi.CustomResourceOptions,
 	) {
 		super(executionRequestProvider, name, args, opts)
+	}
+}
+
+/**
+ * ZitadelExecutionEvent binds a Zitadel Actions v2 event hook (identified by
+ * event type, e.g. `session.user.checked`) to one or more Targets, via the
+ * Management REST API. An event execution is fire-and-forget: it fires after
+ * the event is stored and its webhook response is ignored, so — unlike a
+ * request/response execution — it cannot alter the auth flow or break sign-in.
+ */
+export class ZitadelExecutionEvent extends pulumi.dynamic.Resource {
+	constructor(
+		name: string,
+		args: ZitadelExecutionEventArgs,
+		opts?: pulumi.CustomResourceOptions,
+	) {
+		super(executionEventProvider, name, args, opts)
 	}
 }

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -21,6 +21,7 @@ import { WatchdogProbeComponent } from './components/watchdog-probe.js'
 import {
 	adminOrgIdMap,
 	BACKEND_WEBHOOK_BASE_URL,
+	LOGIN_EVENT_PATH,
 	PRE_ACCESS_TOKEN_PATH,
 	zitadelDomainMap,
 } from './constants.js'
@@ -415,6 +416,7 @@ export class Zitadel {
 			domain,
 			jwtProfileJson,
 			preAccessTokenEndpoint: `${BACKEND_WEBHOOK_BASE_URL}${PRE_ACCESS_TOKEN_PATH}`,
+			loginEventEndpoint: `${BACKEND_WEBHOOK_BASE_URL}${LOGIN_EVENT_PATH}`,
 			provider: this.provider,
 		})
 


### PR DESCRIPTION
Re-provisions the `account.login` source removed by the revert (`c650111`). Instead of the `response`-on-`CreateSession` execution that broke sign-in, this binds a fire-and-forget **event** execution on `session.user.checked` — it fires after the event is stored and Zitadel ignores the webhook response, so it cannot alter the auth flow.

## Changes
- **`ZitadelExecutionEvent`** dynamic resource (`src/zitadel/dynamic/execution.ts`), condition `{ event: { event } }`, mirroring the request/function providers.
- **login-event Target** (`actions-v2.ts`): `REST_CALL`, `PAYLOAD_TYPE_JWT` (backend verifies via JWKS — no HMAC secret), `interruptOnError: false` (analytics never blocks login), pointing at the backend `/account-login-event` webhook.
- **event execution** bound to `session.user.checked`.
- **Re-add the `ACCOUNT`/`ACCOUNT_login` KEDA trigger** that the revert removed (`scaledobject.yaml`) — verified via `kubectl kustomize` render (18 triggers).

`make lint-ts` (biome + tsc) passes; consumer base renders cleanly.

⚠️ **Prod deploy is manual** (Pulumi Cloud console). This creates a Zitadel Target + Execution in prod — the same surface as the 2026-07-02 outage, but an event execution cannot replace the API response. Recommend a real interactive-login smoke immediately after `pulumi up` (task 8.5).

Companion PRs: backend `redesign-account-login-event-handler` (#362), spec `implement-account-login-event-execution` (#688).

Refs: #532