### PR TITLE
feat(monitoring): JetStream consumer backlog stall alert + Recreate strategy (Phase 1)

### DIFF
--- a/k8s/namespaces/backend/base/consumer/deployment.yaml
+++ b/k8s/namespaces/backend/base/consumer/deployment.yaml
@@ -5,6 +5,13 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
+  # Recreate (not RollingUpdate): the consumer owns a single set of JetStream
+  # durables (min=max=1 in prod). A rolling update would briefly run two pods
+  # that both try to bind the same durables; the second silently fails to bind
+  # and the rollout can wedge consumption. Recreate terminates the old pod
+  # before starting the new one so only one pod ever owns the durables.
+  strategy:
+    type: Recreate
   template:
     spec:
       terminationGracePeriodSeconds: 90

--- a/k8s/namespaces/nats/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/nats/overlays/prod/kustomization.yaml
@@ -7,6 +7,11 @@ kind: Kustomization
 
 namespace: nats
 
+# GMP PodMonitoring scraping the prometheus-nats-exporter sidecar, feeding the
+# JetStream consumer-backlog stall alert (see src/gcp/components/monitoring.ts).
+resources:
+- podmonitoring.yaml
+
 helmCharts:
 - name: nats
   repo: https://nats-io.github.io/k8s/helm/charts/

--- a/k8s/namespaces/nats/overlays/prod/podmonitoring.yaml
+++ b/k8s/namespaces/nats/overlays/prod/podmonitoring.yaml
@@ -1,0 +1,33 @@
+# PodMonitoring CRD — opts the NATS pods (prometheus-nats-exporter sidecar)
+# into Google Managed Service for Prometheus (GMP) ingestion so the JetStream
+# consumer-backlog stall alert can query num_pending.
+#
+# The 2026-07 incident wedged all event consumption for ~1 week undetected: the
+# pod stayed Running and emitted no ERROR, so no log-based alert could fire.
+# num_pending (backlog) is the one signal that does not depend on logs, so it
+# is scraped here and alerted on in monitoring.ts.
+#
+# Cost is bounded exactly like the backend-server PodMonitoring: a keep-rule
+# limits ingestion to the two consumer-backlog series, and the scrape interval
+# is 60s. Prod-only — dev has no backlog alert.
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: nats-jetstream-backlog
+  namespace: nats
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nats
+      app.kubernetes.io/instance: nats
+  endpoints:
+  - port: prom-metrics
+    interval: 60s
+    metricRelabeling:
+    # Keep only the consumer backlog gauges. The `-prefix=nats` exporter arg
+    # may or may not prefix the jsz metrics depending on the exporter version,
+    # so match both forms; confirm the exact name against the live /metrics
+    # endpoint during prod verification and tighten if desired.
+    - sourceLabels: [__name__]
+      regex: (nats_)?jetstream_consumer_num_pending|(nats_)?jetstream_consumer_num_ack_pending
+      action: keep

--- a/k8s/namespaces/nats/overlays/prod/values.yaml
+++ b/k8s/namespaces/nats/overlays/prod/values.yaml
@@ -45,6 +45,30 @@ reloader:
 natsBox:
   enabled: false
 
+# prometheus-nats-exporter sidecar. Exposes JetStream consumer metrics
+# (notably jetstream_consumer_num_pending per account/stream/consumer) on a
+# Prometheus /metrics endpoint (port name: prom-metrics) so Google Managed
+# Prometheus can scrape them and the consumer-backlog stall alert can fire.
+# The chart's default exporter args include `-jsz=all` when JetStream is
+# enabled, so no extra args are needed. Prod-only: dev has no backlog alert
+# and stays lean.
+promExporter:
+  enabled: true
+  merge:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 32Mi
+    # GKE Autopilot requires an explicit non-root securityContext.
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+
 service:
   ports:
     monitor:

