### PR TITLE
perf(concert): pin concert-discovery to thinking=medium

### DIFF
--- a/k8s/namespaces/backend/base/cronjob/concert-discovery/configmap.env
+++ b/k8s/namespaces/backend/base/cronjob/concert-discovery/configmap.env
@@ -9,6 +9,17 @@ TELEMETRY_SERVICE_NAME=liverty-music-concert-discovery
 GCP_PROJECT_ID=TO_REPLACE_BY_OVERLAY
 GCP_LOCATION=global
 GCP_GEMINI_MODEL=gemini-3-flash-preview
+# Concert grounded EXTRACT step: pin gemini-3.6-flash + thinking=medium.
+# The model already matches the code default; pinned here for explicitness and
+# to stay robust against future default changes. thinking=medium is the
+# A/B-chosen value: with thinking=low one Vaundy run truncated a long 2027-2028
+# tour (dropped 10 real dates) while medium enumerated it fully every run, at
+# lower thinking-token cost than the former gemini-3.5-flash. Without this
+# override the job ran at Gemini's model-default thinking (not the A/B value),
+# unlike sales-phase-discovery which already pins medium. PARSE keeps the
+# flash-lite code default (plain JSON coercion, no grounding).
+GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash
+GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium
 # Database (Defaults)
 DATABASE_NAME=liverty-music
 DATABASE_HOST=postgres.osaka.psc.internal


### PR DESCRIPTION
concert-discovery had no `GCP_GEMINI_SEARCH_THINKING_EXTRACT` override, so its grounded EXTRACT step ran at Gemini's model-default thinking instead of the A/B-chosen `medium`.

## Why
The concert searcher A/B (optimize-concert-searcher-cost) found `thinking=low` truncating a long 2027-2028 tour (10 real dates dropped) while `medium` enumerated it fully every run, at lower thinking-token cost than the former gemini-3.5-flash. Running at the model default risked long-tour recall loss in prod. sales-phase-discovery already pins `medium` (CP #397) — this makes concert-discovery consistent.

## Change
`concert-discovery/configmap.env`: pin `GCP_GEMINI_SEARCH_MODEL_EXTRACT=gemini-3.6-flash` (already the code default, pinned for explicitness) and `GCP_GEMINI_SEARCH_THINKING_EXTRACT=medium`. PARSE keeps the flash-lite code default. Image pin already v1.25.0.

Completes the deferred prod-config task (5.2) of the concert searcher cost optimization.

Refs: #323