### PR TITLE
fix(prod): bump sales cronjobs to v1.22.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.22.0 # commit 738f5ff4ad25303fb8ba3f5a48c5045978259f62
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.20.0 # commit 5a3057198f0751ec93abf3420f731563a394e150
+    newTag: v1.22.0 # commit 738f5ff4ad25303fb8ba3f5a48c5045978259f62
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.20.0 # commit 5a3057198f0751ec93abf3420f731563a394e150
+    newTag: v1.22.0 # commit 738f5ff4ad25303fb8ba3f5a48c5045978259f62


### PR DESCRIPTION
Follow-up to the v1.22.0 backend release. The automated **Bump Prod Pin omits `sales-phase-discovery` and `sales-reminders`** (known gap), so they were still running v1.20.0 while everything else is v1.22.0.

This matters this release: Phase 2 renamed the reminder subject, and v1.20.0 `sales-reminders` publishes `SALES_PHASE.reminder.due` (3-token) which the now-narrowed `SALES_PHASE.*` stream no longer matches → a publish would fail, and the new consumer only has the `SALES_PHASE.reminder_due` durable. Verified prod logs: no reminder was due in the interim (`reminders_published:0`), so nothing was lost; other workloads (consumer/server) are clean.

Pin both cronjobs to v1.22.0. `make lint-k8s` passes. Refs: liverty-music/specification#695