### PR TITLE
fix(zitadel): login-event target → PAYLOAD_TYPE_JSON + HMAC signingKey

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -46,6 +46,13 @@ export interface GcpArgs {
 	 *  Secret via ExternalSecret. `gemini.NewConcertSearcher` REQUIRES this
 	 *  (no Vertex AI fallback as of backend #303). */
 	geminiSearchApiKey?: pulumi.Output<string>
+	/** HMAC signing key Zitadel generated for the login-event Actions v2 Target
+	 *  (PAYLOAD_TYPE_JSON). Stored in Secret Manager as
+	 *  `webhook-login-event-signing-key` and synced into `backend-secrets` as
+	 *  `WEBHOOK_LOGIN_EVENT_SIGNING_KEY`; the login-event webhook handler
+	 *  verifies the `ZITADEL-Signature` header against it. Present only when the
+	 *  Zitadel workload is provisioned. */
+	loginEventSigningKey?: pulumi.Output<string>
 	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
 	postmarkConfig: PostmarkDnsConfig
@@ -130,6 +137,7 @@ export class Gcp {
 			fanartTvApiKey,
 			posthogProjectApiKey,
 			geminiSearchApiKey,
+			loginEventSigningKey,
 			blockchainConfig,
 			cloudflareConfig,
 			postmarkConfig,
@@ -415,6 +423,19 @@ export class Gcp {
 								{
 									name: 'gemini-search-api-key',
 									value: geminiSearchApiKey,
+								},
+							]
+						: []),
+					// HMAC signing key for the login-event Actions v2 Target
+					// (PAYLOAD_TYPE_JSON). Zitadel generates it at Target creation;
+					// the login-event webhook handler verifies the ZITADEL-Signature
+					// header against it. Present only when the Zitadel workload is
+					// provisioned (conditional-spread as every other optional secret).
+					...(loginEventSigningKey
+						? [
+								{
+									name: 'webhook-login-event-signing-key',
+									value: pulumi.secret(loginEventSigningKey),
 								},
 							]
 						: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,21 @@ const gcp = new Gcp({
 	zitadelMachineKey,
 	zitadelLoginPat,
 	zitadelWatchdogProbePat,
+	// HMAC signing key Zitadel generated for the login-event Target
+	// (PAYLOAD_TYPE_JSON). Plumbed to the backend as GSM secret
+	// `webhook-login-event-signing-key` so the login-event handler can verify
+	// the `ZITADEL-Signature` header. Present only when the Zitadel workload is
+	// provisioned; JSON targets always return a signingKey.
+	loginEventSigningKey: zitadel?.actionsV2.loginEventTarget.signingKey.apply(
+		(key) => {
+			if (!key) {
+				throw new Error(
+					'login-event Target signingKey missing — expected for PAYLOAD_TYPE_JSON',
+				)
+			}
+			return key
+		},
+	),
 	workloadEnabled,
 	postgresAvailabilityType,
 })

--- a/src/zitadel/components/actions-v2.ts
+++ b/src/zitadel/components/actions-v2.ts
@@ -125,8 +125,14 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 		)
 
 		// Login-event Target + ExecutionEvent — the account.login source.
-		// REST_CALL with PAYLOAD_TYPE_JWT so the backend verifies the body with
-		// its existing Zitadel JWKS validator (no HMAC secret). `interruptOnError`
+		// REST_CALL with PAYLOAD_TYPE_JSON (the Zitadel-recommended default):
+		// Zitadel signs each body with an HMAC and the backend verifies the
+		// `ZITADEL-Signature` header with the Target's generated `signingKey`
+		// (captured below and plumbed to the backend via GSM/ESO). PAYLOAD_TYPE_JWT
+		// is NOT used here: an event-execution JWT target requires an active
+		// instance web key, which this instance lacks — it fails with
+		// `Errors.WebKey.NoActive` (whereas the function-based pre-access-token
+		// target signs in the OIDC context and is unaffected). `interruptOnError`
 		// is FALSE: analytics must never block login. Unlike the reverted
 		// `response`-on-CreateSession approach, an EVENT execution is
 		// fire-and-forget — Zitadel ignores the webhook response — so it cannot
@@ -140,7 +146,7 @@ export class ActionsV2Component extends pulumi.ComponentResource {
 				endpoint: loginEventEndpoint,
 				targetType: 'REST_CALL',
 				timeout: '10s',
-				payloadType: 'PAYLOAD_TYPE_JWT',
+				payloadType: 'PAYLOAD_TYPE_JSON',
 				interruptOnError: false,
 			},
 			{ parent: this, dependsOn: [provider] },


### PR DESCRIPTION
The `account.login` event execution fired in prod but every target call failed with `Errors.WebKey.NoActive` — an event-execution `PAYLOAD_TYPE_JWT` target signs with an active instance web key this Zitadel v4.14.0 instance lacks. Switch the login-event Target to `PAYLOAD_TYPE_JSON` (Zitadel's default) so it signs with an HMAC `signingKey`.

- Capture Zitadel's generated `signingKey` → GSM secret `webhook-login-event-signing-key` (threaded via `Gcp` → KubernetesComponent secrets, backend-app + ESO IAM), following the `posthog-public-project-key` pattern.

⚠️ The **k8s ExternalSecret entry is deferred to a follow-up PR** — ESO v1beta1 fails the whole `backend-secrets` bundle when a referenced remote key is absent, so it must land only **after** prod `pulumi up` creates the GSM secret.

⚠️ Prod deploy is manual (Pulumi Cloud console). Preview will show the login-event Target replaced (JWT→JSON) + a new GSM secret.

Companion PRs: backend `fix-login-event-json-hmac`, spec `fix-login-event-json-hmac`.

Refs: #532