### PR TITLE
feat(organizer-console): host the organizer console at organizer.{base}

### DIFF
--- a/.github/workflows/bump-prod-pin.yml
+++ b/.github/workflows/bump-prod-pin.yml
@@ -26,13 +26,14 @@ on:
   workflow_dispatch:
     inputs:
       component:
-        description: 'Component to bump (backend, frontend, or frontend-admin)'
+        description: 'Component to bump (backend, frontend, frontend-admin, or frontend-organizer)'
         required: true
         type: choice
         options:
           - backend
           - frontend
           - frontend-admin
+          - frontend-organizer
       tag:
         description: 'Release tag to pin (vX.Y.Z)'
         required: true
@@ -101,9 +102,9 @@ jobs:
           echo "Trigger: ${{ github.event_name }}; component=${COMPONENT} tag=${TAG} sha=${SHA}"
 
           case "${COMPONENT}" in
-            backend|frontend|frontend-admin) ;;
+            backend|frontend|frontend-admin|frontend-organizer) ;;
             *)
-              echo "::error::Invalid component '${COMPONENT}' — must be 'backend', 'frontend', or 'frontend-admin'."
+              echo "::error::Invalid component '${COMPONENT}' — must be 'backend', 'frontend', 'frontend-admin', or 'frontend-organizer'."
               exit 1
               ;;
           esac
@@ -121,12 +122,13 @@ jobs:
           # Bare semver (no leading `v`) for the app.kubernetes.io/version label.
           BARE="${TAG#v}"
 
-          # Per-component routing. `frontend-admin` is the admin console image: it
-          # SHARES the `frontend` kustomize overlay + prod-AR repo with the
-          # consumer, but bumps ONLY its own `admin-app` image entry and does NOT
-          # move the consumer's `app.kubernetes.io/version` label — so admin and
-          # consumer pins advance independently within the one overlay. `frontend`
-          # conversely edits only `web-app`, never the admin entry.
+          # Per-component routing. `frontend-admin` / `frontend-organizer` are the
+          # admin / organizer console images: each SHARES the `frontend` kustomize
+          # overlay + prod-AR repo with the consumer, but bumps ONLY its own image
+          # entry (`admin-app` / `organizer-app`) and does NOT move the consumer's
+          # `app.kubernetes.io/version` label — so the consoles and the consumer
+          # pins advance independently within the one overlay. `frontend`
+          # conversely edits only `web-app`, never a console entry.
           case "${COMPONENT}" in
             backend)
               OVERLAY=backend; AR_REPO=backend
@@ -139,6 +141,10 @@ jobs:
             frontend-admin)
               OVERLAY=frontend; AR_REPO=frontend
               IMAGES="admin-app"
+              BUMP_LABEL=false ;;
+            frontend-organizer)
+              OVERLAY=frontend; AR_REPO=frontend
+              IMAGES="organizer-app"
               BUMP_LABEL=false ;;
           esac
 

--- a/k8s/namespaces/frontend/base/organizer/deployment.yaml
+++ b/k8s/namespaces/frontend/base/organizer/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  annotations:
+    # Trigger a rolling restart when organizer-app-runtime-config ConfigMap
+    # changes. The ConfigMap is mounted as a single-file subPath volume which
+    # kubelet does NOT live-update; explicit rollout via Reloader is the
+    # contract. Scoped to this Deployment only, so an organizer config change
+    # never restarts the consumer web or admin pod (and vice versa).
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      # Labels handled by kustomize labels transformer
+    spec:
+      containers:
+      - name: caddy
+        image: organizer-app
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+        volumeMounts:
+        - name: runtime-config
+          mountPath: /srv/config.json
+          subPath: config.json
+          readOnly: true
+      volumes:
+      - name: runtime-config
+        configMap:
+          # ConfigMap with this name is provided by each environment overlay
+          # (overlays/<env>/organizer-configmap.yaml). The mounted file shadows
+          # the organizer image's bundled public/config.json fallback. Distinct
+          # from the consumer web-app-runtime-config and admin-app-runtime-config
+          # so the organizer pod gets the organizer client id without any
+          # host-conditional config rewrite. It deliberately omits a fixed org
+          # id — the tenant org is pinned per session by org-pinned entry.
+          name: organizer-app-runtime-config

