### PR TITLE
feat(zitadel): add organizer-console project + organizer-provisioner (B2B tenancy scaffolding)

### DIFF
--- a/src/gcp/index.ts
+++ b/src/gcp/index.ts
@@ -61,6 +61,10 @@ export interface GcpArgs {
 	 *  Stored in Secret Manager and synced into the `zitadel` namespace via
 	 *  ExternalSecret (`zitadel-watchdog-probe-pat`), mounted into the CronJob. */
 	zitadelWatchdogProbePat?: pulumi.Output<string>
+	/** JWT profile JSON for the organizer-provisioner machine user. Stored in
+	 *  Secret Manager (`zitadel-machine-key-for-organizer-provisioner`) for the
+	 *  backend to provision Organizer tenant orgs at runtime. */
+	zitadelOrganizerProvisionerKey?: pulumi.Output<string>
 	/** Gate for the workload tier (GKE / Cloud SQL / monitoring / GSM
 	 *  Zitadel bootstrap secrets). When false (dev shutdown mode), these
 	 *  resources are not provisioned. See
@@ -138,6 +142,7 @@ export class Gcp {
 			zitadelMachineKey,
 			zitadelLoginPat,
 			zitadelWatchdogProbePat,
+			zitadelOrganizerProvisionerKey,
 			workloadEnabled,
 			postgresAvailabilityType,
 		} = args
@@ -408,6 +413,21 @@ export class Gcp {
 								{
 									name: 'zitadel-machine-key-for-backend-app',
 									value: pulumi.secret(zitadelMachineKey),
+								},
+							]
+						: []),
+					// JWT key for the organizer-provisioner machine user — the
+					// backend reads it to provision Organizer tenant orgs at
+					// runtime. Backend-tier readable (same path as backend-app),
+					// but a distinct GSM secret + Zitadel identity so its blast
+					// radius stays isolated. See OpenSpec change `organizer-tenancy`.
+					...(zitadelOrganizerProvisionerKey
+						? [
+								{
+									name: 'zitadel-machine-key-for-organizer-provisioner',
+									value: pulumi.secret(
+										zitadelOrganizerProvisionerKey,
+									),
 								},
 							]
 						: []),

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,7 @@ const zitadel = workloadEnabled
 const zitadelMachineKey = zitadel?.machineKeyDetails
 const zitadelLoginPat = zitadel?.loginClientToken
 const zitadelWatchdogProbePat = zitadel?.watchdogProbeToken
+const zitadelOrganizerProvisionerKey = zitadel?.organizerProvisionerKeyDetails
 
 // 2. GCP Infrastructure (All Environments)
 const gcp = new Gcp({
@@ -178,6 +179,7 @@ const gcp = new Gcp({
 	zitadelMachineKey,
 	zitadelLoginPat,
 	zitadelWatchdogProbePat,
+	zitadelOrganizerProvisionerKey,
 	// HMAC signing key Zitadel generated for the login-event Target
 	// (PAYLOAD_TYPE_JSON). Plumbed to the backend as GSM secret
 	// `webhook-login-event-signing-key` so the login-event handler can verify
@@ -378,3 +380,13 @@ export const adminConsoleClientId: string | pulumi.Output<string> =
 	zitadel?.adminConsole.application.clientId ?? DEV_SHUTDOWN_SENTINEL
 export const adminOrgId: string | pulumi.Output<string> =
 	zitadel?.adminOrg.id ?? DEV_SHUTDOWN_SENTINEL
+
+// Organizer console OIDC client_id — the shared client the organizer console
+// SPA will bake into its bundle at build time (consumed by the later
+// `organizer-console` change). The product-org id is already exported above as
+// `productOrgId` (the console authenticates operators in their own tenant org,
+// but the OIDC app is owned by the product org). Same `DEV_SHUTDOWN_SENTINEL`
+// fallback contract as the other Zitadel exports. See OpenSpec change
+// `organizer-tenancy`.
+export const organizerConsoleClientId: string | pulumi.Output<string> =
+	zitadel?.organizerConsole.application.clientId ?? DEV_SHUTDOWN_SENTINEL

--- a/src/zitadel/components/organizer-console.ts
+++ b/src/zitadel/components/organizer-console.ts
@@ -1,0 +1,189 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+import type { Environment } from '../../config.js'
+import { baseDomainMap } from '../constants.js'
+
+/**
+ * Project role key for the Organizer console: the tenant **owner** — the
+ * principal operator of one Organizer. An operator granted this role on a
+ * Project-Granted Organizer tenant org carries `owner` in the token's
+ * `urn:zitadel:iam:org:project:roles` claim; the organizer API server's authz
+ * gate reads exactly this string, so the two MUST stay in sync — changing this
+ * value requires a matching backend change. Only `owner` is defined now; the
+ * sub-owner roles (`editor`, `viewer`, `reception`) are a later change.
+ *
+ * Named `owner`, NOT `admin`: `admin` already denotes the Liverty-internal
+ * operator role on the separate `admin-console` project
+ * (`ADMIN_CONSOLE_ROLE_ADMIN`), so reusing it would overload the roles claim
+ * and collide with Zitadel's own admin concepts. This principal is the
+ * tenant's owner, not a platform administrator — `owner` is the accurate,
+ * industry-standard term (cf. Zitadel `ORG_OWNER`).
+ */
+export const ORGANIZER_CONSOLE_ROLE_OWNER = 'owner'
+
+export interface OrganizerConsoleComponentArgs {
+	env: Environment
+	/**
+	 * ID of the `liverty-music` product org. The `organizer-console` project
+	 * (its role + apps) is owned here — the console is a Liverty-Music product
+	 * surface — and is Project-Granted to each Organizer tenant org at runtime
+	 * (the grant itself is NOT created by IaC). The owner org is only the
+	 * project's administrative home; operators authenticate in their own tenant
+	 * org, so this org's login policy never applies to them.
+	 */
+	productOrgId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * OrganizerConsoleComponent provisions the static Zitadel scaffolding for the
+ * Organizer B2B tenancy model: a single, actor-named `organizer-console`
+ * Project in the product org that every Organizer tenant shares via Project
+ * Grant, plus the OIDC client the console SPA uses and the `backend-api` app
+ * that names the audience the organizer API server validates.
+ *
+ * ## Why actor-named, shared, and in the product org
+ *
+ * - **Actor-named (`organizer-console`, not generic `console`)** so a future
+ *   `venue-console` never collides — RBAC (roles/grants) is project-scoped, so
+ *   a distinct actor gets a distinct project.
+ * - **Shared, single OIDC app** — one client serves operators of any Organizer
+ *   tenant org; per-tenant isolation comes from the tenant org + Project Grant,
+ *   not from a per-tenant app.
+ * - **Owned by the product org** (not the internal-only `admin` org nor a new
+ *   `platform` org) because the organizer console is an external-facing product
+ *   surface; a *separate* project (not the fan `liverty-music` project) keeps
+ *   its roles/grants/branding independent. See `docs/zitadel-tenancy-model.md`.
+ *
+ * This component provisions ONLY the project + role + apps. Per-Organizer
+ * tenant orgs, their Project Grants, User Grants, and the passkey-only login
+ * policy are runtime concerns of the later `organizer-accounts` change.
+ */
+export class OrganizerConsoleComponent extends pulumi.ComponentResource {
+	public readonly project: zitadel.Project
+	public readonly ownerRole: zitadel.ProjectRole
+	public readonly application: zitadel.ApplicationOidc
+	public readonly backendApi: zitadel.ApplicationApi
+
+	constructor(
+		name: string,
+		args: OrganizerConsoleComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:OrganizerConsole', name, {}, opts)
+
+		const { env, productOrgId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		// The organizer console is served at `organizer.{base-domain}` per
+		// environment (dev: organizer.dev.liverty-music.app, prod:
+		// organizer.liverty-music.app), mirroring the admin console's
+		// `admin.{base-domain}` convention.
+		const domain = `organizer.${baseDomainMap[env]}`
+
+		// Ternary spread (per `refactor-unify-env-dispatch`): localhost URIs are
+		// only meaningful when env === 'dev'. Other envs receive the public
+		// organizer host only. Mirrors `AdminConsoleComponent`.
+		const redirectUris = [
+			`https://${domain}/auth/callback`,
+			...(env === 'dev' ? ['http://localhost:9100/auth/callback'] : []),
+		]
+		const postLogoutRedirectUris = [
+			`https://${domain}/`,
+			...(env === 'dev' ? ['http://localhost:9100/'] : []),
+		]
+
+		// The shared organizer-console project in the product org.
+		// projectRoleAssertion is ON so the `owner` role surfaces in the
+		// userinfo/ID-token paths; the access-token roles the organizer API
+		// server actually reads are turned on by `accessTokenRoleAssertion` on
+		// the OIDC app below. projectRoleCheck stays OFF so sign-in is not
+		// blocked on a missing grant — authorization is enforced at the backend,
+		// keeping the login flow resilient (an operator whose grant has not yet
+		// been created can still authenticate).
+		this.project = new zitadel.Project(
+			'organizer-console',
+			{
+				name: 'organizer-console',
+				orgId: productOrgId,
+				projectRoleAssertion: true,
+				projectRoleCheck: false,
+				hasProjectCheck: false,
+			},
+			resourceOptions,
+		)
+
+		// The single `owner` role. Granted to an operator on their Organizer
+		// tenant org via a runtime User Grant (in `organizer-accounts`). The
+		// sub-owner roles (editor/viewer/reception) are out of scope here.
+		this.ownerRole = new zitadel.ProjectRole(
+			'organizer-console-owner',
+			{
+				orgId: productOrgId,
+				projectId: this.project.id,
+				roleKey: ORGANIZER_CONSOLE_ROLE_OWNER,
+				displayName: 'Owner',
+			},
+			resourceOptions,
+		)
+
+		// Organizer console OIDC app — mirrors the admin console / consumer SPA
+		// settings (public SPA, PKCE, no secret), a single client serving every
+		// Organizer tenant. Redirect URIs carry the organizer host per env.
+		this.application = new zitadel.ApplicationOidc(
+			'organizer-console',
+			{
+				projectId: this.project.id,
+				name: 'organizer-console',
+				orgId: productOrgId,
+				accessTokenType: 'OIDC_TOKEN_TYPE_JWT',
+				appType: 'OIDC_APP_TYPE_USER_AGENT',
+				// PKCE public client — no client secret.
+				authMethodType: 'OIDC_AUTH_METHOD_TYPE_NONE',
+				grantTypes: [
+					'OIDC_GRANT_TYPE_AUTHORIZATION_CODE',
+					'OIDC_GRANT_TYPE_REFRESH_TOKEN',
+				],
+				responseTypes: ['OIDC_RESPONSE_TYPE_CODE'],
+				// Embed the project roles into the JWT *access* token — the claim
+				// the organizer API server validates (`urn:zitadel:iam:org:project:
+				// roles`). Project-level `projectRoleAssertion` only governs the
+				// userinfo/ID-token paths, so without this the bearer token carries
+				// no roles.
+				accessTokenRoleAssertion: true,
+				idTokenRoleAssertion: true,
+				idTokenUserinfoAssertion: true,
+				clockSkew: '0s',
+				redirectUris,
+				postLogoutRedirectUris,
+				devMode: env === 'dev',
+			},
+			resourceOptions,
+		)
+
+		// Backend API application — names the audience the organizer API server
+		// validates. Its project id is requested into the access token by the
+		// organizer console (scope `urn:zitadel:iam:org:project:id:<id>:aud`), so
+		// the resource server can pin `aud`. BASIC auth method is the lightest
+		// choice; the backend validates tokens statelessly against JWKS and does
+		// not use this app's credential for introspection, so no secret is
+		// exported.
+		this.backendApi = new zitadel.ApplicationApi(
+			'organizer-backend-api',
+			{
+				projectId: this.project.id,
+				orgId: productOrgId,
+				name: 'backend-api',
+				authMethodType: 'API_AUTH_METHOD_TYPE_BASIC',
+			},
+			resourceOptions,
+		)
+
+		this.registerOutputs({
+			project: this.project,
+			ownerRole: this.ownerRole,
+			application: this.application,
+			backendApi: this.backendApi,
+		})
+	}
+}

--- a/src/zitadel/components/organizer-provisioner.ts
+++ b/src/zitadel/components/organizer-provisioner.ts
@@ -1,0 +1,136 @@
+import * as pulumi from '@pulumi/pulumi'
+import * as zitadel from '@pulumiverse/zitadel'
+
+export interface OrganizerProvisionerComponentArgs {
+	/**
+	 * Org to host the machine user. The role granted below is instance-wide, so
+	 * org choice is purely organizational; we co-locate it in the product org
+	 * with the other backend service identity (`backend-app`) because the
+	 * backend Go service consumes this credential at runtime. Isolation from
+	 * `backend-app` is by identity + role (a distinct user with a far broader
+	 * instance role), not by org.
+	 */
+	orgId: pulumi.Input<string>
+	provider: zitadel.Provider
+}
+
+/**
+ * OrganizerProvisionerComponent provisions the dedicated machine user the
+ * backend uses at runtime to provision Organizer tenant orgs: creating one
+ * Zitadel Organization per vetted Organizer and wiring its cross-org Project
+ * Grant (to the product org's `organizer-console` project) and the operator's
+ * User Grant.
+ *
+ * ## Least privilege: IAM_ORG_MANAGER, not IAM_OWNER
+ *
+ * Creating orgs + cross-org grants needs instance-level rights far broader than
+ * the existing single-org `backend-app` user (`ORG_USER_MANAGER` on one org).
+ * `IAM_ORG_MANAGER` is the narrowest instance role that still permits
+ * org.create and management within any org (Project Grants, User Grants) — it
+ * is strictly less than `IAM_OWNER` (full instance control, held only by the
+ * bootstrap `pulumi-admin` SA). A dedicated user isolates this blast radius
+ * from `backend-app`. This resolves the design's Open Question on the exact
+ * role. See OpenSpec change `organizer-tenancy`, design D3.
+ *
+ * ## Credential — finite root key (operational tokens are already short-lived)
+ *
+ * A JSON MachineKey (JWT profile) is created and exposed as `keyDetails`; the
+ * caller stores it in GCP Secret Manager (never logs it). The backend
+ * authenticates with this key via the standard `jwt-bearer` grant, through
+ * which Zitadel issues **short-lived access tokens** by the normal OAuth flow
+ * (`accessTokenType = JWT`; lifetime from the instance `DefaultOidcSettings`,
+ * currently 30m). That short-lived-token behaviour is inherent to any machine
+ * user — there is no long-lived opaque bearer / PAT stored and nothing bespoke
+ * to build.
+ *
+ * The security delta over the existing `backend-app` "expires 2099" pattern is
+ * therefore the **root key's own lifecycle**: because this identity is
+ * high-privilege, its key carries a **finite expiry** (not year-2099) so it
+ * cannot live forever if leaked. There is no automated rotation yet, so a
+ * documented rotation runbook is the compensating control — authored in
+ * `organizer-accounts`, where the key is first consumed (design D3). Automated
+ * rotation / workload-identity federation is the target end-state. The finite
+ * expiry is deliberately comfortable (rotation cadence, not a surprise
+ * outage) — rotate before it.
+ */
+export class OrganizerProvisionerComponent extends pulumi.ComponentResource {
+	public readonly machineUser: zitadel.MachineUser
+
+	/** Instance-level membership granting IAM_ORG_MANAGER (org-create + grants). */
+	public readonly instanceMember: zitadel.InstanceMember
+
+	/** The Machine Key containing the JWT private key. */
+	public readonly machineKey: zitadel.MachineKey
+
+	/**
+	 * JWT profile JSON for authenticating as this machine user. Callers MUST
+	 * store it in GCP Secret Manager and never log or expose it directly.
+	 */
+	public readonly keyDetails: pulumi.Output<string>
+
+	constructor(
+		name: string,
+		args: OrganizerProvisionerComponentArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
+		super('zitadel:liverty-music:OrganizerProvisioner', name, {}, opts)
+
+		const { orgId, provider } = args
+		const resourceOptions = { provider, parent: this }
+
+		this.machineUser = new zitadel.MachineUser(
+			'organizer-provisioner',
+			{
+				orgId,
+				userName: 'organizer-provisioner',
+				name: 'Organizer Provisioner',
+				description:
+					'Service account the backend uses at runtime to provision ' +
+					'Organizer tenant orgs (org-create + cross-org Project/User ' +
+					'Grants). Granted IAM_ORG_MANAGER at instance level; isolated ' +
+					'from the single-org backend-app user for blast-radius control.',
+				accessTokenType: 'ACCESS_TOKEN_TYPE_JWT',
+			},
+			resourceOptions,
+		)
+
+		// IAM_ORG_MANAGER at instance level — the narrowest role permitting
+		// org.create and cross-org Project/User Grants. See component docstring.
+		this.instanceMember = new zitadel.InstanceMember(
+			'organizer-provisioner-member',
+			{
+				userId: this.machineUser.id,
+				roles: ['IAM_ORG_MANAGER'],
+			},
+			{ ...resourceOptions, dependsOn: [this.machineUser] },
+		)
+
+		// JSON MachineKey with a FINITE expiry (not year-2099) — see the
+		// credential section of the component docstring. The backend
+		// authenticates with this key via the standard jwt-bearer flow (Zitadel
+		// issues short-lived access tokens); the finite root-key expiry bounds
+		// leak exposure and forces eventual rotation (runbook in
+		// organizer-accounts, no automation yet).
+		this.machineKey = new zitadel.MachineKey(
+			'machine-key-for-organizer-provisioner',
+			{
+				orgId,
+				userId: this.machineUser.id,
+				keyType: 'KEY_TYPE_JSON',
+				// ~1 year from this change (2026-08). Rotate before expiry per the
+				// runbook; revisit once automated rotation / WIF lands.
+				expirationDate: '2027-08-13T00:00:00Z',
+			},
+			{ ...resourceOptions, dependsOn: [this.machineUser] },
+		)
+
+		this.keyDetails = this.machineKey.keyDetails
+
+		this.registerOutputs({
+			machineUser: this.machineUser,
+			instanceMember: this.instanceMember,
+			machineKey: this.machineKey,
+			keyDetails: this.keyDetails,
+		})
+	}
+}

--- a/src/zitadel/index.ts
+++ b/src/zitadel/index.ts
@@ -16,6 +16,8 @@ import { GoogleAdminIdpComponent } from './components/google-admin-idp.js'
 import { HumanAdminComponent } from './components/human-admin.js'
 import { LoginClientComponent } from './components/login-client.js'
 import { MachineUserComponent } from './components/machine-user.js'
+import { OrganizerConsoleComponent } from './components/organizer-console.js'
+import { OrganizerProvisionerComponent } from './components/organizer-provisioner.js'
 import { SmtpComponent } from './components/smtp.js'
 import { WatchdogProbeComponent } from './components/watchdog-probe.js'
 import {
@@ -72,6 +74,8 @@ export * from './components/google-admin-idp.js'
 export * from './components/human-admin.js'
 export * from './components/login-client.js'
 export * from './components/machine-user.js'
+export * from './components/organizer-console.js'
+export * from './components/organizer-provisioner.js'
 export * from './components/secrets.js'
 export * from './components/smtp.js'
 export * from './components/watchdog-probe.js'
@@ -196,6 +200,18 @@ export class Zitadel {
 
 	/** Watchdog probe machine user + PAT for the self-healing CronJob. */
 	public readonly watchdogProbe: WatchdogProbeComponent
+
+	/** Shared `organizer-console` project (`owner` role + OIDC/API apps) in
+	 *  the product org, the static scaffolding for the Organizer B2B tenancy. */
+	public readonly organizerConsole: OrganizerConsoleComponent
+
+	/** Dedicated `organizer-provisioner` machine user (IAM_ORG_MANAGER) used by
+	 *  the backend to provision Organizer tenant orgs at runtime. */
+	public readonly organizerProvisioner: OrganizerProvisionerComponent
+
+	/** JWT profile JSON for the organizer-provisioner machine user. Store in
+	 *  Secret Manager (`zitadel-machine-key-for-organizer-provisioner`). */
+	public readonly organizerProvisionerKeyDetails: pulumi.Output<string>
 
 	/** JWT profile JSON for the backend-app machine user. Store in Secret Manager. */
 	public readonly machineKeyDetails: pulumi.Output<string>
@@ -325,6 +341,18 @@ export class Zitadel {
 			{ provider: this.provider },
 		)
 
+		// Topology invariant — no third IaC-managed org. Pulumi declares
+		// exactly these two `zitadel.Org` resources (`admin`, `liverty-music`)
+		// and NEVER enumerates the instance's orgs (no `getOrgs` data source, no
+		// import of any other org). Runtime-provisioned Organizer tenant orgs
+		// (one per vetted Organizer, created out-of-band via the Zitadel
+		// Management API by the `organizer-provisioner` machine user) are
+		// therefore invisible to Pulumi state — they are neither reconciled nor
+		// reverted on `pulumi up`, so they are not drift. Adding an org-listing
+		// data source here would break this guarantee. See the
+		// `identity-management` "No third org" scenario and OpenSpec change
+		// `organizer-tenancy`.
+
 		this.project = new zitadel.Project(
 			name,
 			{
@@ -453,6 +481,34 @@ export class Zitadel {
 		})
 
 		this.watchdogProbeToken = this.watchdogProbe.token
+
+		// Organizer B2B tenancy scaffolding — the shared `organizer-console`
+		// project (its `owner` role + OIDC/API apps) owned by the product org.
+		// It is Project-Granted to each Organizer tenant org at runtime (the
+		// grant is NOT IaC-managed). Only the static project/role/apps live
+		// here; per-tenant orgs, grants, and login policy are the runtime
+		// concern of the later `organizer-accounts` change. See OpenSpec change
+		// `organizer-tenancy`.
+		this.organizerConsole = new OrganizerConsoleComponent(name, {
+			env,
+			productOrgId: this.productOrg.id,
+			provider: this.provider,
+		})
+
+		// Dedicated provisioner machine user (IAM_ORG_MANAGER at instance
+		// level) — the credential the backend uses at runtime to create
+		// Organizer tenant orgs and their cross-org Project/User Grants.
+		// Isolated from the single-org `backend-app` user for blast-radius
+		// control. Its JWT key flows to GSM
+		// (`zitadel-machine-key-for-organizer-provisioner`) via the parent
+		// stack, mirroring `machineKeyDetails`.
+		this.organizerProvisioner = new OrganizerProvisionerComponent(name, {
+			orgId: this.productOrg.id,
+			provider: this.provider,
+		})
+
+		this.organizerProvisionerKeyDetails =
+			this.organizerProvisioner.keyDetails
 
 		// Instance-level Google IdP for human admin sign-in. The admin org's
 		// LoginPolicy below references this IdP id; the product org's policy


### PR DESCRIPTION
## 🔗 Related Issue
Refs #759

<!-- #759 is the umbrella Phase-3 roadmap / decomposition issue spanning all
four Organizer sub-changes; this PR is the IaC (Zitadel) part of the
`organizer-tenancy` sub-change, so it references (does not close) #759. -->

## 📝 Summary of Changes

Static Zitadel platform scaffolding for the Organizer B2B tenancy model
(OpenSpec change `organizer-tenancy`). IaC-only, no proto/BSR. Adds two Zitadel
component resources in the `liverty-music` product org:

- **`OrganizerConsoleComponent`** — a shared, actor-named `organizer-console`
  Project with the **`owner`** ProjectRole (named `owner`, not `admin`, to
  avoid colliding with the internal admin-console role; cf. `ORG_OWNER`),
  access-token role assertion on, `projectRoleCheck` off; an **OIDC app**
  (PKCE, no secret, per-env `organizer.{base}` redirect URIs) and a
  **`backend-api`** app for the token audience.
- **`OrganizerProvisionerComponent`** — a dedicated **`organizer-provisioner`**
  machine user with **`IAM_ORG_MANAGER`** (narrowest built-in instance role for
  org-create + cross-org Project/User grants; < `IAM_OWNER`), and a JSON
  JWT-profile key with a **finite expiry** (not year-2099) surfaced to GSM
  `zitadel-machine-key-for-organizer-provisioner`. Isolated from `backend-app`.
- Documents the **"no third IaC-managed org"** invariant: Pulumi never
  enumerates orgs, so runtime-provisioned Organizer tenant orgs are not treated
  as drift.
- Exports **`organizerConsoleClientId`** for the future console build.

Per-tenant orgs, Project/User Grants, and the login policy are runtime concerns
of the later `organizer-accounts` change.

## 🌍 Affected Stacks
- [x] Dev — note: dev has `workloadEnabled=false` (intentionally stopped), so
  the Zitadel orchestrator is skipped; these resources materialize in **prod**.
- [x] Prod

## 🔮 Pulumi Preview
See CI. Expected: additive only — the `organizer-console` project + `owner`
role + OIDC/`backend-api` apps, the `organizer-provisioner` machine user +
`IAM_ORG_MANAGER` member + JWT key, and the GSM secret. No deletions/replaces.

## 📦 State Changes
None — no `pulumi state mv` / `import` / destructive changes. Purely additive.

## ✅ Checklist
- [x] `pulumi preview` passes in CI (additive only).
- [x] No unintended destructive changes.
- [x] Secrets managed via GSM / `pulumi.secret()` (the provisioner JWT key is
  wrapped in `pulumi.secret()` and stored in Secret Manager, not source).
