### PR TITLE
feat(backend): sync login-event signing key into backend-secrets

### DIFF
--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -36,3 +36,11 @@ spec:
   - secretKey: zitadel-machine-key-for-backend-app.json
     remoteRef:
       key: zitadel-machine-key-for-backend-app
+  # HMAC signing key for the login-event Actions v2 Target (PAYLOAD_TYPE_JSON).
+  # The login-event webhook handler verifies the ZITADEL-Signature header with
+  # it. GSM secret provisioned by Pulumi; this entry is safe to add now that the
+  # secret exists (ESO v1beta1 fails the whole bundle if a referenced key is
+  # absent).
+  - secretKey: WEBHOOK_LOGIN_EVENT_SIGNING_KEY
+    remoteRef:
+      key: webhook-login-event-signing-key


### PR DESCRIPTION
Phase 2 of the login-event JSON+HMAC fix. Now that prod `pulumi up` (via #380/#381) created the GSM secret `webhook-login-event-signing-key`, add the ExternalSecret entry mapping it into `backend-secrets` as `WEBHOOK_LOGIN_EVENT_SIGNING_KEY`.

The login-event webhook handler (backend v1.19.1) verifies the `ZITADEL-Signature` header against this key. It was deferred until now because ESO v1beta1 fails the whole `backend-secrets` bundle when a referenced remote key is absent.

Once merged → ArgoCD sync → ESO mounts the key → backend server restart → the handler can verify → `account.login` flows.

Verified via `kubectl kustomize` render (prod overlay OK).

Refs: #532