### PR TITLE
fix(monitoring): drop notificationRateLimit from metric-based backlog alert

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -317,9 +317,10 @@ jsonPayload.reason=~"TransientErr|BackoffLimitExceeded"`,
 					},
 				],
 				alertStrategy: {
-					notificationRateLimit: {
-						period: '43200s', // 12 hours
-					},
+					// No notificationRateLimit: the GCP API rejects it on
+					// non-log-based (metric/PromQL) policies ("only log-based
+					// alert policies may specify a notification rate limit").
+					// The sustained 15m+5m condition already prevents flapping.
 					autoClose: '3600s', // 1 hour
 				},
 				notificationChannels,


### PR DESCRIPTION
**This is why every prod `up` aborted.** Creating the backlog alert failed with:

```
Error 400: Field alertStrategy.notificationRateLimit had an invalid value of "period { seconds: 43200 }": only log-based alert policies may specify a notification rate limit
```

The `alertStrategy` was copied from the existing ERROR-log policies (log-based → may set a rate limit). The backlog policy is **metric-based (PromQL)**, for which the GCP API rejects `notificationRateLimit`. Pulumi **preview didn't catch it** (the 400 only surfaces at apply).

**Fix:** remove `notificationRateLimit`, keep `autoClose`; the sustained 15m + 5m window already prevents flapping.

src-only; `make lint-ts` passes. After merge, a prod `pulumi up` will finally create the `Consumer JetStream Backlog Stall` policy (metric already ingested; disableMetricValidation already in place).

Refs: liverty-music/specification#695