### PR TITLE
fix(prod): restore frontend web-app pin to v1.24.0

### DIFF
--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -30,7 +30,7 @@ namespace: frontend
 #   on the Deployment so Pods carry it for Prometheus / OTel scraping.
 labels:
   - pairs:
-      app.kubernetes.io/version: "1.23.1"
+      app.kubernetes.io/version: "1.24.0"
     includeSelectors: false
     includeTemplates: true
 patches:
@@ -109,7 +109,7 @@ patches:
 images:
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/web-app
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/web-app
-    newTag: v1.23.1 # commit 2b420dbc3f333cccc5c29fee4025caa9e7513eb4
+    newTag: v1.24.0 # commit f94098f3911e462396aee0c530ed7d72423f1e20
   # Admin console image. NOTE: until `bump-prod-pin.yml` learns per-component
   # image selection (deferred follow-up), a consumer release's pin-bump rewrites
   # EVERY newTag here, so admin-app tracks the consumer release tag — tolerable


### PR DESCRIPTION
## Problem

A frontend **v1.23.1** release was published ~3 min after **v1.24.0** (the analytics-event prune), and its automated `bump-prod-pin` run rewrote the prod **web-app** pin from `v1.24.0` → `v1.23.1`, rolling prod frontend back two commits and dropping the prune.

`git compare v1.24.0...v1.23.1` = `behind_by=2, ahead_by=0` — **v1.23.1 is a strict ancestor of v1.24.0** (v1.24.0 = v1.23.1 + the two prune commits). Restoring the v1.24.0 pin loses nothing that v1.23.1 carried.

## Change

- `web-app` pin: `v1.23.1` → **`v1.24.0`** (commit `f94098f3`)
- `app.kubernetes.io/version` label: `1.23.1` → `1.24.0`
- `admin-app` left at `v1.23.1` (untouched)

`kubectl kustomize k8s/namespaces/frontend/overlays/prod` renders `web-app:v1.24.0` + `admin-app:v1.23.1`.

> Note: the shared-pin behaviour that caused the clobber (a consumer release's pin-bump rewrites every `newTag`) is the known deferred follow-up documented inline; this PR is a targeted manual restore.

Refs: liverty-music/specification#692