### PR TITLE
fix(monitoring): deploy backlog alert before its metric is ingested

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -307,6 +307,12 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 							query: 'min_over_time(nats_consumer_num_pending[15m]) > 0',
 							duration: '300s', // sustain 5m beyond the 15m window
 							evaluationInterval: '60s',
+							// Allow the policy to deploy before the metric has been
+							// ingested. GMP only registers nats_consumer_num_pending
+							// after the exporter is scraped at least once, so without
+							// this a `pulumi up` on a fresh cluster (or before first
+							// scrape) fails metric-existence validation and aborts.
+							disableMetricValidation: true,
 						},
 					},
 				],


### PR DESCRIPTION
Follow-up to #388/#389. The backlog alert policy still would not create on `pulumi up`.

**Root cause:** the PromQL condition references `nats_consumer_num_pending`, which GMP only registers after the exporter is scraped at least once. Cloud Monitoring validates metric existence at AlertPolicy creation, so any prod `up` before the first scrape (which was every up so far — the keep-rule was only just corrected in #389) fails validation and **aborts the whole update**, leaving the policy uncreated.

**Fix:** `disableMetricValidation: true` on the PromQL condition — the policy deploys regardless of ingestion timing and starts evaluating once GMP has data. (Same trap class as the prior metric-threshold-on-dropped-metric incident.)

src-only change; `make lint-ts` passes. After merge, a prod `pulumi up` will create the alert policy (the metric is also registering now that #389's keep-rule is live).

Refs: liverty-music/specification#695