### PR TITLE
perf(sales): sales-phase-discovery to gemini-3.6-flash + medium (+ pin v1.25.0)

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/sales-phase-discovery/configmap.env
@@ -9,15 +9,17 @@ TELEMETRY_SERVICE_NAME=liverty-music-sales-phase-discovery
 GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
 GCP_LOCATION=global
 GCP_GEMINI_MODEL=gemini-3-flash-preview
-# Sales-phase searcher models: pinned to flash-lite for BOTH steps (cost),
-# overriding the shared concert-search default (gemini-3.5-flash) for THIS job
-# only. thinking=high on the grounded extract recovers flash-lite's weaker
-# rule-following (covered-event accuracy, 全公演 marker, future-only filter):
-# live A/B showed lite+high -> 4/4 coverage, lite+medium -> 3/4. Parse is a plain
-# JSON coercion, so thinking=low suffices.
-GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.1-flash-lite
+# Sales-phase searcher models: the grounded EXTRACT step runs gemini-3.6-flash
+# with thinking=medium. gemini-3.6-flash bills grounding as ordinary tokens
+# rather than flash-lite's per-search-query fan-out (the concert searcher's
+# main cost driver), so grounding is affordable AND recall improves: live A/B
+# (post-cutoff Vaundy tour) showed flash-lite -> 0 phases while 3.6-flash+medium
+# -> exact match on apply/result/payment phases with the correct official URL.
+# The PARSE step stays flash-lite/low — it is a plain JSON coercion with no
+# grounding, so the cheap model suffices.
+GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash
 GCP_GEMINI_SEARCH_MODEL_PARSE=gemini-3.1-flash-lite
-GCP_GEMINI_SEARCH_THINKING_EXTRACT=high
+GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium
 GCP_GEMINI_SEARCH_THINKING_PARSE=low
 # Database (Defaults)
 DATABASE_NAME=liverty-music

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -226,7 +226,7 @@ images:
     newTag: v1.25.0 # commit 54b28aaae129f3195578db4a6ac045725d70464e
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-phase-discovery
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-phase-discovery
-    newTag: v1.23.0 # commit 7e8c21cf427de93b32ca00363ce0b7bec373f0c9
+    newTag: v1.25.0 # commit 54b28aaae129f3195578db4a6ac045725d70464e
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/backend/sales-reminders
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/backend/sales-reminders
-    newTag: v1.23.0 # commit 7e8c21cf427de93b32ca00363ce0b7bec373f0c9
+    newTag: v1.25.0 # commit 54b28aaae129f3195578db4a6ac045725d70464e


### PR DESCRIPTION
Migrate the sales-phase-discovery grounded EXTRACT searcher from `gemini-3.1-flash-lite`/thinking=high to `gemini-3.6-flash`/thinking=medium, mirroring the concert searcher cost optimization (backend v1.24.0).

## Why
`gemini-3.6-flash` bills grounding as ordinary tokens rather than flash-lite's per-search-query fan-out — the concert searcher's main cost driver. Grounding becomes affordable AND recall improves. Live A/B on a post-cutoff Vaundy tour: flash-lite → 0 phases; 3.6-flash+medium → exact apply/result/payment phases with the correct official URL.

## Changes
- `sales-phase-discovery/configmap.env`: `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash`, `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`. PARSE stays flash-lite/low (plain JSON coercion, no grounding).
- prod overlay: manual pin bump of `sales-phase-discovery` and `sales-reminders` v1.23.0 → v1.25.0. The automated `bump-prod-pin` workflow omits these two cronjobs, so they otherwise lag on old code against the current schema.

merch-discovery inherits the new `gemini-3.6-flash`/`medium` code default from backend v1.25.0 with no configmap override (its pin was auto-bumped to v1.25.0).

Refs: #323