### PR TITLE
feat(prod): set concert-discovery Gemini thinking=medium

### DIFF
--- a/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/cronjob/concert-discovery/configmap.env
@@ -16,6 +16,11 @@ DATABASE_MAX_IDLE_CONNS=1
 # post-discovery skip window stays at its default. See backend
 # GCP_GEMINI_SEARCH_CACHE_TTL / GCP_GEMINI_SEARCH_DISCOVERY_WINDOW.
 GCP_GEMINI_SEARCH_CACHE_TTL=72h
+# Step 1 (grounded extract) thinking level. A/B-tuned to "medium": "low"
+# truncated long tours (dropped a tour's tail dates), "medium" enumerated them
+# fully at effectively equal token cost. Extract model is gemini-3.6-flash (the
+# backend default); parse stays gemini-3.1-flash-lite.
+GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium
 
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222


### PR DESCRIPTION
## Summary

Sets `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium` on the **concert-discovery** prod
CronJob — the A/B-tuned Step 1 (grounded extract) thinking level.

- `low` truncated long tours in the A/B (dropped a tour's tail dates); `medium`
  enumerated them fully at effectively equal token cost.
- Extract model is `gemini-3.6-flash` (backend **v1.24.0** default, already pinned
  via the auto pin-bump); parse stays `gemini-3.1-flash-lite`.

k8s-only change (ConfigMap value) → ArgoCD syncs on merge. Verified via
`kubectl kustomize` dry-run (concert-discovery renders `medium`; sales-phase-discovery's
own `high` is unaffected).

Refs liverty-music/backend#323. Companion to backend v1.24.0 (PR #373).