--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -44,6 +44,7 @@ export interface MonitoringComponentArgs {
 export class MonitoringComponent extends pulumi.ComponentResource {
 	public readonly alertPolicies: gcp.monitoring.AlertPolicy[]
 	public readonly atlasMigrationAlertPolicy: gcp.monitoring.AlertPolicy
+	public readonly consumerBacklogAlertPolicy: gcp.monitoring.AlertPolicy
 	public readonly googleChatChannels: gcp.monitoring.NotificationChannel[]
 	public readonly salesReminderDeliveryMetric: gcp.logging.Metric
 
@@ -262,6 +263,77 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 						'3. Check the migration pod logs: `kubectl -n atlas-operator logs -l app.kubernetes.io/name=atlas-operator`',
 						'4. If the error is "non-linear" (out-of-order files), see: https://atlasgo.io/versioned/apply#non-linear-error',
 						'5. After fixing the root cause, the operator will automatically retry on the next reconciliation cycle',
+					].join('\n'),
+					mimeType: 'text/markdown',
+				},
+			},
+			{ parent: this },
+		)
+
+		// JetStream Consumer Backlog Stall Alert.
+		//
+		// The 2026-07 incident wedged ALL event consumption for ~1 week
+		// undetected: a mis-configured durable stopped consumption while the pod
+		// stayed Running and emitted no ERROR/poison, so neither the Consumer
+		// ERROR Log nor the Poison Queue alert could fire. Consumer backlog
+		// (num_pending) is the one signal independent of logs, scraped from the
+		// prometheus-nats-exporter sidecar via GMP (see the nats prod overlay
+		// PodMonitoring `nats-jetstream-backlog`).
+		//
+		// The condition uses `min_over_time(...[15m]) > 0`: it fires only when a
+		// consumer's backlog stayed above zero for a full 15-minute window —
+		// i.e. it never drained to zero, so it is stalled. A healthy consumer
+		// (even a bursty low-traffic one) drains to zero between events, so its
+		// 15-minute minimum is zero and it does not alert. This detects a silent
+		// stall regardless of message volume without per-consumer thresholds.
+		//
+		// The `-prefix=nats` exporter arg may or may not prefix the jsz metrics
+		// across exporter versions, so both metric names are queried with `or`;
+		// only the emitted one contributes. Confirm the exact name against the
+		// live /metrics endpoint during prod verification. Threshold/window are
+		// tunable after baseline observation.
+		this.consumerBacklogAlertPolicy = new gcp.monitoring.AlertPolicy(
+			'alert-consumer-backlog-stall',
+			{
+				displayName: 'Consumer JetStream Backlog Stall',
+				project: projectId,
+				combiner: 'OR',
+				conditions: [
+					{
+						displayName:
+							'JetStream consumer backlog not draining for 15m',
+						conditionPrometheusQueryLanguage: {
+							query: 'min_over_time(nats_jetstream_consumer_num_pending[15m]) > 0 or min_over_time(jetstream_consumer_num_pending[15m]) > 0',
+							duration: '300s', // sustain 5m beyond the 15m window
+							evaluationInterval: '60s',
+						},
+					},
+				],
+				alertStrategy: {
+					notificationRateLimit: {
+						period: '43200s', // 12 hours
+					},
+					autoClose: '3600s', // 1 hour
+				},
+				notificationChannels,
+				documentation: {
+					content: [
+						'## Consumer JetStream Backlog Stall Alert',
+						'',
+						'A backend JetStream consumer stopped draining its backlog: `num_pending` stayed above zero for a full 15-minute window. Events are being published but not consumed.',
+						'',
+						'This is the safety net for the 2026-07 silent-outage class: it fires on backlog metrics alone, independent of ERROR logs or poison messages.',
+						'',
+						'### Alert Labels',
+						'- `stream` / `consumer`: the affected JetStream stream and durable',
+						'- `account`: the NATS account (usually `$G`)',
+						'',
+						'### Triage Steps',
+						'1. Check the consumer pod: `kubectl -n backend get pods -l app=consumer` — is it Running, CrashLooping, or restarting?',
+						'2. Check `/healthz` liveness: a wedged router / unbound durable now reports unhealthy and should have restarted the pod',
+						'3. Inspect the durable: port-forward `nats:4222` and run `nats consumer info <STREAM> <CONSUMER>` — check `push_bound=true` and the delivery/deliver-group config for drift',
+						'4. If a durable is mis-configured (stale deliver group / policy), the startup reconciliation should recreate it on the next restart; force a restart with `kubectl -n backend delete pod -l app=consumer`',
+						'5. Recover lost events by re-publishing from the source (streams retain 7d); `DeliverNew` durables do not replay already-published messages',
 					].join('\n'),
 					mimeType: 'text/markdown',
 				},


### PR DESCRIPTION
## Summary

Phase 1 (cloud-provisioning half) of hardening JetStream consumer reliability. Postmortem: a mis-configured durable silently stopped **all** backend event consumption for ~1 week in 2026-07 with no incident — the pod stayed `Running` and the wedge emitted no ERROR/poison, so neither log-based alert could fire.

This PR adds a **backlog-based stall detector** (independent of logs) plus a safer rollout strategy:

- **prometheus-nats-exporter sidecar** on the prod NATS pods (`promExporter.enabled`), exposing `jetstream_consumer_num_pending` per stream/consumer. The exporter reads the **NATS server**, so backlog is visible even when the consumer pod is completely dead.
- **GMP `PodMonitoring`** (`nats-jetstream-backlog`) scraping only the consumer backlog gauges (keep-rule + 60s interval) to bound ingestion cost — same pattern as the existing `backend-server` PodMonitoring. Prod-only; dev stays lean.
- **Cloud Monitoring alert** `Consumer JetStream Backlog Stall` (PromQL `min_over_time(num_pending[15m]) > 0`): fires per stream/consumer only when a backlog never drains to zero for a full 15-minute window (a silent stall). A healthy bursty consumer that drains between events does not alert — no per-consumer threshold tuning.
- **Consumer Deployment `strategy: Recreate`** so a rollout never runs two pods fighting over the single durable set (`min=max=1` in prod).

Pairs with the backend fail-loud + liveness PR (liverty-music/backend#365).

## Cost

Incremental cost is bounded and consistent with the existing prod GMP pattern: the exporter sidecar is negligible (the NATS pod is already billed at the Autopilot minimum floor), the keep-rule limits GMP to ~2 series/consumer at 60s, and alert policies are free. Dev has no exporter/scrape.

## Notes for prod verification

- `-prefix=nats` may or may not prefix the jsz metric name across exporter versions; the keep-rule regex and the alert PromQL both handle prefixed and unprefixed forms. Confirm the exact metric name against the live `/metrics` endpoint after deploy and tighten if desired.
- Alert threshold/window are tunable after observing baselines.

## Testing

- `make lint-ts` (biome + tsc) and `make lint-k8s` (render + kube-linter + spot-nodeSelector) pass.
- Kustomize dry-runs confirm: prod renders the exporter + PodMonitoring + `Recreate`; dev renders no exporter.

Refs: liverty-music/specification#695
