### PR TITLE
feat(prod): pin sales cronjobs to backend v1.20.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.20.0 # commit 5a3057198f0751ec93abf3420f731563a394e150
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.17.0 # commit 4b12ac9b5a184be47ebf3ebd2cd47080820459ba
+    newTag: v1.20.0 # commit 5a3057198f0751ec93abf3420f731563a394e150
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.17.0 # commit 4b12ac9b5a184be47ebf3ebd2cd47080820459ba
+    newTag: v1.20.0 # commit 5a3057198f0751ec93abf3420f731563a394e150


### PR DESCRIPTION
## Summary

The automated `bump-prod-pin` workflow leaves the **sales-phase-discovery** and **sales-reminders** cronjob pins untouched on a backend release (it only rewrites server/consumer + concert-discovery/artist-image-sync/merch-discovery). They were stuck at **v1.17.0**, three releases behind. This bumps both to **v1.20.0** (images built by the v1.20.0 release).

## Why this is required now

Part of `prune-analytics-event-collection` (liverty-music/specification#692). The **sales-reminders** job at v1.17.0 still publishes the removed `sales_reminder.delivered` event to the `SALES_REMINDER` NATS stream — which is now consumer-less because backend v1.20.0's analytics-consumer dropped that subscription (and removed the stream from `EnsureStreams`). Bumping to v1.20.0 replaces that publish with a structured `"sales_reminder delivery outcome"` log, which the new `sales_reminder_delivery_outcomes` log-based metric (CP #383) consumes.

sales-phase-discovery is bumped in lock-step per the standard post-release cronjob-pin runbook (avoid running old code on the current schema).

## Validation

`kubectl kustomize k8s/namespaces/backend/overlays/prod` renders both cronjobs with the `.../liverty-music-prod/backend/{sales-phase-discovery,sales-reminders}:v1.20.0` images. `app.kubernetes.io/version` is already `1.20.0` from the automated backend pin-bump.

## Deploy

ArgoCD auto-syncs the backend Application on merge; the next scheduled cronjob run picks up the new image.

Refs: liverty-music/specification#692