--- a/k8s/namespaces/frontend/base/organizer/httproute.yaml
+++ b/k8s/namespaces/frontend/base/organizer/httproute.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route
+spec:
+  parentRefs:
+  - name: external-gateway
+    namespace: gateway
+  rules:
+  - backendRefs:
+    - name: svc
+      port: 80
+  # hostname (organizer.{base-domain}) is patched per overlay.

--- a/k8s/namespaces/frontend/base/organizer/kustomization.yaml
+++ b/k8s/namespaces/frontend/base/organizer/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Organizer console workload — an `organizer/` sibling to `web/` and `admin/`
+# in the same `frontend` namespace, served by the existing `frontend` ArgoCD
+# Application. Its own image (organizer-app), Service, and HTTPRoute keep it
+# bundle-, config-, and release-isolated from the consumer web and admin
+# workloads (mirrors the admin console). Pulled in by each environment overlay.
+# See OpenSpec change `organizer-console`.
+
+resources:
+- deployment.yaml
+- service.yaml
+- httproute.yaml
+
+configurations:
+- kustomizeconfig.yaml
+
+namePrefix: organizer-
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: organizer
+
+images:
+- name: organizer-app
+  newName: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/organizer-app
+  newTag: latest

--- a/k8s/namespaces/frontend/base/organizer/kustomizeconfig.yaml
+++ b/k8s/namespaces/frontend/base/organizer/kustomizeconfig.yaml
@@ -1,0 +1,6 @@
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - path: spec/rules/backendRefs/name
+    kind: HTTPRoute

--- a/k8s/namespaces/frontend/base/organizer/service.yaml
+++ b/k8s/namespaces/frontend/base/organizer/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP

--- a/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/kustomization.yaml
@@ -3,7 +3,12 @@ kind: Kustomization
 
 resources:
 - ../../base
+# Organizer console workload — dev sibling of web/ in the frontend namespace.
+# The Spot VM patch targets `kind: Deployment`, so it applies to the organizer
+# Deployment automatically. See OpenSpec change `organizer-console`.
+- ../../base/organizer
 - configmap.yaml
+- organizer-configmap.yaml
 
 namespace: frontend
 
@@ -34,6 +39,28 @@ patches:
                 cpu: 100m
                 memory: 128Mi
 
+# Right-size the organizer console for dev (match the consumer web sizing).
+- target:
+    kind: Deployment
+    name: organizer-app
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: organizer-app
+    spec:
+      template:
+        spec:
+          containers:
+          - name: caddy
+            resources:
+              requests:
+                cpu: 10m
+                memory: 52Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+
 # Patch HTTPRoute hostname for dev environment
 - target:
     kind: HTTPRoute
@@ -42,3 +69,12 @@ patches:
     - op: add
       path: /spec/hostnames
       value: ["dev.liverty-music.app"]
+
+# Dev organizer HTTPRoute hostname.
+- target:
+    kind: HTTPRoute
+    name: organizer-route
+  patch: |-
+    - op: add
+      path: /spec/hostnames
+      value: ["organizer.dev.liverty-music.app"]

--- a/k8s/namespaces/frontend/overlays/dev/organizer-configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/dev/organizer-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizer-app-runtime-config
+data:
+  # Organizer console dev runtime config served at the organizer pod's
+  # /config.json. Same contract as the prod organizer ConfigMap — loaded with
+  # `requireOrgId: false`, so it OMITS a fixed zitadelOrgId (the tenant org is
+  # pinned per session by org-pinned entry).
+  #
+  # zitadelClientId is a PENDING placeholder: the dev Zitadel workload is
+  # intentionally stopped (DEV_SHUTDOWN, workloadEnabled=false), so the dev
+  # organizer-console ApplicationOidc client id is not currently resolvable.
+  # The organizer bootstrap fails closed on a `PENDING_` client id (pointing the
+  # operator here rather than at an opaque IdP `invalid_client`). When the dev
+  # environment is restored, fill this from
+  # `pulumi stack output organizerConsoleClientId --stack dev`.
+  config.json: |
+    {
+      "environment": "dev",
+      "apiBaseUrl": "https://api.organizer.dev.liverty-music.app",
+      "zitadelIssuer": "https://auth.dev.liverty-music.app",
+      "zitadelClientId": "PENDING_PULUMI_UP_ORGANIZER_CLIENT_ID",
+      "vapidPublicKey": "BNg-zJP4IiX11Cz1dghWll0mwBnMV6oeOSSVsYyOK2l8NFAqN9xHFSTS_W3_oXO4k3BlMyYLjkMUE-uA7LABGHo",
+      "previewArtistIds": [],
+      "previewArtistNames": [],
+      "logLevel": "debug"
+    }

