### PR TITLE
refactor(backend): remove blockchain ticket secrets and config

### DIFF
--- a/k8s/namespaces/backend/base/consumer/scaledobject.yaml
+++ b/k8s/namespaces/backend/base/consumer/scaledobject.yaml
@@ -116,38 +116,13 @@ spec:
       consumer: "track-notification-delivered"
       lagThreshold: "1"
       activationLagThreshold: "0"
-  # ENTRY stream
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "ENTRY"
-      consumer: "track-entry-verified"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "ENTRY"
-      consumer: "track-entry-rejected"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
-  # TICKET_JOURNEY / TICKET / TICKET_EMAIL streams
+  # TICKET_JOURNEY / TICKET_EMAIL streams
   - type: nats-jetstream
     metadata:
       natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
       account: "$G"
       stream: "TICKET_JOURNEY"
       consumer: "track-ticket-journey"
-      lagThreshold: "1"
-      activationLagThreshold: "0"
-  - type: nats-jetstream
-    metadata:
-      natsServerMonitoringEndpoint: "nats.nats.svc.cluster.local:8222"
-      account: "$G"
-      stream: "TICKET"
-      consumer: "track-ticket-mint"
       lagThreshold: "1"
       activationLagThreshold: "0"
   - type: nats-jetstream

--- a/k8s/namespaces/backend/base/server/configmap.env
+++ b/k8s/namespaces/backend/base/server/configmap.env
@@ -34,12 +34,6 @@ DATABASE_USER=TO_REPLACE_BY_OVERLAY
 DATABASE_SSL_MODE=disable
 DATABASE_SCHEMA=app
 
-# Blockchain
-TICKET_SBT_ADDRESS=TO_REPLACE_BY_OVERLAY
-
-# ZKP (Entry Verification)
-ZKP_VERIFICATION_KEY_PATH=/configs/zkp/zkp-verification-key.json
-
 # Zitadel Machine Key (Email Verification)
 ZITADEL_MACHINE_KEY_FOR_BACKEND_APP_PATH=/secrets/zitadel/zitadel-machine-key-for-backend-app.json
 

--- a/k8s/namespaces/backend/base/server/external-secret.yaml
+++ b/k8s/namespaces/backend/base/server/external-secret.yaml
@@ -14,15 +14,6 @@ spec:
   - secretKey: LASTFM_API_KEY
     remoteRef:
       key: lastfm-api-key
-  - secretKey: BLOCKCHAIN_DEPLOYER_PRIVATE_KEY
-    remoteRef:
-      key: blockchain-deployer-private-key
-  - secretKey: BLOCKCHAIN_RPC_URL
-    remoteRef:
-      key: blockchain-rpc-url
-  - secretKey: BLOCKCHAIN_BUNDLER_API_KEY
-    remoteRef:
-      key: blockchain-bundler-api-key
   - secretKey: VAPID_PRIVATE_KEY
     remoteRef:
       key: vapid-private-key

--- a/k8s/namespaces/backend/overlays/dev/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/dev/server/configmap.env
@@ -19,9 +19,6 @@ DATABASE_MAX_IDLE_CONNS=1
 # OIDC
 OIDC_ISSUER_URL=https://auth.dev.liverty-music.app
 
-# Blockchain
-TICKET_SBT_ADDRESS=0x7C50bdF2E5d6B81F71868d5B6B59B5B3EC2F06fa
-
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry

--- a/k8s/namespaces/backend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/backend/overlays/prod/kustomization.yaml
@@ -13,8 +13,6 @@ kind: Kustomization
 #
 # Replicas: 1 (per design D8). Resource sizing matches dev exactly.
 #
-# IMPORTANT placeholders (replace before launch):
-#   - TICKET_SBT_ADDRESS (mainnet contract address)
 # Resolved 2026-05-15:
 #   - VAPID_PUBLIC_KEY → prod-specific value derived from the GSM
 #     `vapid-private-key` private scalar (see server/configmap.env note).

