### PR TITLE
feat(monitoring): sales-reminder delivery outcome log metric + KEDA cleanup

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -64,15 +64,6 @@ spec:
   # Analytics-forwarding consumers (analytics_consumer.go): each fans one
   # domain event out to PostHog. Durable name = subject with dots replaced by
   # underscores; stream = the subject's leading segment (see streams.go).
-  # USER.preferred_language_updated → forward to analytics.
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "USER"
-      consumer: "USER_preferred_language_updated"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
   # ARTIST.followed → forward to analytics.
   - type: nats-jetstream
     metadata:
@@ -91,8 +82,9 @@ spec:
       consumer: "ARTIST_unfollowed"
       lagThreshold: "1"
       activationLagThreshold: "0"
-  # ACCOUNT.login → forward to analytics (account.login, sourced from the
-  # Zitadel session.user.checked event execution).
+  # ACCOUNT.login → forward to analytics (account.signin, sourced from the
+  # Zitadel session.user.checked event execution). The NATS transport subject
+  # stays ACCOUNT.login; only the PostHog event name changed to account.signin.
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
@@ -162,14 +154,5 @@ spec:
       account: "$G"
       stream: "TICKET_EMAIL"
       consumer: "TICKET_EMAIL_parsed"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
-  # SALES_REMINDER.delivered → forward to analytics.
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "SALES_REMINDER"
-      consumer: "SALES_REMINDER_delivered"
       lagThreshold: "1"
       activationLagThreshold: "0"

--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -45,6 +45,7 @@ export class MonitoringComponent extends pulumi.ComponentResource {
 	public readonly alertPolicies: gcp.monitoring.AlertPolicy[]
 	public readonly atlasMigrationAlertPolicy: gcp.monitoring.AlertPolicy
 	public readonly googleChatChannels: gcp.monitoring.NotificationChannel[]
+	public readonly salesReminderDeliveryMetric: gcp.logging.Metric
 
 	constructor(
 		name: string,
@@ -263,6 +264,60 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 						'5. After fixing the root cause, the operator will automatically retry on the next reconciliation cycle',
 					].join('\n'),
 					mimeType: 'text/markdown',
+				},
+			},
+			{ parent: this },
+		)
+
+		// Sales-reminder delivery outcome metric.
+		//
+		// Preserves the delivery-reliability visibility (no_subscription / failed
+		// per phase stage) that was previously carried by the removed
+		// `sales_reminder.delivered` product-analytics event. Delivery reach now
+		// lives in PostHog on `notification.delivered` (type = "sales_reminder"),
+		// while the operational failure breakdown belongs here, not in product
+		// analytics.
+		//
+		// salesReminderDeliveryUseCase.DeliverReminder emits one structured
+		// `sales_reminder delivery outcome` log line per terminal outcome (Info
+		// for "delivered", Warn for "no_subscription" / "failed") carrying
+		// `outcome` and `phase_stage` fields. This metric counts those lines,
+		// keyed by both labels so reach and failure rates stay queryable per
+		// stage in Cloud Monitoring. The delivery runs in the backend messaging
+		// consumer, so the filter is scoped to the `backend` namespace.
+		this.salesReminderDeliveryMetric = new gcp.logging.Metric(
+			'log-metric-sales-reminder-delivery-outcomes',
+			{
+				project: projectId,
+				name: 'sales_reminder_delivery_outcomes',
+				description:
+					'Sales-phase push-reminder delivery outcomes (delivered / no_subscription / failed) per reminder stage. Replaces the operational visibility of the removed sales_reminder.delivered analytics event.',
+				filter: pulumi.interpolate`resource.type="k8s_container"
+resource.labels.project_id="${projectId}"
+resource.labels.location="${clusterLocation}"
+resource.labels.cluster_name="${clusterName}"
+resource.labels.namespace_name="backend"
+jsonPayload.msg="sales_reminder delivery outcome"`,
+				metricDescriptor: {
+					metricKind: 'DELTA',
+					valueType: 'INT64',
+					unit: '1',
+					labels: [
+						{
+							key: 'outcome',
+							valueType: 'STRING',
+							description: 'delivered | no_subscription | failed',
+						},
+						{
+							key: 'phase_stage',
+							valueType: 'STRING',
+							description: 'reminder stage, e.g. APPLY_OPEN',
+						},
+					],
+				},
+				labelExtractors: {
+					outcome: 'EXTRACT(jsonPayload.outcome)',
+					phase_stage: 'EXTRACT(jsonPayload.phase_stage)',
 				},
 			},
 			{ parent: this },


### PR DESCRIPTION
## Summary

Ops-side of the `prune-analytics-event-collection` change.

- Adds a Cloud Logging log-based metric `sales_reminder_delivery_outcomes` (labels `outcome`, `phase_stage`) that counts the backend's structured `sales_reminder delivery outcome` logs. This preserves the delivery-reliability visibility (`no_subscription` / `failed` per stage) lost when the `sales_reminder.delivered` analytics event was removed; reach itself stays in PostHog on `notification.delivered` (`type="sales_reminder"`).
- Prunes the KEDA `scaledobject.yaml` triggers for the two analytics consumers the backend removed (`USER.preferred_language_updated`, `SALES_REMINDER.delivered`).

## Validation

- `make lint-ts` (biome + tsc) passes.
- `kubectl kustomize` renders the backend dev/prod overlays cleanly; verified the removed durables are absent and `ACCOUNT_login` (transport unchanged) plus all other analytics durables remain.

## Deploy notes

The log-based metric only records once the backend PR ships the new log line. `prod` runs `pulumi preview` only on PR; merge to `main` auto-deploys `dev`, prod is a manual console `up`.

## Part of

Cross-repo change tracked by liverty-music/specification#692.