### PR TITLE
fix(monitoring): correct consumer backlog metric name + consumer rollout guard

### DIFF
--- a/k8s/namespaces/backend/base/consumer/deployment.yaml
+++ b/k8s/namespaces/backend/base/consumer/deployment.yaml
@@ -5,13 +5,19 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  # Recreate (not RollingUpdate): the consumer owns a single set of JetStream
-  # durables (min=max=1 in prod). A rolling update would briefly run two pods
-  # that both try to bind the same durables; the second silently fails to bind
-  # and the rollout can wedge consumption. Recreate terminates the old pod
-  # before starting the new one so only one pod ever owns the durables.
+  # The consumer owns a single set of JetStream durables (min=max=1 in prod). A
+  # default rolling update would briefly run two pods that both try to bind the
+  # same durables; the second silently fails to bind and the rollout can wedge
+  # consumption. maxSurge=0 guarantees the old pod is torn down before the new
+  # one starts, so only one pod ever owns the durables — the same guarantee as
+  # `type: Recreate`, but expressed as RollingUpdate tuning so it applies
+  # in-place (switching type to Recreate leaves the pre-existing `rollingUpdate`
+  # block populated, which the API rejects / silently keeps as RollingUpdate).
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     spec:
       terminationGracePeriodSeconds: 90

--- a/k8s/namespaces/nats/overlays/prod/podmonitoring.yaml
+++ b/k8s/namespaces/nats/overlays/prod/podmonitoring.yaml
@@ -24,10 +24,11 @@ spec:
   - port: prom-metrics
     interval: 60s
     metricRelabeling:
-    # Keep only the consumer backlog gauges. The `-prefix=nats` exporter arg
-    # may or may not prefix the jsz metrics depending on the exporter version,
-    # so match both forms; confirm the exact name against the live /metrics
-    # endpoint during prod verification and tighten if desired.
+    # Keep only the consumer backlog gauges. The prometheus-nats-exporter jsz
+    # collector names these `consumer_num_pending` / `consumer_num_ack_pending`;
+    # the `-prefix=nats` exporter arg prefixes them to `nats_consumer_num_*`
+    # (there is no `jetstream_` segment). Confirmed against the live /metrics
+    # endpoint on prod nats-0.
     - sourceLabels: [__name__]
-      regex: (nats_)?jetstream_consumer_num_pending|(nats_)?jetstream_consumer_num_ack_pending
+      regex: nats_consumer_num_pending|nats_consumer_num_ack_pending
       action: keep

--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -287,11 +287,12 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 		// 15-minute minimum is zero and it does not alert. This detects a silent
 		// stall regardless of message volume without per-consumer thresholds.
 		//
-		// The `-prefix=nats` exporter arg may or may not prefix the jsz metrics
-		// across exporter versions, so both metric names are queried with `or`;
-		// only the emitted one contributes. Confirm the exact name against the
-		// live /metrics endpoint during prod verification. Threshold/window are
-		// tunable after baseline observation.
+		// Metric name confirmed against the live exporter on prod nats-0: the
+		// prometheus-nats-exporter jsz collector emits `consumer_num_pending`,
+		// which the `-prefix=nats` arg prefixes to `nats_consumer_num_pending`
+		// (no `jetstream_` segment). Per-series labels include `stream_name`,
+		// `consumer_name`, and `account`. Threshold/window are tunable after
+		// baseline observation.
 		this.consumerBacklogAlertPolicy = new gcp.monitoring.AlertPolicy(
 			'alert-consumer-backlog-stall',
 			{
@@ -303,7 +304,7 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 						displayName:
 							'JetStream consumer backlog not draining for 15m',
 						conditionPrometheusQueryLanguage: {
-							query: 'min_over_time(nats_jetstream_consumer_num_pending[15m]) > 0 or min_over_time(jetstream_consumer_num_pending[15m]) > 0',
+							query: 'min_over_time(nats_consumer_num_pending[15m]) > 0',
 							duration: '300s', // sustain 5m beyond the 15m window
 							evaluationInterval: '60s',
 						},
@@ -325,7 +326,7 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 						'This is the safety net for the 2026-07 silent-outage class: it fires on backlog metrics alone, independent of ERROR logs or poison messages.',
 						'',
 						'### Alert Labels',
-						'- `stream` / `consumer`: the affected JetStream stream and durable',
+						'- `stream_name` / `consumer_name`: the affected JetStream stream and durable',
 						'- `account`: the NATS account (usually `$G`)',
 						'',
 						'### Triage Steps',


### PR DESCRIPTION
Follow-up to #388 (verified against prod).

**Problem found in prod verification:** the backlog stall alert had **no data**. The PodMonitoring keep-rule and the alert PromQL used `nats_jetstream_consumer_num_pending`, but the live prometheus-nats-exporter on prod `nats-0` emits **`nats_consumer_num_pending`** (jsz collector name `consumer_num_pending` + `-prefix=nats`; no `jetstream_` segment). The wrong name made the keep-rule drop every series → GMP ingested nothing → the alert query matched nothing.

**Also:** the consumer `strategy: type: Recreate` did **not** take effect in prod (deployment stayed `RollingUpdate`) — switching type while the pre-existing `rollingUpdate` block is populated is rejected/ignored by the API. Re-expressed as `RollingUpdate` with `maxSurge: 0, maxUnavailable: 1` (same 'never two pods over one durable set' guarantee, applies cleanly in-place).

### Changes
- `nats/overlays/prod/podmonitoring.yaml`: keep-rule → `nats_consumer_num_pending|nats_consumer_num_ack_pending`
- `monitoring.ts`: PromQL → `min_over_time(nats_consumer_num_pending[15m]) > 0`; doc labels → `stream_name`/`consumer_name`
- `backend/base/consumer/deployment.yaml`: strategy → RollingUpdate maxSurge:0/maxUnavailable:1

### After merge
ArgoCD syncs the keep-rule + consumer strategy; then a prod `pulumi up` creates the (now-correct) alert policy. Verified metric name against live `/metrics`.

Refs: liverty-music/specification#695