--- a/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/kustomization.yaml
@@ -14,8 +14,15 @@ resources:
   # the `admin-app` image pin below are both v1.11.0. See OpenSpec change
   # `add-admin-console`.
   - ../../base/admin
+  # Organizer console workload — prod sibling of web/ and admin/ in the frontend
+  # namespace. The Spot VM patch targets `kind: Deployment`, so it applies to the
+  # organizer Deployment automatically; the `app.kubernetes.io/version` label and
+  # the `organizer-app` image pin below track the frontend release. See OpenSpec
+  # change `organizer-console`.
+  - ../../base/organizer
   - configmap.yaml
   - admin-configmap.yaml
+  - organizer-configmap.yaml
 namespace: frontend
 # Apply the Kubernetes Recommended Label `app.kubernetes.io/version` to every
 # rendered resource. Value SHALL be the bare semver without the leading `v`
@@ -73,6 +80,14 @@ patches:
       - op: add
         path: /spec/hostnames
         value: ["admin.liverty-music.app"]
+  # Prod organizer HTTPRoute hostname.
+  - target:
+      kind: HTTPRoute
+      name: organizer-route
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value: ["organizer.liverty-music.app"]
 # Pin the web-app image to prod Artifact Registry with an immutable
 # semantic-version tag. Per OpenSpec `enable-prod-ar-immutable-tags` +
 # the `prod-image-tag-immutability` spec, prod uses semver tags (e.g.,
@@ -118,3 +133,11 @@ images:
   - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/admin-app
     newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/admin-app
     newTag: v1.45.1 # commit e18b9c424a984bad205701d180ab352c68ddd9ae
+  # Organizer console image. First pinned at v1.46.0 — the first frontend release
+  # that built and promoted `organizer-app` to prod AR (the build job
+  # `build-and-push-organizer` shipped with the `organizer-console` change). From
+  # here on, like admin-app, a subsequent consumer pin-bump that rewrites every
+  # newTag resolves because every release promotes organizer-app to prod AR.
+  - name: asia-northeast2-docker.pkg.dev/liverty-music-dev/frontend/organizer-app
+    newName: asia-northeast2-docker.pkg.dev/liverty-music-prod/frontend/organizer-app
+    newTag: v1.46.0 # commit 0638e32a6aa584b97266e09cf0ba6679c01d5623

--- a/k8s/namespaces/frontend/overlays/prod/organizer-configmap.yaml
+++ b/k8s/namespaces/frontend/overlays/prod/organizer-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: organizer-app-runtime-config
+data:
+  # Organizer console prod runtime config served at the organizer pod's
+  # /config.json. Same `frontend-runtime-config` contract as the consumer (the
+  # organizer entry reuses the shared loadAppConfig() + AppConfig validator),
+  # but loaded with `requireOrgId: false` — it deliberately OMITS a fixed
+  # zitadelOrgId. One client serves every Organizer tenant and the tenant org is
+  # pinned per session by org-pinned entry (an org handle), not baked into
+  # config. Fields:
+  #   - zitadelClientId: the prod organizer-console ApplicationOidc client id
+  #     from `pulumi stack output organizerConsoleClientId --stack prod`.
+  #   - apiBaseUrl: the dedicated organizer API host (api.organizer.{base}) the
+  #     later `organizer-rpc-server` change serves; the shell makes no API calls
+  #     yet, so the host need not exist to serve this access-controlled shell.
+  #   - vapidPublicKey: reuses the prod consumer public VAPID key purely to
+  #     satisfy the shared validator's non-empty requirement; the organizer
+  #     entry registers no service worker and sends no push.
+  #   - previewArtist*: empty — consumer-only discovery fields, unused here.
+  config.json: |
+    {
+      "environment": "prod",
+      "apiBaseUrl": "https://api.organizer.liverty-music.app",
+      "zitadelIssuer": "https://auth.liverty-music.app",
+      "zitadelClientId": "386069105062510743",
+      "vapidPublicKey": "BH-m9-6-0-y70MdQG7Lz-htDaz4T_NuYdmcgK5wBEElzXo22AyGs30gvHAtHbWtQBQa4XxySD6ZEaiM9Crwl6Pc",
+      "previewArtistIds": [],
+      "previewArtistNames": [],
+      "logLevel": "info"
+    }

