### PR TITLE
feat(config): add releaseVersion to frontend ConfigMaps and pin-bump workflow

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -322,6 +322,7 @@ jobs:
           SHA: ${{ steps.payload.outputs.sha }}
           BARE: ${{ steps.payload.outputs.bare }}
           BUMP_LABEL: ${{ steps.payload.outputs.bump_label }}
+          COMPONENT: ${{ steps.payload.outputs.component }}
         run: |
           set -euo pipefail
           file="k8s/namespaces/${OVERLAY}/overlays/prod/kustomization.yaml"
@@ -340,6 +341,20 @@ jobs:
           fi
           echo "----- edited ${file} -----"
           yq '{"images": .images, "labels": .labels}' "$file"
+
+          # For frontend bumps: write releaseVersion into the config.json blob
+          # inside the prod ConfigMap so the SPA Settings screen shows the correct
+          # version immediately after the ArgoCD rollout. The no-downgrade guard
+          # (step above) has already passed, so a blocked bump never reaches here.
+          # `frontend-admin` shares the overlay but MUST NOT touch the consumer
+          # configmap — the configmap tracks the consumer (web-app) release only.
+          if [ "${COMPONENT}" = "frontend" ]; then
+            configmap="k8s/namespaces/${OVERLAY}/overlays/prod/configmap.yaml"
+            # Tag format is v[0-9]+\.[0-9]+\.[0-9]+ — safe for sed substitution.
+            sed -i "s/\"releaseVersion\": \"[^\"]*\"/\"releaseVersion\": \"${TAG}\"/" "${configmap}"
+            echo "----- releaseVersion in ${configmap} -----"
+            grep '"releaseVersion"' "${configmap}"
+          fi
 
       # ----------------------------------------------------------------------
       # 1.5 Validation gate — `kustomize build` the edited overlay. A non-zero
@@ -383,14 +398,16 @@ jobs:
           git config user.name "${BOT_SLUG}[bot]"
           git config user.email "${BOT_SLUG}[bot]@users.noreply.github.com"
 
+          configmap="k8s/namespaces/${OVERLAY}/overlays/prod/configmap.yaml"
+
           # Defensive: if no net diff (e.g. label/comment already matched),
           # skip the commit rather than create an empty one.
-          if git diff --quiet -- "$file"; then
+          if git diff --quiet -- "$file" "$configmap"; then
             echo "No net change after edit; skipping commit."
             exit 0
           fi
 
-          git add "$file"
+          git add "$file" "$configmap"
           # Build the commit message in a file to avoid heredoc indentation
           # leaking YAML/shell indent into the body.
           {

--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -398,16 +398,23 @@ jobs:
           git config user.name "${BOT_SLUG}[bot]"
           git config user.email "${BOT_SLUG}[bot]@users.noreply.github.com"
 
-          configmap="k8s/namespaces/${OVERLAY}/overlays/prod/configmap.yaml"
+          # Build the list of files to add/diff. The frontend configmap is only
+          # written for component=frontend; backend/frontend-admin have no such
+          # file, so including it unconditionally causes `fatal: pathspec` for
+          # non-frontend bumps under `set -euo pipefail`.
+          paths=("$file")
+          if [ "${COMPONENT}" = "frontend" ]; then
+            paths+=("k8s/namespaces/${OVERLAY}/overlays/prod/configmap.yaml")
+          fi
 
           # Defensive: if no net diff (e.g. label/comment already matched),
           # skip the commit rather than create an empty one.
-          if git diff --quiet -- "$file" "$configmap"; then
+          if git diff --quiet -- "${paths[@]}"; then
             echo "No net change after edit; skipping commit."
             exit 0
           fi
 
-          git add "$file" "$configmap"
+          git add "${paths[@]}"
           # Build the commit message in a file to avoid heredoc indentation
           # leaking YAML/shell indent into the body.
           {

--- a/k8s/namespaces/frontend/overlays/dev/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/configmap.yaml
@@ -40,5 +40,6 @@ data:
         "ONE OK ROCK",
         "RADWIMPS"
       ],
-      "logLevel": "debug"
+      "logLevel": "debug",
+      "releaseVersion": "dev"
     }

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -40,5 +40,6 @@ data:
         "ONE OK ROCK",
         "緑黄色社会"
       ],
-      "logLevel": "info"
+      "logLevel": "info",
+      "releaseVersion": "v1.26.0"
     }

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -41,5 +41,5 @@ data:
         "緑黄色社会"
       ],
       "logLevel": "info",
-      "releaseVersion": "v1.26.0"
+      "releaseVersion": "v1.26.2"
     }


### PR DESCRIPTION
## Summary

- Add `"releaseVersion"` field to the dev and prod frontend `config.json` ConfigMaps so the SPA Settings screen can display the deployed semver tag
- Update `bump-prod-pin.yml` to overwrite `releaseVersion` in the prod configmap atomically with the `kustomization.yaml` image pin on every frontend release

## Changes

**ConfigMaps:**
- `k8s/namespaces/frontend/overlays/dev/configmap.yaml`: `"releaseVersion": "dev"` (static placeholder)
- `k8s/namespaces/frontend/overlays/prod/configmap.yaml`: `"releaseVersion": "v1.26.0"` (current prod tag, updated by pin-bump on each release)

**Pin-bump workflow** (`.github/workflows/bump-prod-pin.yml`, "Edit prod overlay" step):
- For `component=frontend`: sed rewrites `"releaseVersion"` in `configmap.yaml` after the `kustomization.yaml` edit
- Both files are added to the same commit, so the image tag and displayed version are always in sync
- `frontend-admin` bumps do NOT touch the configmap — this field tracks the consumer (web-app) release only
- The no-downgrade guard executes before the edit step; a blocked bump never modifies either file

## Testing

- `kustomize build` validation in the workflow verifies the edited overlay renders without error
- No manual deploy required; ArgoCD auto-syncs on merge

Refs: liverty-music/specification#712