--- a/k8s/namespaces/backend/overlays/prod/server/configmap.env
+++ b/k8s/namespaces/backend/overlays/prod/server/configmap.env
@@ -18,9 +18,6 @@ DATABASE_MAX_IDLE_CONNS=1
 # OIDC
 OIDC_ISSUER_URL=https://auth.liverty-music.app
 
-# Blockchain (prod ticket SBT — placeholder; replace with mainnet contract address before launch)
-TICKET_SBT_ADDRESS=0x0000000000000000000000000000000000000000
-
 # NATS
 NATS_URL=nats://nats.nats.svc.cluster.local:4222
 # Telemetry

--- a/k8s/namespaces/frontend/overlays/dev/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/configmap.yaml
@@ -11,7 +11,6 @@ data:
       "zitadelClientId": "371355407710421859",
       "zitadelOrgId": "371348346264093539",
       "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
-      "circuitBaseUrl": "/circuits/ticketcheck-v1",
       "posthogApiHost": "https://eu.i.posthog.com",
       "posthogProjectKey": "phc_tJe37LsNQskgKySDJRPfQwAZpqhM3RkH7MXDJKyb9wcU",
       "previewArtistIds": [

--- a/k8s/namespaces/frontend/overlays/prod/admin-configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/admin-configmap.yaml
@@ -28,7 +28,6 @@ data:
       "zitadelClientId": "376175199994839311",
       "zitadelOrgId": "372892288692584603",
       "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
-      "circuitBaseUrl": "",
       "previewArtistIds": [],
       "previewArtistNames": [],
       "logLevel": "info"

--- a/k8s/namespaces/frontend/overlays/prod/configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/configmap.yaml
@@ -11,7 +11,6 @@ data:
       "zitadelClientId": "373015520582107291",
       "zitadelOrgId": "373015514391249051",
       "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
-      "circuitBaseUrl": "/circuits/ticketcheck-v1",
       "posthogApiHost": "https://eu.i.posthog.com",
       "posthogProjectKey": "phc_CVzLNs8ys4zeczYv36Td3aYgBhzdnaMKUqKBT7tM8H4Q",
       "previewArtistIds": [

--- a/src/gcp/components/project.ts
+++ b/src/gcp/components/project.ts
@@ -3,16 +3,6 @@ import * as pulumi from '@pulumi/pulumi'
 import type { Environment } from '../../config.js'
 import { ApiService } from '../services/api.js'
 
-/** Blockchain (EVM) configuration for smart contract interactions. */
-export interface BlockchainConfig {
-	/** Hex-encoded private key of the deployer EOA (holds MINTER_ROLE on TicketSBT). */
-	deployerPrivateKey?: string
-	/** JSON-RPC endpoint URL for the target EVM chain. */
-	rpcUrl?: string
-	/** ERC-4337 Bundler (Pimlico/Alchemy) API key. */
-	bundlerApiKey?: string
-}
-
 export interface GcpConfig {
 	organizationId: string
 	billingAccount: string

--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -13,11 +13,7 @@ import {
 } from './components/network.js'
 import type { PostgresAvailabilityType } from './components/postgres.js'
 import { PostgresComponent } from './components/postgres.js'
-import {
-	type BlockchainConfig,
-	type GcpConfig,
-	ProjectComponent,
-} from './components/project.js'
+import { type GcpConfig, ProjectComponent } from './components/project.js'
 import { WorkloadIdentityComponent } from './components/workload-identity.js'
 import { ZitadelMonitoringComponent } from './components/zitadel-monitoring.js'
 import { RegionNames, Regions } from './region.js'
@@ -53,7 +49,6 @@ export interface GcpArgs {
 	 *  verifies the `ZITADEL-Signature` header against it. Present only when the
 	 *  Zitadel workload is provisioned. */
 	loginEventSigningKey?: pulumi.Output<string>
-	blockchainConfig?: BlockchainConfig
 	cloudflareConfig: CloudflareConfig
 	postmarkConfig: PostmarkDnsConfig
 	/** Zitadel machine key JWT profile JSON. Stored in Secret Manager for backend use. */
@@ -138,7 +133,6 @@ export class Gcp {
 			posthogProjectApiKey,
 			geminiSearchApiKey,
 			loginEventSigningKey,
-			blockchainConfig,
 			cloudflareConfig,
 			postmarkConfig,
 			zitadelMachineKey,
@@ -338,36 +332,6 @@ export class Gcp {
 								{
 									name: 'lastfm-api-key',
 									value: lastFmApiKey,
-								},
-							]
-						: []),
-					...(blockchainConfig?.deployerPrivateKey
-						? [
-								{
-									name: 'blockchain-deployer-private-key',
-									value: pulumi.secret(
-										blockchainConfig.deployerPrivateKey,
-									),
-								},
-							]
-						: []),
-					...(blockchainConfig?.rpcUrl
-						? [
-								{
-									name: 'blockchain-rpc-url',
-									value: pulumi.secret(
-										blockchainConfig.rpcUrl,
-									),
-								},
-							]
-						: []),
-					...(blockchainConfig?.bundlerApiKey
-						? [
-								{
-									name: 'blockchain-bundler-api-key',
-									value: pulumi.secret(
-										blockchainConfig.bundlerApiKey,
-									),
 								},
 							]
 						: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi'
 import type { CloudflareConfig } from './cloudflare/config.js'
 import type { Environment } from './config.js'
-import type { BlockchainConfig, GcpConfig } from './gcp/components/project.js'
+import type { GcpConfig } from './gcp/components/project.js'
 import { Gcp } from './gcp/index.js'
 import {
 	type BufConfig,
@@ -32,9 +32,6 @@ const posthogProjectApiKey = config.getSecret('posthogProjectApiKey')
 // fails fast when the env var is empty, so this secret SHALL be set in every
 // stack where the backend workload runs (dev / prod).
 const geminiSearchApiKey = config.getSecret('geminiSearchApiKey')
-const blockchainConfig = config.getObject('blockchain') as
-	| BlockchainConfig
-	| undefined
 const bufConfig = config.requireObject('buf') as BufConfig
 const cloudflareConfig = config.getObject('cloudflare') as CloudflareConfig
 const postmarkConfig = config.requireObject(
@@ -176,7 +173,6 @@ const gcp = new Gcp({
 	fanartTvApiKey,
 	posthogProjectApiKey,
 	geminiSearchApiKey,
-	blockchainConfig,
 	cloudflareConfig,
 	postmarkConfig,
 	zitadelMachineKey,


### PR DESCRIPTION
Removes the blockchain ticket system's infrastructure footprint under the Scenario A walled-garden pivot. Part of the cross-repo teardown tracked by liverty-music/specification#741.

## What
- Remove BlockchainConfig (deployer private key, RPC URL, Bundler API key) from Pulumi Secret Manager wiring + ExternalSecret mappings
- Drop ENTRY + TICKET(mint) KEDA scaledobject triggers (keep TICKET_JOURNEY / TICKET_EMAIL)
- Strip `TICKET_SBT_ADDRESS` (incl. recorded Base Sepolia address) / `ZKP_VERIFICATION_KEY_PATH` backend configmap entries + frontend `circuitBaseUrl`

## Deploy notes
- Merge triggers dev `pulumi up` automatically; **prod `pulumi up` is manual** from the Pulumi Cloud console.
- The ESC `blockchain` object still holds the raw key material — deleted separately alongside `pulumi up` so secrets are purged end to end.
- Merge after backend is released so the removed env/secrets aren't referenced by a running pod.

`make lint-ts` + kustomize render GREEN.

Refs: liverty-music/specification#741