--- a/src/gcp/components/network.ts
+++ b/src/gcp/components/network.ts
@@ -360,6 +360,12 @@ const SERVICES: ReadonlyArray<{
 	// a dedicated HTTPRoute on this same shared gateway. See OpenSpec change
 	// `split-admin-rpc-server`.
 	{ name: 'admin-backend-server', subdomain: 'api.admin' },
+	// Organizer console — dev: organizer.dev.liverty-music.app,
+	// prod: organizer.liverty-music.app. A bundle-isolated frontend entry served
+	// by its own k8s Deployment via a dedicated HTTPRoute on this same shared
+	// gateway. Mirrors the admin console hosting. See OpenSpec change
+	// `organizer-console`.
+	{ name: 'organizer-app', subdomain: 'organizer' },
 ]
 
 /**


### PR DESCRIPTION
## 🔗 Related Issue
Refs: liverty-music/specification#759

## 📝 Summary of Changes

Hosts the **organizer console** at `organizer.{base-domain}`, mirroring the admin
console hosting. Sub-change 3/4 of roadmap step ① (OpenSpec change
`organizer-console`); depends on the frontend `organizer-app` image, first
released at **v1.46.0**.

- **K8s** (`k8s/namespaces/frontend/base/organizer/` + dev/prod overlays): a
  dedicated `organizer-app` Deployment/Service/HTTPRoute on the shared external
  gateway, bundle-/config-/release-isolated from `web` and `admin`. Per-host
  `/config.json` ConfigMap that **omits a fixed org id** (the tenant org is
  pinned per session by org-pinned entry) and is served `no-store` via the
  image's Caddyfile + rolled by Reloader on change.
  - Prod host `organizer.liverty-music.app`, image pinned to `organizer-app:v1.46.0`.
  - Dev host `organizer.dev.liverty-music.app`; the dev config carries a
    `PENDING_` client-id placeholder because the dev Zitadel workload is
    intentionally stopped (fail-closed until dev is restored).
- **Pulumi** (`src/gcp/components/network.ts`): adds the `organizer` subdomain to
  the SERVICES catalog → managed TLS cert (certmap) + Cloud DNS A record + ACME
  DNS-01 CNAME for `organizer.{base}` in each environment.
- **CI** (`bump-prod-pin.yml`): routes the `frontend-organizer` component to edit
  only the `organizer-app` image entry (never the consumer configmap or version
  label).

The `organizer-console` OIDC app redirect URIs (`organizer.{base}/auth/callback`)
are already provisioned by the `organizer-tenancy` change.

## 🌍 Affected Stacks
- [x] Dev
- [x] Prod

## 🔮 Pulumi Preview

Local `pulumi preview --stack prod` shows **5 creates** (all intended) + 1
unrelated pre-existing dashboard drift:
- `organizer-app-dns-auth` (DnsAuthorization → organizer.liverty-music.app)
- `organizer-app-cert` (managed Certificate)
- `organizer-app-cert-map-entry`
- `organizer-app-a-record` (Cloudflare A → api-gateway static IP)
- `organizer-app-dns-auth-cname` (ACME DNS-01 challenge)

## 📦 State Changes
None. Additive only (new host + cert/DNS + k8s workload). No `state mv` / import.

## ✅ Checklist
- [x] `pulumi preview` passes locally or in CI.
- [x] No unintended destructive changes.
- [x] Secrets are managed in Pulumi Config. (The ConfigMap carries only a public
  OIDC client id, not a secret.)
