### PR TITLE
feat(monitoring): add ERROR-log alert policies for sales-phase-discovery and merch-discovery

### DIFF
--- a/src/gcp/components/monitoring.ts
+++ b/src/gcp/components/monitoring.ts
@@ -101,6 +101,14 @@ export class MonitoringComponent extends pulumi.ComponentResource {
 				displayName: 'Concert Discovery',
 				appLabel: 'concert-discovery',
 			},
+			{
+				displayName: 'Sales Phase Discovery',
+				appLabel: 'sales-phase-discovery',
+			},
+			{
+				displayName: 'Merch Discovery',
+				appLabel: 'merch-discovery',
+			},
 		]
 
 		this.alertPolicies = workloads.map(


### PR DESCRIPTION
## 🔗 Related Issue
Refs: liverty-music/specification#717

## 📝 Summary of Changes

Extends the per-workload ERROR-log Alert Policies to cover `sales-phase-discovery` and `merch-discovery` CronJobs.

Both jobs exit 0 on handled failures by design (so a broken run does not retry into the same persistent fault), making ERROR-log alerting their **sole** failure signal — yet neither was in the `workloads[]` list. A live gap was confirmed on 2026-07-28: a `sales-phase-discovery` run failed at startup with a DB ping timeout, exited 0, and opened no Incident.

Changes:
- Add `{ displayName: 'Sales Phase Discovery', appLabel: 'sales-phase-discovery' }` and `{ displayName: 'Merch Discovery', appLabel: 'merch-discovery' }` to the `workloads[]` array in `src/gcp/components/monitoring.ts`.
- Two new `gcp.monitoring.AlertPolicy` resources: `alert-error-log-sales-phase-discovery` and `alert-error-log-merch-discovery`.
- Same filter shape, 12h rate-limit, 1h auto-close, and Slack + Google Chat notification channels as existing per-workload policies.

## 🌍 Affected Stacks
- [ ] Dev  _(dev is intentionally stopped — monitoring gate off; no resources created in dev)_
- [x] Prod  _(two new AlertPolicy resources; applied via manual Pulumi Cloud console `up` after merge)_

## 🔮 Pulumi Preview

CI `pulumi preview` will show the two new resources for the prod stack.

## 📦 State Changes

No state migration required. Two new resources are created on `pulumi up`.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config.
