### PR TITLE
fix(prod): bump sales cronjobs to v1.23.0

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.23.0 # commit 7e8c21cf427de93b32ca00363ce0b7bec373f0c9
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.22.0 # commit 738f5ff4ad25303fb8ba3f5a48c5045978259f62
+    newTag: v1.23.0 # commit 7e8c21cf427de93b32ca00363ce0b7bec373f0c9
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.22.0 # commit 738f5ff4ad25303fb8ba3f5a48c5045978259f62
+    newTag: v1.23.0 # commit 7e8c21cf427de93b32ca00363ce0b7bec373f0c9


### PR DESCRIPTION
Bumps `sales-phase-discovery` and `sales-reminders` prod overlay tags to v1.23.0. The automated Bump Prod Pin omits these two cronjobs, so they would otherwise stay on v1.22.0. No schema change in v1.23.0 — version-consistency hygiene. ArgoCD auto-syncs on merge.

Refs: #703